### PR TITLE
fixed link to Item class in gis module nb.

### DIFF
--- a/guide/03-the-gis/the-gis-module.ipynb
+++ b/guide/03-the-gis/the-gis-module.ipynb
@@ -33,7 +33,7 @@
     "* [**User**](/python/guide/accessing-and-managing-users/) : represents a GIS user\n",
     "* [**Role**](/python/guide/accessing-and-managing-users#about-user-roles/) : represents the role of a GIS user\n",
     "* [**Group**](/python/guide/accessing-and-managing-groups/) : represents a group in the GIS\n",
-    "* [**Item**](/python/guide/accessing-and-creating-your-contents/) : represents an Item in the GIS\n",
+    "* [**Item**](/python/guide/accessing-and-creating-content/) : represents an Item in the GIS\n",
     "\n",
     "\n",
     "* Resource manager classes for managing GIS users, groups, content and datastores:\n",
@@ -63,9 +63,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
[gis module](https://developers.arcgis.com/python/guide/the-gis-module/) link for the [Item](https://developers.arcgis.com/python/guide/accessing-and-creating-your-contents/) class was broken