### PR TITLE
your_first_notebook.ipynb harcoded location fix

### DIFF
--- a/samples/your_first_notebook.ipynb
+++ b/samples/your_first_notebook.ipynb
@@ -104,18 +104,16 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<Item title:\"Collier County Emergency Services\" type:Feature Layer Collection owner:philsherman_collierbcc>,\n",
-       " <Item title:\"WRI_BeforeAndAfterPhotos\" type:Feature Layer Collection owner:BuckEhler>,\n",
-       " <Item title:\"Ecological Overlay Feature Service (Cnps FS10)\" type:Feature Layer Collection owner:charlesc>,\n",
-       " <Item title:\"FireHistory_Hazard_LA_County\" type:Feature Layer Collection owner:cgujtangenberg>,\n",
-       " <Item title:\"Ecological Overlay Feature ServiceB (CNPS FS10B)\" type:Feature Layer Collection owner:charlesc>]"
+       "[<Item title:\"Natuurrampen\" type:Feature Layer Collection owner:Esri_NL_Content>,\n",
+       " <Item title:\"Collier County Emergency Services\" type:Feature Layer Collection owner:philsherman_collierbcc>,\n",
+       " <Item title:\"Intact Forest Landscapes (2000)\" type:Feature Layer Collection owner:GlobalForestWatch>,\n",
+       " <Item title:\"Fire Perimeters\" type:Feature Layer Collection owner:cferner_CALFIRE>,\n",
+       " <Item title:\"WRI_BeforeAndAfterPhotos\" type:Feature Layer Collection owner:BuckEhler>]"
       ]
      },
      "execution_count": 4,
@@ -138,9 +136,36 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": false
+    "scrolled": true
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='http://www.arcgis.com/home/item.html?id=59993d39bc934c1d8516ed436ecae917' target='_blank'>\n",
+       "                        <img src='http://www.arcgis.com/sharing/rest//content/items/59993d39bc934c1d8516ed436ecae917/info/thumbnail/thumbnail.png' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='http://www.arcgis.com/home/item.html?id=59993d39bc934c1d8516ed436ecae917' target='_blank'><b>Natuurrampen</b>\n",
+       "                        </a>\n",
+       "                        <br/>Deze service toont de typen 'Natuurbrand' en 'Aardbeving' uit het thema 'Natuurrampen' van de risicokaart<img src='http://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by Esri_NL_Content\n",
+       "                        <br/>Last Modified: September 07, 2017\n",
+       "                        <br/>0 comments, 4,133 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"Natuurrampen\" type:Feature Layer Collection owner:Esri_NL_Content>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "data": {
       "text/html": [
@@ -156,13 +181,67 @@
        "                        </a>\n",
        "                        <br/>Emergency Facilities in Collier County<img src='http://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by philsherman_collierbcc\n",
        "                        <br/>Last Modified: May 22, 2014\n",
-       "                        <br/>0 comments, 3,732 views\n",
+       "                        <br/>0 comments, 4,436 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
       ],
       "text/plain": [
        "<Item title:\"Collier County Emergency Services\" type:Feature Layer Collection owner:philsherman_collierbcc>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='http://www.arcgis.com/home/item.html?id=5a811508e1ab4ddbb79f7f0753d7d2d7' target='_blank'>\n",
+       "                        <img src='http://www.arcgis.com/sharing/rest//content/items/5a811508e1ab4ddbb79f7f0753d7d2d7/info/thumbnail/ago_downloaded.png' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='http://www.arcgis.com/home/item.html?id=5a811508e1ab4ddbb79f7f0753d7d2d7' target='_blank'><b>Intact Forest Landscapes (2000)</b>\n",
+       "                        </a>\n",
+       "                        <br/>Identifies the world’s last remaining unfragmented forest landscapes, large enough to retain all native biodiversity and showing no signs of human alteration as of the year 2013. This layer also shows the reduction in the extent of Intact Forest Landscapes from 2000 to 2013.<img src='http://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by GlobalForestWatch\n",
+       "                        <br/>Last Modified: October 20, 2017\n",
+       "                        <br/>0 comments, 1,979 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"Intact Forest Landscapes (2000)\" type:Feature Layer Collection owner:GlobalForestWatch>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='http://www.arcgis.com/home/item.html?id=0cfcebd51ca24a34a4dd2c663b60ddbd' target='_blank'>\n",
+       "                        <img src='http://www.arcgis.com/sharing/rest//content/items/0cfcebd51ca24a34a4dd2c663b60ddbd/info/thumbnail/ago_downloaded.png' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='http://www.arcgis.com/home/item.html?id=0cfcebd51ca24a34a4dd2c663b60ddbd' target='_blank'><b>Fire Perimeters</b>\n",
+       "                        </a>\n",
+       "                        <br/>Current calendar year fire perimeters in California from GeoMAC<img src='http://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by cferner_CALFIRE\n",
+       "                        <br/>Last Modified: October 24, 2017\n",
+       "                        <br/>0 comments, 16,841 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"Fire Perimeters\" type:Feature Layer Collection owner:cferner_CALFIRE>"
       ]
      },
      "metadata": {},
@@ -183,94 +262,13 @@
        "                        </a>\n",
        "                        <br/>WRI Projects with Before and After Photos<img src='http://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by BuckEhler\n",
        "                        <br/>Last Modified: February 13, 2017\n",
-       "                        <br/>0 comments, 9,324 views\n",
+       "                        <br/>0 comments, 9,340 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
       ],
       "text/plain": [
        "<Item title:\"WRI_BeforeAndAfterPhotos\" type:Feature Layer Collection owner:BuckEhler>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
-       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='http://www.arcgis.com/home/item.html?id=77693e47d8cc43fca24cb9ebf2f381c1' target='_blank'>\n",
-       "                        <img src='http://www.arcgis.com/sharing/rest//content/items/77693e47d8cc43fca24cb9ebf2f381c1/info/thumbnail/FS10ge1.jpg' class=\"itemThumbnail\">\n",
-       "                       </a>\n",
-       "                    </div>\n",
-       "\n",
-       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='http://www.arcgis.com/home/item.html?id=77693e47d8cc43fca24cb9ebf2f381c1' target='_blank'><b>Ecological Overlay Feature Service (Cnps FS10)</b>\n",
-       "                        </a>\n",
-       "                        <br/>Ecological Overlay Feature Service (Cnps FS10)<img src='http://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by charlesc\n",
-       "                        <br/>Last Modified: January 12, 2015\n",
-       "                        <br/>0 comments, 523 views\n",
-       "                    </div>\n",
-       "                </div>\n",
-       "                "
-      ],
-      "text/plain": [
-       "<Item title:\"Ecological Overlay Feature Service (Cnps FS10)\" type:Feature Layer Collection owner:charlesc>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
-       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='http://www.arcgis.com/home/item.html?id=6640e3b0d7ee47ac8912e7f76487b334' target='_blank'>\n",
-       "                        <img src='http://www.arcgis.com/sharing/rest//content/items/6640e3b0d7ee47ac8912e7f76487b334/info/thumbnail/thumbnail.png' class=\"itemThumbnail\">\n",
-       "                       </a>\n",
-       "                    </div>\n",
-       "\n",
-       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='http://www.arcgis.com/home/item.html?id=6640e3b0d7ee47ac8912e7f76487b334' target='_blank'><b>FireHistory_Hazard_LA_County</b>\n",
-       "                        </a>\n",
-       "                        <br/>50 year fire history and hazard zones for LA County<img src='http://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by cgujtangenberg\n",
-       "                        <br/>Last Modified: January 06, 2015\n",
-       "                        <br/>0 comments, 288 views\n",
-       "                    </div>\n",
-       "                </div>\n",
-       "                "
-      ],
-      "text/plain": [
-       "<Item title:\"FireHistory_Hazard_LA_County\" type:Feature Layer Collection owner:cgujtangenberg>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
-       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='http://www.arcgis.com/home/item.html?id=ea1cc16de5dc47c8b33ae7b7e95a863d' target='_blank'>\n",
-       "                        <img src='http://www.arcgis.com/sharing/rest//content/items/ea1cc16de5dc47c8b33ae7b7e95a863d/info/thumbnail/FS10B_e2.jpg' class=\"itemThumbnail\">\n",
-       "                       </a>\n",
-       "                    </div>\n",
-       "\n",
-       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='http://www.arcgis.com/home/item.html?id=ea1cc16de5dc47c8b33ae7b7e95a863d' target='_blank'><b>Ecological Overlay Feature ServiceB (CNPS FS10B)</b>\n",
-       "                        </a>\n",
-       "                        <br/>Ecological Overlay Feature ServiceB (CNPS FS10B)<img src='http://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by charlesc\n",
-       "                        <br/>Last Modified: January 12, 2015\n",
-       "                        <br/>0 comments, 169 views\n",
-       "                    </div>\n",
-       "                </div>\n",
-       "                "
-      ],
-      "text/plain": [
-       "<Item title:\"Ecological Overlay Feature ServiceB (CNPS FS10B)\" type:Feature Layer Collection owner:charlesc>"
       ]
      },
      "metadata": {},
@@ -288,20 +286,63 @@
    "metadata": {},
    "source": [
     "### Display layers on a map\n",
-    "The ArcGIS API for Python adds a map widget to the Jupyter Notebook. You can easily pull up a map as shown below. It may take a few seconds for the map to display the first time."
+    "The ArcGIS API for Python adds a map widget to the Jupyter Notebook. This map widget can be used to display layers from any of the above public content items. Pick an example item:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='http://www.arcgis.com/home/item.html?id=59993d39bc934c1d8516ed436ecae917' target='_blank'>\n",
+       "                        <img src='http://www.arcgis.com/sharing/rest//content/items/59993d39bc934c1d8516ed436ecae917/info/thumbnail/thumbnail.png' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='http://www.arcgis.com/home/item.html?id=59993d39bc934c1d8516ed436ecae917' target='_blank'><b>Natuurrampen</b>\n",
+       "                        </a>\n",
+       "                        <br/>Deze service toont de typen 'Natuurbrand' en 'Aardbeving' uit het thema 'Natuurrampen' van de risicokaart<img src='http://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by Esri_NL_Content\n",
+       "                        <br/>Last Modified: September 07, 2017\n",
+       "                        <br/>0 comments, 4,133 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"Natuurrampen\" type:Feature Layer Collection owner:Esri_NL_Content>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "example_item = public_content[0]\n",
+    "display(example_item)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can then easily pull up a map, as shown below. It may take a few seconds for the map to display the first time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b33a328e8e6547f9bea7f729300475fd"
+       "model_id": "3e8faae9fbc34104b7e4ce7dfb2640b5"
       }
      },
      "metadata": {},
@@ -309,7 +350,11 @@
     }
    ],
    "source": [
-    "map1 = gis.map('Collier County, FL')\n",
+    "#Create a new map object\n",
+    "map1 = gis.map()\n",
+    "#Focus the map to the part of the world containing the example item\n",
+    "map1.extent = example_item.extent\n",
+    "#Display the map\n",
     "map1"
    ]
   },
@@ -317,22 +362,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Get the first item from your search result and add it the map you created"
+    "You can now add your example item to the map you just created."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "#get the first item\n",
-    "fire = public_content[0]\n",
-    "\n",
-    "#add to map\n",
-    "map1.add_layer(fire)"
+    "map1.add_layer(example_item)"
    ]
   },
   {
@@ -362,7 +403,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
your_first_notebook.ipynb had a hardcoded location when generating a new map, making data population on the map be hidden.

This fix moves the map focus to whatever example layer is queried, making it "future-proof" from any online content changes.

Looking at the notebook without running any code:
![no_code](https://user-images.githubusercontent.com/18691334/32292375-3d25bf42-befd-11e7-9996-fc95904ba079.gif)

-----

Running code on the notebook:
![run_code](https://user-images.githubusercontent.com/18691334/32292380-4367594c-befd-11e7-895c-1b64852ee79f.gif)

-----

Changing the "example_item" to another item. Notice how the map focus is moved to adequately display this information?
![another_layer](https://user-images.githubusercontent.com/18691334/32292392-4d24462a-befd-11e7-9d6d-49187a61c571.gif)
