### PR TITLE
fixed typo in link to Anaconda Distribution in understanding-conda.ipynb

### DIFF
--- a/guide/01-getting-started/understanding-conda.ipynb
+++ b/guide/01-getting-started/understanding-conda.ipynb
@@ -21,7 +21,7 @@
     "## Conda Environments\n",
     "When you create conda environments, you create physical directories that isolate the specific Python interpreter and packages you install into the environment. This allows you to create multiple environments that can have different versions of software, including Python. You can easily create new environments and then switch between them without affecting other environments.  For detailed explanation and instructions, see the conda documentation on [Managing environments](https://conda.io/docs/user-guide/tasks/manage-environments.html).\n",
     "\n",
-    "Let's explore what is available directly after installing conda through either [ArcGIS Pro](#ArcGIS-Pro) or the [Anaconda Distribution](#Anaconda-distribution).\n",
+    "Let's explore what is available directly after installing conda through either [ArcGIS Pro](#ArcGIS-Pro) or the [Anaconda Distribution](#Anaconda-Distribution).\n",
     "### The Default Environments:\n",
     "Depending upon how you installed the Python API (with ArcGIS Pro or the Anaconda Distribution), you will notice different sets of default environments.\n",
     "\n",
@@ -160,9 +160,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda env:arcgis-pyapi]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-arcgis-pyapi-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -174,7 +174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.3"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
@AtmaMani the link from the Anaconda Distribution text in 'The Default Environments' section to the Anaconda-Distribution section of the doc is broken.