### PR TITLE
Updated hurricane tracks sample referencing pythonapi playground data

### DIFF
--- a/samples/04_gis_analysts_data_scientists/creating_hurricane_tracks_using_geoanalytics.ipynb
+++ b/samples/04_gis_analysts_data_scientists/creating_hurricane_tracks_using_geoanalytics.ipynb
@@ -6,15 +6,16 @@
    "source": [
     "# Creating hurricane tracks using Geoanalytics\n",
     "\n",
-    "The sample code below uses big data analytics (GeoAnalytics) to reconstruct hurricane tracks using data registered on a big data file share in the GIS. Note that this functionality is currently available on ArcGIS Enterprise 10.5 and not yet with ArcGIS Online.\n",
+    "The sample code below uses big data analytics ([GeoAnalytics](http://enterprise.arcgis.com/en/server/latest/get-started/windows/what-is-arcgis-geoanalytics-server-.htm)) to reconstruct hurricane tracks using data registered on a [big data file share](http://enterprise.arcgis.com/en/server/latest/get-started/windows/what-is-a-big-data-file-share.htm) in the GIS. \n",
+    "> Note: This functionality is currently only available on ArcGIS Enterprise 10.5 and later and not yet with ArcGIS Online.\n",
     "\n",
     "## Reconstruct tracks\n",
-    "Reconstruct tracks is a type of data aggregation tool available in the `arcgis.geoanalytics` module. This tool works with a layer of point features or polygon features that are time enabled. It first determines which points belong to a track using an identification number or identification string. Using the time at each location, the tracks are ordered sequentially and transformed into a line representing the path of movement.\n",
+    "Reconstruct tracks is a type of data aggregation tool available in the [`arcgis.geoanalytics`](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.geoanalytics.toc.html) module. This tool works with a layer of point features or polygon features that are [time enabled](http://enterprise.arcgis.com/en/portal/latest/use/configure-time.htm). It first determines which points belong to a track using an identification number or identification string. Using the time at each location, the tracks are ordered sequentially and transformed into a line representing the path of movement.\n",
     "\n",
     "## Data used\n",
-    "For this sample, hurricane data from over a period of 50 years, totalling about 150,000 points split into 5 shape files was used. The [National Hurricane Center](http://www.nhc.noaa.gov/gis/) provides similar datasets that can be used for exploratory purposes.\n",
+    "This sample uses hurricane data collected from 1848 through 2010, totalling over 177,000 points stored as a shapefile. The [National Hurricane Center](http://www.nhc.noaa.gov/gis/) provides similar datasets that can be used for exploratory purposes.\n",
     "\n",
-    "To illustrate the nature of the data a subset was published as a feature service and can be visualized as below:"
+    "To illustrate the nature of the data, a subset was published as a feature layer so we can visualize it:"
    ]
   },
   {
@@ -29,23 +30,23 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='http://www.arcgis.com/home/item.html?id=8ebd08e3d0c04d249b29afba7a5e1b8f' target='_blank'>\n",
-       "                        <img src='http://www.arcgis.com/sharing/rest//content/items/8ebd08e3d0c04d249b29afba7a5e1b8f/info/thumbnail/thumbnail.png' class=\"itemThumbnail\">\n",
+       "                       <a href='https://www.arcgis.com/home/item.html?id=8ebd08e3d0c04d249b29afba7a5e1b8f' target='_blank'>\n",
+       "                        <img src='https://www.arcgis.com/sharing/rest//content/items/8ebd08e3d0c04d249b29afba7a5e1b8f/info/thumbnail/thumbnail.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='http://www.arcgis.com/home/item.html?id=8ebd08e3d0c04d249b29afba7a5e1b8f' target='_blank'><b>Hurricane_tracks_points</b>\n",
+       "                        <a href='https://www.arcgis.com/home/item.html?id=8ebd08e3d0c04d249b29afba7a5e1b8f' target='_blank'><b>Hurricane_tracks_points</b>\n",
        "                        </a>\n",
-       "                        <br/>Years 1932 - 1942<img src='http://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by atma.mani\n",
+       "                        <br/>Years 1932 - 1942<img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by atma.mani\n",
        "                        <br/>Last Modified: September 15, 2016\n",
-       "                        <br/>0 comments, 0 views\n",
+       "                        <br/>0 comments, 780 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
       ],
       "text/plain": [
-       "<Item title:\"Hurricane_tracks_points\" type:Feature Service owner:atma.mani>"
+       "<Item title:\"Hurricane_tracks_points\" type:Feature Layer Collection owner:atma.mani>"
       ]
      },
      "execution_count": 1,
@@ -64,20 +65,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "034bea83f1f74c438f5f46bc23d87878",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "MapView(basemaps=['dark-gray', 'dark-gray-vector', 'gray', 'gray-vector', 'hybrid', 'national-geographic', 'oc…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "subset_map = arcgis_online.map(\"USA\")\n",
     "subset_map"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![subset_img](http://esri.github.io/arcgis-python-api/notebooks/nbimages/04_HurricaneGeoanalytics_01.PNG)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "subset_map.add_layer(hurricane_pts)"
@@ -100,6 +121,19 @@
      "data": {
       "text/html": [
        "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
@@ -115,6 +149,7 @@
        "      <th>ATC_w34_r3</th>\n",
        "      <th>ATC_w34_r4</th>\n",
        "      <th>...</th>\n",
+       "      <th>day</th>\n",
        "      <th>hour</th>\n",
        "      <th>min_</th>\n",
        "      <th>month</th>\n",
@@ -123,35 +158,34 @@
        "      <th>wmo_wind</th>\n",
        "      <th>wmo_wind__</th>\n",
        "      <th>year</th>\n",
-       "      <th>geometry.x</th>\n",
-       "      <th>geometry.y</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>FID</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
+       "      <th>SHAPE</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999.</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999.0</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999.0</td>\n",
+       "      <td>1932</td>\n",
+       "      <td>{'x': 58.749999999600334, 'y': -18.07999992365...</td>\n",
+       "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>-999</td>\n",
@@ -165,16 +199,16 @@
        "      <td>-999</td>\n",
        "      <td>-999</td>\n",
        "      <td>...</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>6</td>\n",
        "      <td>0</td>\n",
        "      <td>1</td>\n",
-       "      <td>-999</td>\n",
-       "      <td>-999.0</td>\n",
-       "      <td>-999</td>\n",
-       "      <td>-999.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>-100.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>-100.0</td>\n",
        "      <td>1932</td>\n",
-       "      <td>58.750000</td>\n",
-       "      <td>-18.080000</td>\n",
+       "      <td>{'x': 58.40000152555001, 'y': -18.499999999800...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -189,16 +223,16 @@
        "      <td>-999</td>\n",
        "      <td>-999</td>\n",
        "      <td>...</td>\n",
-       "      <td>6</td>\n",
+       "      <td>1</td>\n",
+       "      <td>12</td>\n",
        "      <td>0</td>\n",
        "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>-100.0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>-100.0</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999.0</td>\n",
+       "      <td>-999</td>\n",
+       "      <td>-999.0</td>\n",
        "      <td>1932</td>\n",
-       "      <td>58.400002</td>\n",
-       "      <td>-18.500000</td>\n",
+       "      <td>{'x': 58.06999969483013, 'y': -18.899999618587...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -213,7 +247,8 @@
        "      <td>-999</td>\n",
        "      <td>-999</td>\n",
        "      <td>...</td>\n",
-       "      <td>12</td>\n",
+       "      <td>1</td>\n",
+       "      <td>18</td>\n",
        "      <td>0</td>\n",
        "      <td>1</td>\n",
        "      <td>-999</td>\n",
@@ -221,8 +256,7 @@
        "      <td>-999</td>\n",
        "      <td>-999.0</td>\n",
        "      <td>1932</td>\n",
-       "      <td>58.070000</td>\n",
-       "      <td>-18.900000</td>\n",
+       "      <td>{'x': 57.729999542445, 'y': -19.3099994656028,...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -237,30 +271,7 @@
        "      <td>-999</td>\n",
        "      <td>-999</td>\n",
        "      <td>...</td>\n",
-       "      <td>18</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>-999</td>\n",
-       "      <td>-999.0</td>\n",
-       "      <td>-999</td>\n",
-       "      <td>-999.0</td>\n",
-       "      <td>1932</td>\n",
-       "      <td>57.730000</td>\n",
-       "      <td>-19.309999</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>-999</td>\n",
-       "      <td>-999.</td>\n",
-       "      <td>-999</td>\n",
-       "      <td>-999</td>\n",
-       "      <td>-999</td>\n",
-       "      <td>-999</td>\n",
-       "      <td>-999</td>\n",
-       "      <td>-999</td>\n",
-       "      <td>-999</td>\n",
-       "      <td>-999</td>\n",
-       "      <td>...</td>\n",
+       "      <td>2</td>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
        "      <td>1</td>\n",
@@ -269,8 +280,7 @@
        "      <td>-999</td>\n",
        "      <td>-999.0</td>\n",
        "      <td>1932</td>\n",
-       "      <td>57.349998</td>\n",
-       "      <td>-19.760000</td>\n",
+       "      <td>{'x': 57.3499984744501, 'y': -19.7600002291272...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -278,29 +288,40 @@
        "</div>"
       ],
       "text/plain": [
-       "     ATC_eye ATC_grade  ATC_poci  ATC_pres  ATC_rmw  ATC_roci  ATC_w34_r1  \\\n",
-       "FID                                                                         \n",
-       "1       -999     -999.      -999      -999     -999      -999        -999   \n",
-       "2       -999     -999.      -999      -999     -999      -999        -999   \n",
-       "3       -999     -999.      -999      -999     -999      -999        -999   \n",
-       "4       -999     -999.      -999      -999     -999      -999        -999   \n",
-       "5       -999     -999.      -999      -999     -999      -999        -999   \n",
+       "   ATC_eye ATC_grade  ATC_poci  ATC_pres  ATC_rmw  ATC_roci  ATC_w34_r1  \\\n",
+       "0     -999     -999.      -999      -999     -999      -999        -999   \n",
+       "1     -999     -999.      -999      -999     -999      -999        -999   \n",
+       "2     -999     -999.      -999      -999     -999      -999        -999   \n",
+       "3     -999     -999.      -999      -999     -999      -999        -999   \n",
+       "4     -999     -999.      -999      -999     -999      -999        -999   \n",
        "\n",
-       "     ATC_w34_r2  ATC_w34_r3  ATC_w34_r4     ...      hour  min_  month  \\\n",
-       "FID                                         ...                          \n",
-       "1          -999        -999        -999     ...         0     0      1   \n",
-       "2          -999        -999        -999     ...         6     0      1   \n",
-       "3          -999        -999        -999     ...        12     0      1   \n",
-       "4          -999        -999        -999     ...        18     0      1   \n",
-       "5          -999        -999        -999     ...         0     0      1   \n",
+       "   ATC_w34_r2  ATC_w34_r3  ATC_w34_r4  \\\n",
+       "0        -999        -999        -999   \n",
+       "1        -999        -999        -999   \n",
+       "2        -999        -999        -999   \n",
+       "3        -999        -999        -999   \n",
+       "4        -999        -999        -999   \n",
        "\n",
-       "     wmo_pres  wmo_pres__  wmo_wind  wmo_wind__  year  geometry.x  geometry.y  \n",
-       "FID                                                                            \n",
-       "1        -999      -999.0      -999      -999.0  1932   58.750000  -18.080000  \n",
-       "2           0      -100.0         0      -100.0  1932   58.400002  -18.500000  \n",
-       "3        -999      -999.0      -999      -999.0  1932   58.070000  -18.900000  \n",
-       "4        -999      -999.0      -999      -999.0  1932   57.730000  -19.309999  \n",
-       "5        -999      -999.0      -999      -999.0  1932   57.349998  -19.760000  \n",
+       "                         ...                          day  hour  min_  month  \\\n",
+       "0                        ...                            1     0     0      1   \n",
+       "1                        ...                            1     6     0      1   \n",
+       "2                        ...                            1    12     0      1   \n",
+       "3                        ...                            1    18     0      1   \n",
+       "4                        ...                            2     0     0      1   \n",
+       "\n",
+       "   wmo_pres  wmo_pres__  wmo_wind  wmo_wind__  year  \\\n",
+       "0      -999      -999.0      -999      -999.0  1932   \n",
+       "1         0      -100.0         0      -100.0  1932   \n",
+       "2      -999      -999.0      -999      -999.0  1932   \n",
+       "3      -999      -999.0      -999      -999.0  1932   \n",
+       "4      -999      -999.0      -999      -999.0  1932   \n",
+       "\n",
+       "                                               SHAPE  \n",
+       "0  {'x': 58.749999999600334, 'y': -18.07999992365...  \n",
+       "1  {'x': 58.40000152555001, 'y': -18.499999999800...  \n",
+       "2  {'x': 58.06999969483013, 'y': -18.899999618587...  \n",
+       "3  {'x': 57.729999542445, 'y': -19.3099994656028,...  \n",
+       "4  {'x': 57.3499984744501, 'y': -19.7600002291272...  \n",
        "\n",
        "[5 rows x 148 columns]"
       ]
@@ -319,9 +340,9 @@
    "metadata": {},
    "source": [
     "## Create a data store\n",
-    "For the GeoAnalytics server to process your big data, it needs the data to be registered as a data store. In our case, the data is in multiple shape files and we will register the folder containing the files as a data store of type `bigDataFileShare`.\n",
+    "GeoAnalytics server processes big data through [big data file share](http://enterprise.arcgis.com/en/server/latest/get-started/windows/what-is-a-big-data-file-share.htm) items published on the portal. In our case, the source hurricane data is stored as a shapefile. We created the big data file share by [registering the folder](http://enterprise.arcgis.com/en/server/latest/get-started/windows/what-is-a-big-data-file-share.htm#ESRI_SECTION1_CC7720EEC36F47149C7F82E1FCEDF2F7) containing the shapefile as a data store of type `bigDataFileShare`. \n",
     "\n",
-    "Let us connect to an ArcGIS Enterprise"
+    "Let us connect to an ArcGIS Enterprise and use the [Datastore Manager](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.gis.toc.html#datastoremanager) to search for big data file shares:"
    ]
   },
   {
@@ -330,7 +351,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gis = GIS(\"https://yourportal.domain.com/webcontext\", \"username\", \"password\")"
+    "gis = GIS(\"https://pythonapi.playground.esri.com/portal\", \"arcgis_python\", \"amazing_arcgis_123\")"
    ]
   },
   {
@@ -348,13 +369,9 @@
     {
      "data": {
       "text/plain": [
-       "[<Datastore title:\"/bigDataFileShares/Chicago_accidents\" type:\"bigDataFileShare\">,\n",
-       " <Datastore title:\"/bigDataFileShares/hurricanes\" type:\"bigDataFileShare\">,\n",
-       " <Datastore title:\"/bigDataFileShares/hurricanes_1m_168yrs\" type:\"bigDataFileShare\">,\n",
-       " <Datastore title:\"/bigDataFileShares/hurricanes_all\" type:\"bigDataFileShare\">,\n",
-       " <Datastore title:\"/bigDataFileShares/Hurricane_tracks\" type:\"bigDataFileShare\">,\n",
-       " <Datastore title:\"/bigDataFileShares/NYCdata\" type:\"bigDataFileShare\">,\n",
-       " <Datastore title:\"/bigDataFileShares/NYC_taxi\" type:\"bigDataFileShare\">]"
+       "[<Datastore title:\"/bigDataFileShares/NYC_taxi_data15\" type:\"bigDataFileShare\">,\n",
+       " <Datastore title:\"/bigDataFileShares/all_hurricanes\" type:\"bigDataFileShare\">,\n",
+       " <Datastore title:\"/bigDataFileShares/hurricanes_1848_1900\" type:\"bigDataFileShare\">]"
       ]
      },
      "execution_count": 6,
@@ -374,47 +391,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The dataset `hurricanes_all` data is registered as a big data file share with the Geoanalytics datastore, so we can reference it:"
+    "Using the `Datastore Manager.search()` method with no parameters returns all the datastores registered with the GeoAnalytics Server. We see the `all_hurricanes` big data file share in the list of datastores, so let's retrieve the [`datastore`](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.gis.toc.html#datastore):"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_item = bigdata_fileshares[3]"
+    "data_item = bigdata_fileshares[1]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If there is no big data file share for hurricane track data registered on the server, we can register one that points to the shared folder containing the shape files."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Big Data file share exists for Hurricane_tracks\n"
-     ]
-    }
-   ],
-   "source": [
-    "data_item = datastores.add_bigdata(\"Hurricane_tracks\", r\"\\\\path_to_hurricane_data\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Once a big data file share is registered, the GeoAnalytics server processes all the valid file types to discern the schema of the data. This process can take a few minutes depending on the size of your data. Once processed, querying the manifest property returns the schema. As you can see from below, the schema is similar to the subset we observed earlier in this sample."
+    "If there is no big data file share for hurricane track data, we can use the Datastore Manager [`add_bigdata()`](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.gis.toc.html#item) method to register a shared folder accessible by the GeoAnalytics Server (see [Making your data accessible](http://enterprise.arcgis.com/en/server/latest/install/linux/making-your-data-accessible-to-arcgis-server.htm) as a big data file share:"
    ]
   },
   {
@@ -423,12 +416,39 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created Big Data file share for hurricanes_1848_1900\n"
+     ]
+    }
+   ],
+   "source": [
+    "data_item = datastores.add_bigdata(\"hurricanes_1848_1900\", \n",
+    "                                   r\"\\\\path_to_hurricane_data\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once a big data file share is registered, the GeoAnalytics server samples all the datasets within the share to discern the schema of the data, including information about the geometry in a dataset. If the dataset is time-enabled, as is required to use some GeoAnalytics Tools, the [`manifest`](http://enterprise.arcgis.com/en/server/latest/get-started/windows/understanding-the-big-data-file-share-manifest.htm) reports the necessary metadata about how time information is stored as well.\n",
+    "\n",
+    "This process can take a few minutes depending on the size of your data. Once processed, querying the [`manifest`](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.gis.toc.html#arcgis.gis.Datastore.manifest) property returns the schema as a dictionary. We can use the datasets key to retrieve information about the dataset. As you can see below, the schema is similar to the subset we observed earlier in this sample:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
      "data": {
       "text/plain": [
        "{'format': {'extension': 'shp', 'type': 'shapefile'},\n",
        " 'geometry': {'geometryType': 'esriGeometryPoint',\n",
        "  'spatialReference': {'wkid': 4326}},\n",
-       " 'name': 'full_dataset',\n",
+       " 'name': 'hurricanes',\n",
        " 'schema': {'fields': [{'name': 'serial_num', 'type': 'esriFieldTypeString'},\n",
        "   {'name': 'season', 'type': 'esriFieldTypeBigInteger'},\n",
        "   {'name': 'num', 'type': 'esriFieldTypeBigInteger'},\n",
@@ -447,18 +467,19 @@
        "   {'name': 'track_type', 'type': 'esriFieldTypeString'},\n",
        "   {'name': 'size', 'type': 'esriFieldTypeString'},\n",
        "   {'name': 'Wind', 'type': 'esriFieldTypeBigInteger'}]},\n",
-       " 'time': {'fields': [{'formats': ['yyyy-MM-dd HH:mm:ss'], 'name': 'iso_time'}],\n",
+       " 'time': {'fields': [{'formats': ['yyyy-MM-dd HH:mm:ss', 'MM/dd/yyyy HH:mm'],\n",
+       "    'name': 'iso_time'}],\n",
        "  'timeReference': {'timeZone': 'UTC'},\n",
        "  'timeType': 'instant'}}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "data_item.manifest['datasets'][0] #for brevity only a portion is printed"
+    "data_item.manifest['datasets'][0]"
    ]
   },
   {
@@ -472,21 +493,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<Item title:\"bigDataFileShares_hurricanes_1m_168yrs\" type:Big Data File Share owner:admin>,\n",
-       " <Item title:\"bigDataFileShares_NYC_taxi\" type:Big Data File Share owner:admin>,\n",
-       " <Item title:\"bigDataFileShares_hurricanes\" type:Big Data File Share owner:admin>,\n",
-       " <Item title:\"bigDataFileShares_Chicago_accidents\" type:Big Data File Share owner:admin>,\n",
-       " <Item title:\"bigDataFileShares_hurricanes_all\" type:Big Data File Share owner:admin>,\n",
-       " <Item title:\"bigDataFileShares_NYCdata\" type:Big Data File Share owner:admin>]"
+       "[<Item title:\"bigDataFileShares_all_hurricanes\" type:Big Data File Share owner:api_data_owner>,\n",
+       " <Item title:\"bigDataFileShares_hurricanes_1848_1900\" type:Big Data File Share owner:arcgis_python>,\n",
+       " <Item title:\"bigDataFileShares_NYC_taxi_data15\" type:Big Data File Share owner:api_data_owner>]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -498,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -506,44 +524,23 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://dev003246.esri.com/portal/home/item.html?id=3363093d4c1e4631b62561a6a8a5bb68' target='_blank'>\n",
-       "                        <img src='https://dev003246.esri.com/portal/portalimages/desktopapp.png' class=\"itemThumbnail\">\n",
+       "                       <a href='https://pythonapi.playground.esri.com/portal/home/item.html?id=f00d3b06838b47c79809c71687f73c8a' target='_blank'>\n",
+       "                        <img src='https://pythonapi.playground.esri.com/portal/portalimages/desktopapp.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://dev003246.esri.com/portal/home/item.html?id=3363093d4c1e4631b62561a6a8a5bb68' target='_blank'><b>bigDataFileShares_hurricanes_all</b>\n",
+       "                        <a href='https://pythonapi.playground.esri.com/portal/home/item.html?id=f00d3b06838b47c79809c71687f73c8a' target='_blank'><b>bigDataFileShares_all_hurricanes</b>\n",
        "                        </a>\n",
-       "                        <br/><img src='https://dev003246.esri.com/portal/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">Big Data File Share by admin\n",
-       "                        <br/>Last Modified: November 21, 2016\n",
+       "                        <br/><img src='https://pythonapi.playground.esri.com/portal/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">Big Data File Share by api_data_owner\n",
+       "                        <br/>Last Modified: May 01, 2018\n",
        "                        <br/>0 comments, 0 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
       ],
       "text/plain": [
-       "<Item title:\"bigDataFileShares_hurricanes_all\" type:Big Data File Share owner:admin>"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "data_item = search_result[4]\n",
-    "data_item"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Layer url:\"https://yourserver.domain.com/webcontext/rest/services/DataStoreCatalogs/bigDataFileShares_hurricanes_all/BigDataCatalogServer/full_dataset\">"
+       "<Item title:\"bigDataFileShares_all_hurricanes\" type:Big Data File Share owner:api_data_owner>"
       ]
      },
      "execution_count": 11,
@@ -552,8 +549,29 @@
     }
    ],
    "source": [
-    "years_50 = data_item.layers[0]\n",
-    "years_50"
+    "data_item = search_result[0]\n",
+    "data_item"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Layer url:\"https://pythonapi.playground.esri.com/ga/rest/services/DataStoreCatalogs/bigDataFileShares_all_hurricanes/BigDataCatalogServer/hurricanes\">"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "years_all = data_item.layers[0]\n",
+    "years_all"
    ]
   },
   {
@@ -562,12 +580,12 @@
    "source": [
     "### Reconstruct tracks tool\n",
     "\n",
-    "The `reconstruct_tracks()` function is available in the `arcgis.geoanalytics.summarize_data` module. In this example, we are using this tool to aggregate the numerous points into line segments showing the tracks followed by the hurricanes. The tool creates a feature layer item as an output which can be accessed once the processing is complete."
+    "The [`arcgis.geoanalytics.summarize_data`](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.geoanalytics.summarize_data.html) module contains the [`reconstruct_tracks()`](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.geoanalytics.summarize_data.html#reconstruct-tracks). We will use this tool to aggregate the numerous points into line segments showing the tracks followed by the various hurricanes occurring between 1848 and 2010. The tool creates a [`feature layer`](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.features.toc.html#featurelayer) item as output which we'll visualize on a map and query to see the results."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -575,8 +593,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use the [`arcgis.env`](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.env.html#) module to modify environment settings that geoprocessing and geoanalytics tools use during execution. Set [`verbose`](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.env.html#)to True to return detailed messaging when running tools. "
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arcgis.env.verbose = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the tool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -585,27 +626,24 @@
      "text": [
       "Submitted.\n",
       "Executing...\n",
-      "Executing (ReconstructTracks): ReconstructTracks \"Feature Set\" Serial_Num Geodesic # # # # {\"itemProperties\":{\"itemId\":\"9b2d3c8e7418468fb2a89e3f27db1639\"},\"serviceProperties\":{\"serviceUrl\":\"http://yourserver.domain.com/webcontext/rest/services/Hosted/Reconstructed_Tracks_IOBYC0/FeatureServer\",\"name\":\"Reconstructed_Tracks_IOBYC0\"}} #\n",
-      "Start Time: Wed Dec 14 16:36:10 2016\n",
-      "Using URL based GPRecordSet param: https://yourserver.domain.com/webcontext/rest/services/DataStoreCatalogs/bigDataFileShares_hurricanes_all/BigDataCatalogServer/full_dataset?token=AYU95RBC50dIrjFxzzUIdYeI4Tqf-cXBdtRbuOKnpo3vvW1bu7FF4EAnwfwef1AVMEdRGXPTxCGWkWf81iuWCIBpQBP8-xoVp1eRrSeNbVgpOFekTsUokT6OW_LGgH1yn6DHC-Uul6ndvMSycCyp8ENol2_UMn7ksRRrQh_26Kc.\n",
+      "Executing (ReconstructTracks): ReconstructTracks \"Feature Set\" Serial_Num Geodesic # # # # # # \"{\"serviceProperties\": {\"name\": \"Reconstructed_Tracks_I49893\", \"serviceUrl\": \"https://pythonapi.playground.esri.com/server/rest/services/Hosted/Reconstructed_Tracks_I49893/FeatureServer\"}, \"itemProperties\": {\"itemId\": \"dca4efc3f7da4dab966bdd9d34437b04\"}}\" #\n",
+      "Start Time: Mon May 07 18:16:31 2018\n",
+      "Using URL based GPRecordSet param: https://pythonapi.playground.esri.com/ga/rest/services/DataStoreCatalogs/bigDataFileShares_all_hurricanes/BigDataCatalogServer/hurricanes\n",
       "{\"messageCode\":\"BD_101028\",\"message\":\"Starting new distributed job with 8 tasks.\",\"params\":{\"totalTasks\":\"8\"}}\n",
+      "{\"messageCode\":\"BD_101029\",\"message\":\"0/8 distributed tasks completed.\",\"params\":{\"completedTasks\":\"0\",\"totalTasks\":\"8\"}}\n",
+      "{\"messageCode\":\"BD_101029\",\"message\":\"5/8 distributed tasks completed.\",\"params\":{\"completedTasks\":\"5\",\"totalTasks\":\"8\"}}\n",
+      "{\"messageCode\":\"BD_101029\",\"message\":\"7/8 distributed tasks completed.\",\"params\":{\"completedTasks\":\"7\",\"totalTasks\":\"8\"}}\n",
       "{\"messageCode\":\"BD_101029\",\"message\":\"8/8 distributed tasks completed.\",\"params\":{\"completedTasks\":\"8\",\"totalTasks\":\"8\"}}\n",
-      "Finished writing\n",
-      "  extent = Some(Envelope: [-103.0, -39.8, 80.0, 63.0])\n",
-      "  interval = Some(Interval(MutableInstant(1848-01-11 06:00:00.000),MutableInstant(1899-12-26 06:00:00.000)))\n",
-      "  count = 568\n",
-      "{\"messageCode\":\"BD_0\",\"message\":\"Feature service layer created: http://yourserver.domain.com/webcontext/rest/services/Hosted/Reconstructed_Tracks_IOBYC0/FeatureServer/0\",\"params\":{\"serviceUrl\":\"http://yourserver.domain.com/webcontext/rest/services/Hosted/Reconstructed_Tracks_IOBYC0/FeatureServer/0\"}}\n",
-      "{\"messageCode\":\"BD_101051\",\"message\":\"Possible issues were found while reading 'inputLayer'.\",\"params\":{\"paramName\":\"inputLayer\"}}\n",
-      "{\"messageCode\":\"BD_101052\",\"message\":\"Some records have either missing or invalid time values.\"}\n",
-      "      > GenericFeature(attributes=[1979260N16312,1979,16,NA,MM,UNNAMED,9/19/1979 12:00,TS,28.8,-51.5,30.0,0,atcf,17.071,-100.0,main,30000,30000],geometry={\"x\":-51.5,\"y\":28.8},time=null)\n",
-      "      > GenericFeature(attributes=[1979260N16312,1979,16,NA,MM,UNNAMED,9/19/1979 18:00,TS,30.2,-51.5,30.0,0,atcf,17.071,-100.0,main,30000,30000],geometry={\"x\":-51.5,\"y\":30.2},time=null)\n",
-      "      > GenericFeature(attributes=[1979260N16312,1979,16,NA,MM,UNNAMED,9/20/1979 0:00,TS,32.1,-51.2,30.0,0,atcf,17.071,-100.0,main,30000,30000],geometry={\"x\":-51.2,\"y\":32.1},time=null)\n",
-      "Succeeded at Wed Dec 14 16:36:28 2016 (Elapsed Time: 17.58 seconds)\n"
+      "{\"messageCode\":\"BD_101081\",\"message\":\"Finished writing results:\"}\n",
+      "{\"messageCode\":\"BD_101082\",\"message\":\"* Count of features = 6647\",\"params\":{\"resultCount\":\"6647\"}}\n",
+      "{\"messageCode\":\"BD_101083\",\"message\":\"* Spatial extent = {\\\"xmin\\\":-180,\\\"ymin\\\":-68.5,\\\"xmax\\\":180,\\\"ymax\\\":70.7}\",\"params\":{\"extent\":\"{\\\"xmin\\\":-180,\\\"ymin\\\":-68.5,\\\"xmax\\\":180,\\\"ymax\\\":70.7}\"}}\n",
+      "{\"messageCode\":\"BD_101084\",\"message\":\"* Temporal extent = Interval(MutableInstant(1848-01-11 06:00:00.000),MutableInstant(2010-12-22 18:00:00.000))\",\"params\":{\"extent\":\"Interval(MutableInstant(1848-01-11 06:00:00.000),MutableInstant(2010-12-22 18:00:00.000))\"}}\n",
+      "{\"messageCode\":\"BD_0\",\"message\":\"Feature service layer created: https://pythonapi.playground.esri.com/server/rest/services/Hosted/Reconstructed_Tracks_I49893/FeatureServer/0\",\"params\":{\"serviceUrl\":\"https://pythonapi.playground.esri.com/server/rest/services/Hosted/Reconstructed_Tracks_I49893/FeatureServer/0\"}}\n"
      ]
     }
    ],
    "source": [
-    "agg_result = reconstruct_tracks(years_50, \n",
+    "agg_result = reconstruct_tracks(years_all, \n",
     "                                track_fields='Serial_Num',\n",
     "                                method='GEODESIC')"
    ]
@@ -620,22 +658,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fd0255b0347b4de3a5b8a9523faa1b59",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "MapView(basemaps=['dark-gray', 'dark-gray-vector', 'gray', 'gray-vector', 'hybrid', 'national-geographic', 'oc…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "processed_map = gis.map(\"USA\")\n",
     "processed_map"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![extent_1860_1879_img](http://esri.github.io/arcgis-python-api/notebooks/nbimages/04_HurricaneGeoanalytics_time.PNG)"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 17,
+   "metadata": {},
    "outputs": [],
    "source": [
     "processed_map.add_layer(agg_result)"
@@ -645,22 +701,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Thus we transformed a bunch of ponints into tracks that represents paths taken by the hurricanes over a period of 50 years. We can pull up another map and inspect the results a bit more closely"
+    "Thus we transformed more than 175,000 points into more than 6600 tracks that represents paths taken by individual hurricanes spanning a time period of more than 150 years. "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Our input data and the map widget is time enabled. Thus we can filter the data to represent the tracks from only the years 1860 to 1870"
+    "Our input data and the map widget is time enabled, so we can filter these tracks using the `set_time_extent` method on the map widget, which accepts `start_time` and `end_time` parameters to inspect the results for a specific decade, 1860 - 1870:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 18,
+   "metadata": {},
    "outputs": [],
    "source": [
     "processed_map.set_time_extent('1860', '1870')"
@@ -672,17 +726,17 @@
    "source": [
     "## What can geoanalytics do for you?\n",
     "\n",
-    "With this sample we just scratched the surface of what big data analysis can do for you. ArcGIS Enterprise at 10.5 packs a powerful set of tools that let you derive a lot of value from your data. You can do so by asking the right questions, for instance, a weather dataset such as this could be used to answer a few interesting questions such as\n",
+    "With this sample we just scratched the surface of what big data analysis can do for you. ArcGIS Enterprise at 10.5 packs a powerful set of tools that let you derive huge value from your data. You can do so by asking the right questions. For instance, the weather dataset we examined such could answer important questions such as:\n",
     " \n",
     " - did the number of hurricanes per season increase over the years?\n",
-    " - give me the hurricanes that travelled longest distance\n",
-    " - give me the ones that stayed for longest time. Do we see a trend?\n",
+    " - which hurricanes travelled thelongest distance?\n",
+    " - which hurricanes had the longest duration? Is there a trend?\n",
     " - how are wind speed and distance travelled correlated?\n",
-    " - my assets are located in a tornado corridor. How many times in the past century, was there a hurricane within 50 miles from my assets?\n",
+    " - how many times in the past century did a hurricane occur within 50 miles of my assets?\n",
     " - my industry is dependent on tourism, which is heavily impacted by the vagaries of weather. From historical weather data, can I correlate my profits with major weather events? How well is my business insulated from freak weather events?\n",
-    " - over the years do we see any shifts in major weather events - do we notice a shift in when the hurricane season starts?\n",
+    " - do we see any shifts in major hurricane events over the years? is there any shift in when the hurricane season starts?\n",
     " \n",
-    "The ArcGIS API for Python gives you a gateway to easily access the big data tools from your ArcGIS Enterprise. By combining it with other powerful libraries from the pandas and scipy stack and the rich visualization capabilities of the Jupyter notebook, you can extract a lot of value from your data, big or small."
+    "The ArcGIS API for Python gives you a gateway to easily access the big data tools from your ArcGIS Enterprise. By combining it with other powerful libraries from the pandas and scipy stack and the rich visualization capabilities of the Jupyter notebook, you can extract a huge amount of value from your data, big or small."
    ]
   }
  ],
@@ -703,7 +757,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
@DavidJVitale Issuing this PR to _master_ as we discussed
@rohitgeo @AtmaMani - Lines 684-690 reference the image from #242...so when that image is loaded up to esri.github.io the notebook will reference an image that reflects the last command in the notebook:
`processed_map.set_time_extent('1860', '1870')`
  * current map image on the public sample references the map as it looks when running the cell above the last step:
    `processed_map.add_layer(agg_result)`

* This PR reflects sampe updates to notebook as [arcgis-for-developers PR #6766](https://github.com/ArcGIS/arcgis-for-developers/pull/6766)
