### PR TITLE
changed `learn more` link to reference Portal enterprise login account doc

### DIFF
--- a/guide/03-the-gis/accessing-and-managing-users.ipynb
+++ b/guide/03-the-gis/accessing-and-managing-users.ipynb
@@ -449,9 +449,10 @@
    "source": [
     "<a id=\"creating-new-user-accounts\"></a>\n",
     "## Creating new user accounts\n",
-    "You can add new users to the org using either the `signup()` or `create()` methods available on the `UserManager` class. The `signup()` method is limited in scope as it can be used only for adding built-in accounts to an ArcGIS Enterprise instance and not for an org that is hosted on ArcGIS Online. However, you can call the `signup()` anonymously and does not require admin privileges unlike the `create()` method. Note, you can disable self-signup in your ArcGIS Enterprise which would render the `signup()` unusable if you wanted to turn the org invite-only.\n",
+    "You can add new users to the org using either the `signup()` or `create()` methods available on the `UserManager` class. The `signup()` method is limited in scope as it can be used only for adding built-in accounts to an ArcGIS Enterprise instance and not for an org that is hosted on ArcGIS Online. However, you can call the `signup()` anonymously and does not require admin privileges unlike the `create()` method. \n",
+    "> Note, you can disable self-signup in your ArcGIS Enterprise which would render the `signup()` unusable if you wanted to turn the org invite-only.\n",
     "\n",
-    "You need admin privileges to call the `create()` method. This method is powerful as it allows you to create new accounts from arcgis built-in credential store or your enterprise's credential store. In case of accounts from built-in credential store, you would provide a password when the account is created. The user can change it at any time once they login. For accounts from your enterprise's credential store, you can ignore the `password` parameter and your users will authenticate through that credential store.\n",
+    "You need admin privileges to call the `create()` method. This method is very powerful in an instance of ArcGIS Enterprise, as it allows you to create new accounts from either the arcgis built-in credential store or your enterprise's credential store. For an ArcGIS Online Organization, you can only create users that will use the built-in credential store. For the case of accounts from a built-in credential store, you would provide a password when the account is created. The user can change it at any time once they login. For accounts from your enterprise's credential store, you can ignore the `password` parameter and your users will authenticate through that credential store.\n",
     "\n",
     "In addition to `role` that can be set, a `level` can be used to allocate accounts based on the privileges that members need. The level determines which privileges are available to the member. The enterprise offers two levels of membership.  Level 1 membership is for members who only need privileges to **view** content, such as maps and apps, that has been shared with them through the organization, as well as join groups within the organization. Level 2 membership is for members who need to view, create, and share content and own groups, in addition to other tasks.\n",
     "\n",
@@ -521,7 +522,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that we specified `provider` as `arcgis`. If you were creating accounts from your enterprise credential store, you would specify this value as `enterprise` and use the `idpUsername` parameter to specify the username of the user in that credential store. To learn more about this configuration, refer to this help topic on [setting up enterprise logins](https://doc.arcgis.com/en/arcgis-online/administer/enterprise-logins.htm).\n",
+    "> Note that we specified `arcgis` as the `provider` argument. If you were creating accounts from your enterprise credential store, you would specify this value as `enterprise` and use the `idpUsername` parameter to specify the username of the user in that credential store. To learn more about this configuration, refer to this help topic on [setting up enterprise logins](http://enterprise.arcgis.com/en/portal/latest/administer/windows/about-configuring-portal-authentication.htm#ESRI_SECTION1_83F7B85FEF594A6B96997AF3CADF3D38).\n",
     "\n",
     "Note, the `role` parameter was specified as `org_user`. This takes us to the next section on `Role` and `RoleManager` objects."
    ]
@@ -1243,9 +1244,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
* addressing [Geosaurus #621](https://github.com/ArcGIS/geosaurus/issues/621)
* Currently the _Creating new user accounts_ section of the _accessing-and-managing-users_ Guide links to ArcGIS Online documentation to learn more about configuring enterprise logins.  But since the API Reference doc for [gis.users.create()](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.gis.toc.html#arcgis.gis.UserManager.create) states _"This operation is used to pre-create built-in or enterprise accounts within the portal, **or built-in users in an ArcGIS Online organization account**", the link seemed misleading, so I updated the learn more link to reference [configuring enterprise logins for portal]( http://enterprise.arcgis.com/en/portal/latest/administer/windows/about-configuring-portal-authentication.htm#ESRI_SECTION1_83F7B85FEF594A6B96997AF3CADF3D38)