### PR TITLE
removed errant message about User Types from release notes

### DIFF
--- a/guide/02-api-overview/release-notes.ipynb
+++ b/guide/02-api-overview/release-notes.ipynb
@@ -19,7 +19,6 @@
     "* Added capability to to view the server Services Directory properties\n",
     "* Added support for True Curves in `Geometry` module\n",
     "* Updated documentation for `Spatially Enabled DataFrame`\n",
-    "* Added support for new [`User Types`](https://www.esri.com/en-us/arcgis/products/arcgis-online/pricing/arcgis-online-subscriptions) building blocks\n",
     "* Reduced overhead on certificate searches in [gis.server.admin.SSLCertificates](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.gis.admin.html#sslcertificates)\n",
     "* Added ability to set the map widget extent to that of a loaded [`Spatially Enabled DataFrame`](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.features.toc.html#arcgis-features-geoaccessor)\n",
     "* Added [`from_shapely()`]() method to [`Geometry`](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.geometry.html#geometry) class\n",


### PR DESCRIPTION
* incorrectly stated that support for User Types was in 1.5.1
