### PR TITLE
too many escaped quotes

### DIFF
--- a/samples/02_power_users_developers/building_a_change_detection_app_using_jupyter_dashboard.ipynb
+++ b/samples/02_power_users_developers/building_a_change_detection_app_using_jupyter_dashboard.ipynb
@@ -78,7 +78,7 @@
     "gis = GIS()\n",
     "\n",
     "# search for the landsat multispectral imagery layer\n",
-    "landsat_item = gis.content.search('\"Landsat Multispectral\"', 'Imagery Layer', outside_org=True)[0]\n",
+    "landsat_item = gis.content.search('Landsat Multispectral', 'Imagery Layer', outside_org=True)[0]\n",
     "landsat = landsat_item.layers[0]\n",
     "df = None"
    ]

--- a/samples/02_power_users_developers/jupyter_dashboard_for_raster_analytics.ipynb
+++ b/samples/02_power_users_developers/jupyter_dashboard_for_raster_analytics.ipynb
@@ -123,7 +123,7 @@
     "\n",
     "gis = GIS()\n",
     "\n",
-    "landsat_item = gis.content.search('\"Landsat Multispectral\"', 'Imagery Layer')[0]\n",
+    "landsat_item = gis.content.search('Landsat Multispectral', 'Imagery Layer')[0]\n",
     "\n",
     "landsat = landsat_item.layers[0]"
    ]

--- a/samples/02_power_users_developers/tour_the_world_with_landsat_imagery_and_raster_functions.ipynb
+++ b/samples/02_power_users_developers/tour_the_world_with_landsat_imagery_and_raster_functions.ipynb
@@ -61,7 +61,7 @@
    },
    "outputs": [],
    "source": [
-    "landsat_item = gis.content.search('\"Landsat Multispectral\"', 'Imagery Layer')[0]"
+    "landsat_item = gis.content.search('Landsat Multispectral', 'Imagery Layer')[0]"
    ]
   },
   {

--- a/samples/04_gis_analysts_data_scientists/counting_features_in_satellite_images_using_scikit_image.ipynb
+++ b/samples/04_gis_analysts_data_scientists/counting_features_in_satellite_images_using_scikit_image.ipynb
@@ -66,7 +66,7 @@
     }
    ],
    "source": [
-    "l8 = agol.content.search('\"Landsat Multispectral\"', 'Imagery Layer')[0]\n",
+    "l8 = agol.content.search('Landsat Multispectral', 'Imagery Layer')[0]\n",
     "l8"
    ]
   },


### PR DESCRIPTION
in a workshop today a customer noticed a failing search  caused by a single+double quoted (which makes it tripled quoted?) string.

![screenshot 2019-01-31 16 55 50](https://user-images.githubusercontent.com/3011734/52095769-23003f00-2579-11e9-9c61-3095704692f4.png)
