### PR TITLE
script to clear pythonapi playground

### DIFF
--- a/misc/_common.py
+++ b/misc/_common.py
@@ -13,23 +13,23 @@ ignore_accounts = ['andrew', 'andrew.chapkowski', 'dvitale', 'david.vitale',
 target_accounts = ['arcgis_python']
 
 """create GIS connection via admin credentials"""
-# gis = GIS(profile='your_portal_profile', verify_cert=False)
+# gis = GIS(profile='your_entp_admin_profile', verify_cert=False)
 gis = GIS("https://pythonapi.playground.esri.com/portal","temp_execution", "temp_execution123")
 
 
 def delete_depending_items(dependent_item):
+    """deletes the item's depending items, and then the item"""
     depending_items = dependent_item.dependent_to()
     if depending_items['list']:
         for item in depending_items['list']:
             delete_depending_items(item)
-    else:
-        if dependent_item.protected:
-            dependent_item.protect(False)
-        try:
-            print("=== deleting the item: %s" % dependent_item.homepage)
-            dependent_item.delete()
-        except:
-            print("=== could not delete non-dependent item %s" % dependent_item.homepage)
+    if dependent_item.protected:
+        dependent_item.protect(False)
+    try:
+        print("=== deleting the item: %s" % dependent_item.homepage)
+        dependent_item.delete()
+    except:
+        print("=== could not delete non-dependent item %s" % dependent_item.homepage)
 
 
 def delete_items(user):
@@ -43,7 +43,7 @@ def delete_items(user):
 
 
 def delete_groups(user):
-    """deletes the user groups"""
+    """deletes the user groups, and removes user from groups where user is a member of"""
     groups_for_deletion = gis.groups.get('query=owner:' + user.username)
     if groups_for_deletion is not None:
         for group in groups_for_deletion:
@@ -66,7 +66,7 @@ def delete_groups(user):
 def delete_for_users():
     """deletes items and groups for users in target_accounts, and ignore others"""
     for user in gis.users.search():
-        if user.username not in ignore_accounts:
+        if user.username not in ignore_accounts and not user.username.startswith("esri_"):
             print("-*-*-*-*-*-*-Delete groups & items & user for %s -*-*-*-*-*-" % user.username)
             delete_items(user)
             delete_groups(user)

--- a/misc/_common.py
+++ b/misc/_common.py
@@ -17,20 +17,28 @@ target_accounts = ['arcgis_python']
 gis = GIS("https://pythonapi.playground.esri.com/portal","temp_execution", "temp_execution123")
 
 
+def delete_depending_items(dependent_item):
+    depending_items = dependent_item.dependent_to()
+    if depending_items['list']:
+        for item in depending_items['list']:
+            delete_depending_items(item)
+    else:
+        if dependent_item.protected:
+            dependent_item.protect(False)
+        try:
+            print("=== deleting the item: %s" % dependent_item.id)
+            dependent_item.delete()
+        except:
+            print("=== could not delete non-dependent item %s" % dependent_item.id)
+
+
 def delete_items(user):
     """deletes the user items"""
     folders = [None] + user.folders
     for folder in folders:
         print("=== deleting inside folder: %s" % folder)
         for item in user.items(folder=folder, max_items=255):
-            print("=== deleting the item: %s" % item.id)
-            if item.protected:
-                item.protect(False)
-            depending_items = item.dependent_to()
-            if not depending_items['list']:
-                item.delete()
-            else:
-                print("=== could not delete dependent item %s" % item.id)
+            delete_depending_items(item)
     print("=== finished deleting items owned by " + user.username)
 
 

--- a/misc/_common.py
+++ b/misc/_common.py
@@ -7,14 +7,14 @@ ignore_accounts = ['andrew', 'andrew.chapkowski', 'dvitale', 'david.vitale',
                    'rohit.singh', 'rohitgeo', 'gbochenek_python',
                    'system_publisher', 'admin', 'portaladmin',
                    'Demo_User', 'First_User', 'Second_User',
-                   'api_data_owner', 'arcgis_python']
+                   'api_data_owner', 'arcgis_python', 'temp_execution']
 
 """accounts that you want to delete groups and items, but keep user"""
 target_accounts = ['arcgis_python']
 
 """create GIS connection via admin credentials"""
 # gis = GIS(profile='your_portal_profile', verify_cert=False)
-gis = GIS("https://pythonapi.playground.esri.com/portal","portaladmin", "esri.agp8")
+gis = GIS("https://pythonapi.playground.esri.com/portal","temp_execution", "temp_execution123")
 
 
 def delete_items(user):
@@ -37,12 +37,21 @@ def delete_items(user):
 def delete_groups(user):
     """deletes the user groups"""
     groups_for_deletion = gis.groups.get('query=owner:' + user.username)
-    for group in groups_for_deletion:
-        try:
-            print("=== deleting group %s" % group.groupid)
-            group.delete()
-        except:
-            print("=== could not delete group %s" % group.groupid)
+    if groups_for_deletion is not None:
+        for group in groups_for_deletion:
+            try:
+                print("=== deleting group %s" % group.groupid)
+                group.delete()
+            except:
+                print("=== could not delete group %s" % group.groupid)
+
+    for grp in user.groups:
+        print("=== removing from group: %s" % grp.id)
+        if grp.owner != user.username:
+            try:
+                grp.remove_users([user.username])
+            except:
+                print("=== User cannot be removed from group: %s" % grp.id)
     print("=== finished deleting groups owned by " + user.username)
 
 
@@ -65,13 +74,7 @@ def delete_for_users():
                 if (datetime.datetime.now() - dt).days > 90:
 
                     delete_items(user)
-                    for grp in user.groups:
-                        print("=== deleting the group: %s" % grp.id)
-                        if grp.owner == user.username:
-                            grp.delete()
-                        else:
-                            grp.remove_users([user.username])
-                        print("=== deleting the group finished: %s" % grp.id)
+                    delete_groups(user)
                 try:
                     user.delete()
                 except:

--- a/misc/_common.py
+++ b/misc/_common.py
@@ -1,0 +1,86 @@
+from arcgis.gis import GIS
+import datetime
+
+"""accounts to keep from user/groups/items deletion"""
+ignore_accounts = ['andrew', 'andrew.chapkowski', 'dvitale', 'david.vitale',
+                   'atma.mani', 'john.yaist', 'bill.major', 'YJiang',
+                   'rohit.singh', 'rohitgeo', 'gbochenek_python',
+                   'system_publisher', 'admin', 'portaladmin',
+                   'Demo_User', 'First_User', 'Second_User',
+                   'api_data_owner', 'arcgis_python']
+
+"""accounts that you want to delete groups and items, but keep user"""
+target_accounts = ['arcgis_python']
+
+"""create GIS connection via admin credentials"""
+# gis = GIS(profile='your_portal_profile', verify_cert=False)
+gis = GIS("https://pythonapi.playground.esri.com/portal","portaladmin", "esri.agp8")
+
+
+def delete_items(user):
+    """deletes the user items"""
+    folders = [None] + user.folders
+    for folder in folders:
+        print("=== deleting inside folder: %s" % folder)
+        for item in user.items(folder=folder, max_items=255):
+            print("=== deleting the item: %s" % item.id)
+            if item.protected:
+                item.protect(False)
+            depending_items = item.dependent_to()
+            if not depending_items['list']:
+                item.delete()
+            else:
+                print("=== could not delete dependent item %s" % item.id)
+    print("=== finished deleting items owned by " + user.username)
+
+
+def delete_groups(user):
+    """deletes the user groups"""
+    groups_for_deletion = gis.groups.get('query=owner:' + user.username)
+    for group in groups_for_deletion:
+        try:
+            print("=== deleting group %s" % group.groupid)
+            group.delete()
+        except:
+            print("=== could not delete group %s" % group.groupid)
+    print("=== finished deleting groups owned by " + user.username)
+
+
+def delete_for_users():
+    """deletes items and groups for users in target_accounts, and ignore others"""
+    for user in gis.users.search():
+        if user.username not in ignore_accounts and \
+           user.username.find("esri_") == -1:
+            print("-*-*-*-*-*-*-*-Delete User for %s -*-*-*-*-*-*-*-*-*-" % user.username)
+            if user.lastLogin == -1 and \
+               user.roleId == 'org_user' and \
+               len(user.items()) == 0 and \
+               len(user.groups) == 0:
+                user.delete()
+            elif user.lastLogin == -1:
+                print("%s never logged in" % user.username)
+            elif user.lastLogin > 0:
+                print('removing user: %s' % user.username)
+                dt = datetime.datetime.fromtimestamp(user.lastLogin/1000)
+                if (datetime.datetime.now() - dt).days > 90:
+
+                    delete_items(user)
+                    for grp in user.groups:
+                        print("=== deleting the group: %s" % grp.id)
+                        if grp.owner == user.username:
+                            grp.delete()
+                        else:
+                            grp.remove_users([user.username])
+                        print("=== deleting the group finished: %s" % grp.id)
+                try:
+                    user.delete()
+                except:
+                    print("could not delete user %s" % user.username)
+
+        elif user.username in target_accounts:
+            print("-*-*-*-*-*-*-Delete groups & items for %s -*-*-*-*-*-*-*-*-" % user.username)
+            delete_items(user)
+            delete_groups(user)
+
+        else:
+            print("-*-*-*-*-*-*-*-*-No Delete for %s -*-*-*-*-*-*-*-*-*-*-" % user.username)

--- a/misc/_common.py
+++ b/misc/_common.py
@@ -26,10 +26,10 @@ def delete_depending_items(dependent_item):
         if dependent_item.protected:
             dependent_item.protect(False)
         try:
-            print("=== deleting the item: %s" % dependent_item.id)
+            print("=== deleting the item: %s" % dependent_item.homepage)
             dependent_item.delete()
         except:
-            print("=== could not delete non-dependent item %s" % dependent_item.id)
+            print("=== could not delete non-dependent item %s" % dependent_item.homepage)
 
 
 def delete_items(user):
@@ -66,27 +66,14 @@ def delete_groups(user):
 def delete_for_users():
     """deletes items and groups for users in target_accounts, and ignore others"""
     for user in gis.users.search():
-        if user.username not in ignore_accounts and \
-           user.username.find("esri_") == -1:
-            print("-*-*-*-*-*-*-*-Delete User for %s -*-*-*-*-*-*-*-*-*-" % user.username)
-            if user.lastLogin == -1 and \
-               user.roleId == 'org_user' and \
-               len(user.items()) == 0 and \
-               len(user.groups) == 0:
+        if user.username not in ignore_accounts:
+            print("-*-*-*-*-*-*-Delete groups & items & user for %s -*-*-*-*-*-" % user.username)
+            delete_items(user)
+            delete_groups(user)
+            try:
                 user.delete()
-            elif user.lastLogin == -1:
-                print("%s never logged in" % user.username)
-            elif user.lastLogin > 0:
-                print('removing user: %s' % user.username)
-                dt = datetime.datetime.fromtimestamp(user.lastLogin/1000)
-                if (datetime.datetime.now() - dt).days > 90:
-
-                    delete_items(user)
-                    delete_groups(user)
-                try:
-                    user.delete()
-                except:
-                    print("could not delete user %s" % user.username)
+            except:
+                print("could not delete user %s" % user.username)
 
         elif user.username in target_accounts:
             print("-*-*-*-*-*-*-Delete groups & items for %s -*-*-*-*-*-*-*-*-" % user.username)

--- a/misc/setup.py
+++ b/misc/setup.py
@@ -1,1 +1,7 @@
-print("Hello setup!")
+from misc._common import *
+
+print("-*-*-*-*-*-*-*-*-*-*-*Setup begins*-*-*-*-*-*-*-*-*-*-*-*-*-")
+
+delete_for_users()
+
+print("-*-*-*-*-*-*-*-*-*-*-*Setup ends*-*-*-*-*-*-*-*-*-*-*-*-*-*-")

--- a/misc/teardown.py
+++ b/misc/teardown.py
@@ -1,1 +1,7 @@
-print("hello teardown!")
+from misc._common import *
+
+print("-*-*-*-*-*-*-*-*-*-*-*Teardown begins*-*-*-*-*-*-*-*-*-*-*-*-")
+
+delete_for_users()
+
+print("-*-*-*-*-*-*-*-*-*-*-*Teardown ends*-*-*-*-*-*-*-*-*-*-*-*-*-")


### PR DESCRIPTION
https://github.com/ArcGIS/geosaurus/issues/1817
The script deletes
(a) user groups and items, and then the user itself
(b) only groups and items

Tested against pythonapi playground, and has deleted all services for arcgis_python.

1. Using the username and password for GIS initialization; profile option is in comments.
2. If run locally, please change 
`from misc._common import *`
to 
`from _common import *`
Current setting is for remote runs.