### PR TITLE
fix advanced-map-widget-usage and fix import for carto 2

### DIFF
--- a/guide/10-mapping-and-visualization/advanced-cartography-part2.ipynb
+++ b/guide/10-mapping-and-visualization/advanced-cartography-part2.ipynb
@@ -57,6 +57,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from arcgis.features import FeatureLayer"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
    "outputs": [

--- a/guide/10-mapping-and-visualization/advanced-map-widget-usage.ipynb
+++ b/guide/10-mapping-and-visualization/advanced-map-widget-usage.ipynb
@@ -156,7 +156,7 @@
     "\n",
     "You can setup an asyncronous callback using the `on_click()` or `on_draw_end()` to create dynamic, interactive 'apps'. You need to create a callback function like `function_name(map_inst, geometry)`, with `map_inst` being the `MapView` instance, and `geometry` being the geometry instance that the user clicked.\n",
     "\n",
-    "The below example takes a point a user clicks on the map, reverse geocodes from the geometry, and prints out the resultant location."
+    "The below example takes a point a user clicks on the map, reverse geocodes from the geometry, and prints out the resultant location. Also to note here, you can either create the GIS connection using existing profile, or by simply entering the username and password, e.g. `gis = GIS(\"https://www.arcgis.com\", \"arcgis_python\", \"P@ssword123\")`."
    ]
   },
   {
@@ -181,7 +181,7 @@
    "source": [
     "from arcgis.gis import GIS\n",
     "import arcgis.geocoding as geocoding\n",
-    "gis = GIS()\n",
+    "gis = GIS(profile = \"your_online_profile\")\n",
     "callback_map = gis.map('San Diego convention center, San Diego, CA', 16)\n",
     "def find_addr(callback_map, g):\n",
     "    try:\n",
@@ -495,11 +495,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Use this string unix based file systems\n",
-    "file_path = \"/Users/username/myHurricaneMap.html\"\n",
-    "#Use this string for Windows based file systems\n",
-    "file_path = r\"C:\\Users\\username\\myHurricaneMap.html\"\n",
-    "visual_var_map.export_to_html(file_path)"
+    "import os\n",
+    "\n",
+    "file_dir = os.path.join(os.getcwd(), 'home')\n",
+    "if not os.path.isdir(file_dir):\n",
+    "    os.mkdir(file_dir)\n",
+    "    \n",
+    "file_path = os.path.join(file_dir, 'myHurricaneMap.html')\n",
+    "\n",
+    "visual_var_map.export_to_html(file_path)\n",
+    "print(\"html saved as \" + file_path) # On Windows, path can be 'C:\\Users\\Username\\Documents\\home\\myHurricaneMap.html'"
    ]
   }
  ],
@@ -519,7 +524,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
https://github.com/ArcGIS/geosaurus/issues/1885

1. need to create real connection with profile to save a web map item (the original script uses anonymous connection)
2. use os.path.join(...) to create the output path name (VS. the original script has two fixed paths for Win and Lin env which show as non-existent in the nightly runs)
3. file name has a spelling mistake -> changing useage to usage
4. advanced-carto-part2.ipynb misses the FeatureLayer import statement

**Ready for review** @AtmaMani 