### PR TITLE
Added proper online credentials to connect to the data referenced in guide

### DIFF
--- a/guide/04-feature-data-and-analysis/appending-features.ipynb
+++ b/guide/04-feature-data-and-analysis/appending-features.ipynb
@@ -104,7 +104,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Make a GIS Connection"
+    "### Make a GIS Connection\n",
+    "\n",
+    "The cell below is a generic placeholder to illustrate connecting to your GIS through a profile holding your specific credentials. This notebook accesses data shared within a particular ArcGIS Online Organization accessible with the following credentials:\n",
+    "\n",
+    "* url = https://www.arcgis.com\n",
+    "* username = arcgis_python\n",
+    "* password = P@ssword123\n",
+    "\n",
+    "So make a connection with the following syntax to continue running through the notebook:\n",
+    "`gis = GIS(\"https://www.arcgis.com\", \"arcgis_python\", \"P@ssword123\")`"
    ]
   },
   {


### PR DESCRIPTION
The current [append guide](https://developers.arcgis.com/python/guide/appending-features/) does not explicitly reference the `arcgis_python` credentials necessary to access the data used in this guide.  If anyone enters in their own ArcGIS Online credentials (instead of the  online `arcgis_python` user credentials) they will receive errors when searching for the items used in the notebook since they are not shared publicly.

Added some text explaining how to connect with the `arcgis_python` user credentials and that the "your_online_profile" text is a placeholder.

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports?
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [ ] Code refactored & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
