### PR TITLE
doc clarification for issue #469

### DIFF
--- a/apidoc/arcgis.gis.toc.html
+++ b/apidoc/arcgis.gis.toc.html
@@ -1886,7 +1886,7 @@ as a dictionary when False</td>
 <td>The user’s favorites group and is created automatically for each user.</td>
 </tr>
 <tr class="row-odd"><td>lastLogin</td>
-<td>The last login date of the user as a UNIX timestamp.</td>
+<td>The last login date of the user in milliseconds since the Unix epoch.</td>
 </tr>
 <tr class="row-even"><td>mfaEnabled</td>
 <td>Indicates if the user’s account has multifactor authentication set up.</td>
@@ -1937,10 +1937,10 @@ as a dictionary when False</td>
 <td>The file name of the thumbnail used for the user.</td>
 </tr>
 <tr class="row-even"><td>created</td>
-<td>The date the user was created. Shown in UNIX time.</td>
+<td>The date the user was created. Shown in milliseconds since the Unix epoch.</td>
 </tr>
 <tr class="row-odd"><td>modified</td>
-<td>The date the user was last modified. Shown in UNIX time.</td>
+<td>The date the user was last modified. Shown in milliseconds since the Unix epoch.</td>
 </tr>
 <tr class="row-even"><td>groups</td>
 <td>A JSON array of groups the user belongs to. See Group for properties of a group.</td>


### PR DESCRIPTION
Language changes to clarify use of milliseconds since epoch instead of implied seconds since the epoch for `arcgis.gis.User` properties `created`, `modified`, and `lastLogin` noted in #469.

Assuming no problems with checklist below with such a simple diff to master; checking them off.

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [X] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports?
- [X] All `GIS` object instantiations are one of the following?
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [X] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [X] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [X] Code refactored & split out across multiple cells, useful comments?
- [X] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [X] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [X] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [x] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
