### PR TITLE
fixed typo in offline instructions

### DIFF
--- a/guide/01-getting-started/install-and-set-up.ipynb
+++ b/guide/01-getting-started/install-and-set-up.ipynb
@@ -364,7 +364,6 @@
     "     gis = GIS(\"url_to_your_gis\", \"username\", \"password\")\n",
     "     print(f\"Connected to {gis.properties.portalHostname} as {gis.users.me.username}\")\n",
     "    ```\n",
-    "    \n",
     " * The `map widget` is only supported within [`Jupyter`](https://jupyter.org/) applications. Follow these additional steps to use the map widget in a disconnected environment:\n",
     " \n",
     "   * install the `jupyterlab` package for visualizing with maps in either Jupyter Notebook or Jupyter Lab: \n",
@@ -381,7 +380,7 @@
     "      \n",
     "      **NOTE**: You may need to configure the map widget to use the Javascript API shipped with the portal you're connecting to in the disconnected environment. If `gis.map()` does not return a map, run the following code to configure the map widget with the Javascript API shipped with the portal:\n",
     "      ```python\n",
-    "      MapView.set_js_cd(\"https://your-portal-host/jsapi4/\")\n",
+    "      MapView.set_js_cdn(\"https://your-portal-host/jsapi4/\")\n",
     "      ```\n",
     "\n",
     "> _NOTE:_ The Web GIS must have a [`Geocoder`](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.geocoding.html#geocoder) configured as a Utility Service to display a map. See [`here`](https://enterprise.arcgis.com/en/portal/latest/administer/windows/configure-portal-to-geocode-addresses.htm) for details if your portal does not have one."
@@ -412,7 +411,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.8"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
- fixed typo in `set_js_cd` command...should be `set_js_cdn()`

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports?
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [ ] Code refactored & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
