### PR TITLE
Updating Display a web map tutorial notebook to get web map by item id

### DIFF
--- a/labs/display_web_map.ipynb
+++ b/labs/display_web_map.ipynb
@@ -23,7 +23,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's search get the Los Angeles Parks and Trails Map by item id.  We know the id is 41281c51f9de45edaf1c8ed44bb10e30. "
+    "Let's get the Los Angeles Parks and Trails Map by item id.  We know the id is 41281c51f9de45edaf1c8ed44bb10e30. "
    ]
   },
   {

--- a/labs/display_web_map.ipynb
+++ b/labs/display_web_map.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,43 +23,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's search for a Los Angeles Parks and Trails Map by web map id.  We know the id is 41281c51f9de45edaf1c8ed44bb10e30. "
+    "Let's search get the Los Angeles Parks and Trails Map by item id.  We know the id is 41281c51f9de45edaf1c8ed44bb10e30. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
-       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://www.arcgis.com/home/item.html?id=41281c51f9de45edaf1c8ed44bb10e30' target='_blank'>\n",
-       "                        <img src='https://www.arcgis.com/sharing/rest//content/items/41281c51f9de45edaf1c8ed44bb10e30/info/thumbnail/ago_downloaded.png' class=\"itemThumbnail\">\n",
-       "                       </a>\n",
-       "                    </div>\n",
-       "\n",
-       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://www.arcgis.com/home/item.html?id=41281c51f9de45edaf1c8ed44bb10e30' target='_blank'><b>LA Parks and Trails Map (styled with popups)</b>\n",
-       "                        </a>\n",
-       "                        <br/>Trails and parks in the LA area (styled with popups)<img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/maps16.png' style=\"vertical-align:middle;\">Web Map by esri_devlabs\n",
-       "                        <br/>Last Modified: May 02, 2019\n",
-       "                        <br/>0 comments, 62,237 views\n",
-       "                    </div>\n",
-       "                </div>\n",
-       "                "
-      ],
-      "text/plain": [
-       "<Item title:\"LA Parks and Trails Map (styled with popups)\" type:Web Map owner:esri_devlabs>"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "webmap = gis.content.get(\"41281c51f9de45edaf1c8ed44bb10e30\")\n",
     "webmap"
@@ -74,36 +45,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "34f0679913e64f5aa90706a77810891c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "MapView(hide_mode_switch=True, layout=Layout(height='400px', width='100%'))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"map-static-img-preview-b6c79da5-8049-4d70-afd5-8114c528c923\"><img src=\"\"></img></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from arcgis.mapping import WebMap\n",
     "\n",
@@ -120,17 +64,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The webmap has 4 layers.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "op_layers = la_parks_trails.layers\n",
     "print(\"The webmap has {} layers.\".format(len(op_layers)))"
@@ -138,24 +74,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Trailheads_8053\n",
-      "\thttps://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trailheads/FeatureServer/0\n",
-      "Trails_7558_8861\n",
-      "\thttps://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trails/FeatureServer/0\n",
-      "Trails_7558\n",
-      "\thttps://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trails/FeatureServer/0\n",
-      "Parks_and_Open_Space_8268\n",
-      "\thttps://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Parks_and_Open_Space/FeatureServer/0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for lyr in la_parks_trails.layers:\n",
     "    print(\"{}\\n\\t{}\".format(lyr['id'], lyr['url']))"

--- a/labs/display_web_map.ipynb
+++ b/labs/display_web_map.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,44 +23,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's search for a Los Angeles Parks and Trails Map. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<Item title:\"Tree Canopy by City in Minnesota\" type:Web Map owner:vikalpa>,\n",
-       " <Item title:\"Vaals3\" type:Web Map owner:haicao1975>,\n",
-       " <Item title:\"LA Parks and Trails Map (styled)\" type:Web Map owner:esri_devlabs>,\n",
-       " <Item title:\"San Diego Shortlist Cool Places to Go\" type:Web Map owner:ec249>,\n",
-       " <Item title:\"LA Parks and Trails Map (unstyled)-Copy\" type:Web Map owner:nicolemichelle13>,\n",
-       " <Item title:\"Santa Monica Mountains Map - Route Multiple Vehicles Solution\" type:Web Map owner:esri_devlabs>,\n",
-       " <Item title:\"San Diego Places To Go-复制\" type:Web Map owner:win_001>,\n",
-       " <Item title:\"LA Parks and Trails Map (unstyled)-Copy\" type:Web Map owner:tinytonson04>,\n",
-       " <Item title:\"LA Parks and Trails Map (unstyled)-Copy\" type:Web Map owner:hosweh>,\n",
-       " <Item title:\"bamboo\" type:Web Map owner:alamsiam1>]"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "webmaps = gis.content.search(query=\"LA Parks and Trails *\", item_type=\"Web Map\")\n",
-    "webmaps"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The index position for the LA Parks and Trails Map in your search list may vary from the example."
+    "Let's search for a Los Angeles Parks and Trails Map by web map id.  We know the id is 41281c51f9de45edaf1c8ed44bb10e30. "
    ]
   },
   {
@@ -73,23 +36,23 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://www.arcgis.com/home/item.html?id=6712da5c872c44deaf24499e6f6c2d2b' target='_blank'>\n",
-       "                        <img src='https://www.arcgis.com/sharing/rest//content/items/6712da5c872c44deaf24499e6f6c2d2b/info/thumbnail/ago_downloaded.png' class=\"itemThumbnail\">\n",
+       "                       <a href='https://www.arcgis.com/home/item.html?id=41281c51f9de45edaf1c8ed44bb10e30' target='_blank'>\n",
+       "                        <img src='https://www.arcgis.com/sharing/rest//content/items/41281c51f9de45edaf1c8ed44bb10e30/info/thumbnail/ago_downloaded.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://www.arcgis.com/home/item.html?id=6712da5c872c44deaf24499e6f6c2d2b' target='_blank'><b>LA Parks and Trails Map (styled)</b>\n",
+       "                        <a href='https://www.arcgis.com/home/item.html?id=41281c51f9de45edaf1c8ed44bb10e30' target='_blank'><b>LA Parks and Trails Map (styled with popups)</b>\n",
        "                        </a>\n",
-       "                        <br/>Trails and parks in the LA area (styled)<img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/maps16.png' style=\"vertical-align:middle;\">Web Map by esri_devlabs\n",
-       "                        <br/>Last Modified: October 04, 2017\n",
-       "                        <br/>0 comments, 3,004 views\n",
+       "                        <br/>Trails and parks in the LA area (styled with popups)<img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/maps16.png' style=\"vertical-align:middle;\">Web Map by esri_devlabs\n",
+       "                        <br/>Last Modified: May 02, 2019\n",
+       "                        <br/>0 comments, 62,237 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
       ],
       "text/plain": [
-       "<Item title:\"LA Parks and Trails Map (styled)\" type:Web Map owner:esri_devlabs>"
+       "<Item title:\"LA Parks and Trails Map (styled with popups)\" type:Web Map owner:esri_devlabs>"
       ]
      },
      "execution_count": 3,
@@ -98,7 +61,7 @@
     }
    ],
    "source": [
-    "webmap = webmaps[2]\n",
+    "webmap = gis.content.get(\"41281c51f9de45edaf1c8ed44bb10e30\")\n",
     "webmap"
    ]
   },
@@ -117,7 +80,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c6fc199f26b04dd69d854119291c14c8",
+       "model_id": "34f0679913e64f5aa90706a77810891c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -131,7 +94,7 @@
     {
      "data": {
       "text/html": [
-       "<div class=\"map-static-img-preview-47bbaaec-b0a3-406f-b4c6-829f1ab58c3b\"><img src=\"\"></img></div>"
+       "<div class=\"map-static-img-preview-b6c79da5-8049-4d70-afd5-8114c528c923\"><img src=\"\"></img></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -143,6 +106,7 @@
    ],
    "source": [
     "from arcgis.mapping import WebMap\n",
+    "\n",
     "la_parks_trails = WebMap(webmap)\n",
     "la_parks_trails"
    ]
@@ -156,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -174,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -183,12 +147,12 @@
      "text": [
       "Trailheads_8053\n",
       "\thttps://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trailheads/FeatureServer/0\n",
+      "Trails_7558_8861\n",
+      "\thttps://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trails/FeatureServer/0\n",
       "Trails_7558\n",
       "\thttps://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trails/FeatureServer/0\n",
-      "Parks_and_Open_Space_2992\n",
-      "\thttps://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Parks_and_Open_Space/FeatureServer/0\n",
-      "Boundary_1356\n",
-      "\thttps://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Boundary/FeatureServer/0\n"
+      "Parks_and_Open_Space_8268\n",
+      "\thttps://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Parks_and_Open_Space/FeatureServer/0\n"
      ]
     }
    ],
@@ -215,7 +179,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updated the [Display a web map](https://developers.arcgis.com/labs/python/display-a-web-map/) tutorial to `get` the web map item by id value instead of using `search`. Requested by dev site.

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports?
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [ ] Code refactored & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
