### PR TITLE
document_requirements_for_classified_tiles

### DIFF
--- a/guide/14-deep-learning/how-unet-works.ipynb
+++ b/guide/14-deep-learning/how-unet-works.ipynb
@@ -123,7 +123,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.6.9"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
this fixes https://github.com/ArcGIS/geosaurus/issues/2346

documented bit depth requirement of classified_tiles