### PR TITLE
Typo correction from credentialls to credentials

### DIFF
--- a/guide/03-the-gis/working-with-different-authentication-schemes.ipynb
+++ b/guide/03-the-gis/working-with-different-authentication-schemes.ipynb
@@ -502,7 +502,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Storing your credentialls locally\n",
+    "## Storing your credentials locally\n",
     "If you are signing in frequently to a particular GIS and would like to store the credentials locally on your computer, then you could do so using the `profile` parameter of your `GIS`.\n",
     "\n",
     "Persistent profiles for the GIS can be created by giving the GIS authorization credentials and specifying a profile name. The profile stores all of the authorization credentials (except the password) in the user’s home directory in an unencrypted config file named `.arcgisprofile.` The profile securely stores the password in an O.S. specific password manager through the [keyring](https://pypi.python.org/pypi/keyring) python module. (Note: Linux systems may need additional software installed and configured for proper security) Once a profile has been saved, passing the profile parameter by itself uses the authorization credentials saved in the configuration file/password manager by that profile name. Multiple profiles can be created and used in parallel.\n"


### PR DESCRIPTION
Fixed typo. Changed "credentialls" to "credentials". That should fix the last link in the list at top of the page: the link is currently broken.
- https://developers.arcgis.com/python/guide/working-with-different-authentication-schemes. _Scroll to **Storing your credentialls locally**_.

### Related issues:
- https://github.com/ArcGIS/geosaurus/issues/3315
- https://github.com/ArcGIS/geosaurus/issues/1275


### My fix:
Removed the second _l_ from **credentialls**, making it **credentials**. That is EVERYTHING I touched.

### Follow-on action required:
After this PR is merged into `arcgis-python-api` repo, the corresponding HTML file(s) must be generated and committed to `arcgis-for-developers` repo, at the following path: `src/python/guide/working-with-different-authentication-schemes.html`.

_Perhaps, generation of HTML files and committing them to arcgis-for-developers is performed automatically? Or manually at scheduled intervals?_

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports?
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [ ] Code refactored & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
