### PR TITLE
clarify seamless login experience with IWA

### DIFF
--- a/guide/03-the-gis/working-with-different-authentication-schemes.ipynb
+++ b/guide/03-the-gis/working-with-different-authentication-schemes.ipynb
@@ -314,7 +314,9 @@
    "source": [
     "### Web-tier authentication secured with IWA\n",
     "\n",
-    "If your portal is configured to pick up your Windows credentials using NTLM or Kerberos, you can omit passing in the username and password. The ArcGIS API for Python is able to figure out when the GIS is using Windows authentication and picks the login credentials from the currently running process providing a seamless and secure login experience. \n",
+    "If your Enterprise is configured with the [ArcGIS Portal WebAdaptor for IIS on Microsoft's IIS Web Server and enabled for Windows Authentication with Kerberos or NTLM providers](https://enterprise.arcgis.com/en/web-adaptor/latest/install/iis/use-integrated-windows-authentication-with-your-portal.htm), you can omit passing in the username and password.. The ArcGIS API for Python is able to figure out when the GIS is using Windows authentication and picks the login credentials from the currently running process providing a seamless and secure login experience. \n",
+    "\n",
+    "> **Note:** SAML-compliant identity providers configured to use Kerberos or NTLM will not create this same seamless login experience.\n",
     "\n",
     "<blockquote>\n",
     "Windows authentication only works on the Windows OS and requires pywin32 and kerberos-sspi python packages.</blockquote>"
@@ -626,7 +628,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* add the specific configuration necessary for IWA seamless authentication

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports?
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [ ] Code refactored & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
