### PR TITLE
Product name change updates

### DIFF
--- a/guide/13-managing-arcgis-applications/configuring-location-tracking-and-track-views.ipynb
+++ b/guide/13-managing-arcgis-applications/configuring-location-tracking-and-track-views.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "[Location tracking](https://enterprise.arcgis.com/en/portal/latest/administer/windows/configure-location-tracking.htm) is an organization-wide capability, providing the ability to record where users are and where they have been. Location tracking makes use of a feature service that stores tracked locations as point features in the scalable spatiotemporal big data store. The tracks are secure within the location tracking service: users only see their own tracks, with additional permissions required to view the tracks of others. The tracks can be used for situational awareness and for analysis to answer questions related to where users have been.\n",
     "\n",
-    "[Tracker for ArcGIS](https://www.esri.com/en-us/arcgis/products/tracker-for-arcgis/overview) empowers location tracking, using two apps: the **Track Viewer web app** and the **Tracker for ArcGIS mobile app**. The Track Viewer web app enables administrators to create track views, defining who is tracked and who can view those tracks. The Tracker mobile app is optimized for tracking locations in the field, running in background while minimizing the impact on device battery. The mobile app records tracks whether or not there is a data connection, and gives mobile users control of when they are and aren't tracked.\n",
+    "[ArcGIS Tracker](https://www.esri.com/en-us/arcgis/products/tracker-for-arcgis/overview) empowers location tracking, using two apps: the **Track Viewer web app** and the **ArcGIS Tracker mobile app**. The Track Viewer web app enables administrators to create track views, defining who is tracked and who can view those tracks. The Tracker mobile app is optimized for tracking locations in the field, running in background while minimizing the impact on device battery. The mobile app records tracks whether or not there is a data connection, and gives mobile users control of when they are and aren't tracked.\n",
     "\n",
     "The ArcGIS API for Python makes it easy to manage location tracking capability in an automated, repeatable, and scalable way."
    ]
@@ -469,7 +469,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In order to sign into the Tracker mobile app and upload tracks, users must be provisioned a [Tracker for ArcGIS](https://www.esri.com/en-us/arcgis/products/tracker-for-arcgis/overview) License.\n",
+    "In order to sign into the Tracker mobile app and upload tracks, users must be provisioned an [ArcGIS Tracker](https://www.esri.com/en-us/arcgis/products/tracker-for-arcgis/overview) License.\n",
     "\n",
     "We can see how many licenses are available and how many are assigned"
    ]
@@ -529,7 +529,7 @@
     }
    ],
    "source": [
-    "tracker_license = gis.admin.license.get('Tracker for ArcGIS')\n",
+    "tracker_license = gis.admin.license.get('ArcGIS Tracker')\n",
     "tracker_license.report"
    ]
   },
@@ -537,7 +537,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A Tracker for ArcGIS License can be assigned as follows"
+    "An ArcGIS Tracker License can be assigned as follows"
    ]
   },
   {
@@ -670,7 +670,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/guide/13-managing-arcgis-applications/managing-workforce-projects.ipynb
+++ b/guide/13-managing-arcgis-applications/managing-workforce-projects.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Managing Workforce for ArcGIS projects\n",
+    "# Managing Workforce projects\n",
     "\n",
-    "[Workforce for ArcGIS](http://doc.arcgis.com/en/workforce/) is a mobile solution that uses the power of location-based decision making for better field workforce coordination and teamwork. It is composed of a web app used by project administrators and dispatchers in the office, and a mobile app used by mobile workers on their devices. Organizations using Workforce for ArcGIS get these benefits:\n",
+    "[ArcGIS Workforce](http://doc.arcgis.com/en/workforce/) is a mobile solution that uses the power of location-based decision making for better field workforce coordination and teamwork. It is composed of a web app used by project administrators and dispatchers in the office, and a mobile app used by mobile workers on their devices. Organizations using ArcGIS Workforce get these benefits:\n",
     "\n",
     "- Everything you need on one device. Mobile workers can easily view and process work assignments, provide updates on work status, and inform others of their location, all from one device.\n",
     "\n",
@@ -574,7 +574,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updated product names for ArcGIS Workforce and ArcGIS Tracker 

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [x] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [x] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [x] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [x] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [x] Code refactored & split out across multiple cells, useful comments?
- [x] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [x] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [x] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
