### PR TITLE
Update arcgis.gis.toc.html

### DIFF
--- a/apidoc/arcgis.gis.toc.html
+++ b/apidoc/arcgis.gis.toc.html
@@ -1402,13 +1402,10 @@ user.reassign_to() method.  This method only moves one item at a time.</p>
 <tr class="row-odd"><td><p><strong>Argument</strong></p></td>
 <td><p><strong>Description</strong></p></td>
 </tr>
-<tr class="row-even"><td><p>item_id</p></td>
-<td><p>Required string. The unique identifier for the item.</p></td>
-</tr>
-<tr class="row-odd"><td><p>target_owner</p></td>
+<tr class="row-even"><td><p>target_owner</p></td>
 <td><p>Required string. The new desired owner of the item.</p></td>
 </tr>
-<tr class="row-even"><td><p>target_folder</p></td>
+<tr class="row-odd"><td><p>target_folder</p></td>
 <td><p>Optional string. The folder to move the item to.</p></td>
 </tr>
 </tbody>


### PR DESCRIPTION
Updated the documentation. the item.reassign_to function Argument Table contains itemid as argument, but this argument is not in the api . I updated the doc to reflect actual API
Checklist below seems to apply to actual python code only, marked everything with an X since this is just a minor html doc change

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [X ] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [X ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [X ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [X ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [X ] Code refactored & split out across multiple cells, useful comments?
- [X ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [X ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ X] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ X] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
