### PR TITLE
Animal species identification NB

### DIFF
--- a/samples/04_gis_analysts_data_scientists/wildlife_species_identification_in_camera_trap_images.ipynb
+++ b/samples/04_gis_analysts_data_scientists/wildlife_species_identification_in_camera_trap_images.ipynb
@@ -44,13 +44,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Automatic animal identification could improve all biology missions that require identifying species and counting individuals, including animal monitoring and management, examining biodiversity, and population estimation.\n",
+    "Automatic animal identification can improve biology missions that require identifying species and counting individuals, such as animal monitoring and management, examining biodiversity, and population estimation.\n",
     "\n",
-    "This notebook intends to showcase the workflow to classify animal species on camera trap images. This notebook has two main sections:\n",
+    "This notebook will showcase a workflow to classify animal species in camera trap images. The notebook has two main sections:\n",
     "1. Training a deep learning model that can classify animal species  \n",
     "2. Using the trained model to classify animal species against each camera location\n",
     "\n",
-    "We have used a subset of a community licensed open source dataset for camera trap images provided under [LILA BC](http://lila.science/) (Labeled Information Library of Alexandria: Biology and Conservation) repository to train our deep learning model details of which are shared in [this](#Get-the-data-for-analysis) section. For inferencing, we have taken 5 fictional camera locations in Kruger National Park, South Africa and to each of those points we have some images attached as attachments. This feature layer simulates a requirement where there are multiple cameras at different locations and images captured by each of those cameras need to be classified for animal species. The whole workflow enabling this required in explained in [this](#Model-inference) section. "
+    "We have used a subset of a community licensed open source dataset for camera trap images, provided under the [LILA BC](http://lila.science/) (Labeled Information Library of Alexandria: Biology and Conservation) repository, to train our deep learning model, which is further detailed in [this](#Get-the-data-for-analysis) section. For inferencing, we have taken 5 fictional camera locations in Kruger National Park, South Africa, and to each of those points, we have attached some images. This feature layer simulates a scenario where there are multiple cameras at different locations that have captured images that need to be classified for animal species. The whole workflow enabling this is explained in [this](#Model-inference) section."
    ]
   },
   {
@@ -179,7 +179,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, we have provided a subset of training data containing a few samples from the above mentioned 11 species."
+    "Alternatively, we have provided a subset of training data containing a few samples from the 11 species mentioned above."
    ]
   },
   {

--- a/samples/04_gis_analysts_data_scientists/wildlife_species_identification_in_camera_trap_images.ipynb
+++ b/samples/04_gis_analysts_data_scientists/wildlife_species_identification_in_camera_trap_images.ipynb
@@ -260,15 +260,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "output_path = r\"C:\\Users\\gun10635\\AppData\\Local\\Temp\\wildlife_species_identification_in_camera_trap_images\""
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
    "outputs": [],
@@ -1594,7 +1585,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.12"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Contains animal species identification notebook

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [X] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [X] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [X] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [X] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [X] Code refactored & split out across multiple cells, useful comments?
- [X] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [X] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [X] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [X] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
