### PR TITLE
v2 workforce

### DIFF
--- a/guide/13-managing-arcgis-applications/managing-workforce-projects.ipynb
+++ b/guide/13-managing-arcgis-applications/managing-workforce-projects.ipynb
@@ -12,7 +12,9 @@
     "\n",
     "- Greater agility—Using real-time and location-based information, dispatchers can assign and prioritize fieldwork on the fly and ensure that work is assigned to the right people at the right time.\n",
     "\n",
-    "- Increased productivity—Replace time-consuming and error-prone manual workforce management processes, reduce downtime, and keep projects on schedule."
+    "- Increased productivity—Replace time-consuming and error-prone manual workforce management processes, reduce downtime, and keep projects on schedule.\n",
+    "\n",
+    "Please note that working with an offline-enabled Workforce project ensures you have a version of the Python API > 1.8.3. "
    ]
   },
   {
@@ -105,7 +107,7 @@
    "metadata": {},
    "source": [
     "### Workforce Project\n",
-    "A project is created using its corresponding item or created via the `create_project` function. This can either be a version 1 \"Classic\" workforce project or a version 2 (recommended) \"Offline\" workforce project."
+    "A project is created using its corresponding item or created via the `create_project` function. This can either be a version 1 \"Classic\" workforce project or a version 2 (recommended) \"Offline\" workforce project. While the functions are the same no matter if you're using a Classic or Offline Workforce project, you want to ensure the item you pass into the `arcgis.apps.workforce.Project` class is correct - a Workforce Project item for classic and a hosted feature service for offline."
    ]
   },
   {
@@ -154,9 +156,14 @@
     }
    ],
    "source": [
-    "## This instantiates a project that previously existed\n",
+    "## This instantiates a project that previously existed for a classic project\n",
     "workforce_project_item = gis.content.get(\"c63e3d46af7d4204b66b18d43a188c2e\")\n",
-    "workforce_project_item"
+    "workforce_project_item\n",
+    "\n",
+    "# This instantiates a project that previously existed for an offline-enabled project. \n",
+    "fs_item_id = \"04b66b18d43a1804b66b1a188c2e\"\n",
+    "fs_item = gis.content.get(fs_item_id)\n",
+    "offline_project = arcgis.apps.workforce.Project(fs_item)"
    ]
   },
   {
@@ -618,7 +625,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,

--- a/guide/13-managing-arcgis-applications/managing-workforce-projects.ipynb
+++ b/guide/13-managing-arcgis-applications/managing-workforce-projects.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "## Contents of a Workforce project\n",
     "\n",
-    "An offline-enabled workforce project is composed of two webmaps and a feature service. The feature service contains two layers and three tables:\n",
+    "An offline-enabled (Version 2) workforce project is composed of two webmaps and a feature service. The feature service contains two layers and three tables:\n",
     "\n",
     "**Layers**\n",
     " - **Assignments** - contains a record for each assignment. It stores information such as status, location, and description, among others.\n",
@@ -38,7 +38,7 @@
     " - **Dispatcher web map** - for back-office dispatchers. It shows the assignments and worker locations\n",
     " - **Worker web map** - This map is what a field worker uses on their iOS or Android device.\n",
     " \n",
-    "The webmaps and feature service are connected via a \"WorkforceMap2FeatureService\" relationship. To learn more about those details, refer [here](https://doc.arcgis.com/en/workforce/android-phone/help/workforce-schema.htm)."
+    "The webmaps and feature service are connected via a \"WorkforceMap2FeatureService\" relationship. To learn more about those details, refer [here](https://doc.arcgis.com/en/workforce/android-phone/help/workforce-schema.htm). Previously, Workforce used a \"classic\" project consisting of four feature layers and two web maps; these can still be managed and created using the Python API."
    ]
   },
   {
@@ -47,6 +47,11 @@
    "source": [
     "## What can you do with this module?\n",
     "Using the `workforce` module under the `arcgis.apps` module, you can automate the following tasks:\n",
+    "\n",
+    "### Projects\n",
+    "- Creating Projects\n",
+    "- Managing Projects created either through Python or the web app\n",
+    "- Deleting Projects\n",
     "\n",
     "### Workers and Dispatchers\n",
     "- Adding Dispatchers and Workers to a Project\n",
@@ -100,7 +105,7 @@
    "metadata": {},
    "source": [
     "### Workforce Project\n",
-    "A project is created using its corresponding item or created via the `create_project` function. This can either be a version 1 \"Classic\" workforce project or a new \"Offline\" workforce project."
+    "A project is created using its corresponding item or created via the `create_project` function. This can either be a version 1 \"Classic\" workforce project or a version 2 (recommended) \"Offline\" workforce project."
    ]
   },
   {

--- a/guide/13-managing-arcgis-applications/managing-workforce-projects.ipynb
+++ b/guide/13-managing-arcgis-applications/managing-workforce-projects.ipynb
@@ -23,19 +23,22 @@
    "source": [
     "## Contents of a Workforce project\n",
     "\n",
-    "A workforce project is composed of four point feature layers:\n",
-    " - **Workers** - contains a record for each mobile worker along with their contact number and job title.\n",
+    "An offline-enabled workforce project is composed of two webmaps and a feature service. The feature service contains two layers and three tables:\n",
+    "\n",
+    "**Layers**\n",
     " - **Assignments** - contains a record for each assignment. It stores information such as status, location, and description, among others.\n",
-    " - **Dispatchers** - contains a record for each dispatcher within the project and includes information such as name and contact number.\n",
-    " - **Location Tracking** - contains a record for each point location logged while location tracking is enabled.\n",
+    " - **Workers** - contains a record for each mobile worker along with their contact number and job title.\n",
     " \n",
-    "and two web maps:\n",
+    "**Tables** \n",
+    " - **Dispatchers** - contains a record for each dispatcher within the project and includes information such as name and contact number.\n",
+    " - **Assignment Types** - contains a record for each type of assignment that can be added to the project.\n",
+    " - **Assignment Integrations** - contains a record for each URL an assignment can link to in order to perform external actions such as navigation and survey collection\n",
+    " \n",
+    "**Web Maps**\n",
     " - **Dispatcher web map** - for back-office dispatchers. It shows the assignments and worker locations\n",
     " - **Worker web map** - This map is what a field worker uses on their iOS or Android device.\n",
     " \n",
-    "and a **workforce** project item. This is an item on the portal that stores project meta data in json format. This item connects all the layers and maps described above.\n",
-    "\n",
-    "The feature layers described above are named using a combination of a moniker, describing the purpose of the feature layer, appended with the GUID of the Workforce project item. For example, the Workers layer associated with a project with GUID `5dd018fcd88c4d33814cf3da9c44061e` would be named `workers_5dd018fcd88c4d33814cf3da9c44061e`. This guarantees uniqueness of each feature layer. The four feature layers are connected to one-another using primary key-foreign key relationships to track the workforce. To know more about those details, refer [here](https://doc.arcgis.com/en/workforce/android-phone/help/workforce-schema.htm)."
+    "The webmaps and feature service are connected via a \"WorkforceMap2FeatureService\" relationship. To learn more about those details, refer [here](https://doc.arcgis.com/en/workforce/android-phone/help/workforce-schema.htm)."
    ]
   },
   {
@@ -59,8 +62,8 @@
     "- Searching Assignments in a Project\n",
     "- Adding/Removing/Downloading Attachments\n",
     "\n",
-    "### Tracks\n",
-    "- Searching Tracks (for analysis)"
+    "### Integrations\n",
+    "- Adding, Updating, and Deleting Integrations"
    ]
   },
   {
@@ -69,7 +72,7 @@
    "source": [
     "## Get Started\n",
     "\n",
-    "A user must be authenticated with a GIS in order to fetch a Project. The workforce functionality is available in `arcgis.apps.workforce` module."
+    "A user must be authenticated with a GIS in order to fetch or create a Project. The workforce functionality is available in `arcgis.apps.workforce` module."
    ]
   },
   {
@@ -97,12 +100,23 @@
    "metadata": {},
    "source": [
     "### Workforce Project\n",
-    "A project is created using its corresponding item."
+    "A project is created using its corresponding item or created via the `create_project` function. This can either be a version 1 \"Classic\" workforce project or a new \"Offline\" workforce project."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## These create instances of arcgis.apps.workforce.Project\n",
+    "old_workforce_project = arcgis.apps.workforce.create_project('old project', major_version=1)\n",
+    "new_workforce_project = arcgis.apps.workforce.create_project('new project', major_version=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -129,19 +143,20 @@
        "<Item title:\"demo-workforce-project\" type:Workforce Project owner:arcgis_python>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "## This instantiates a project that previously existed\n",
     "workforce_project_item = gis.content.get(\"c63e3d46af7d4204b66b18d43a188c2e\")\n",
     "workforce_project_item"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -150,7 +165,7 @@
        "<Project c63e3d46af7d4204b66b18d43a188c2e>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -170,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -179,7 +194,7 @@
        "[<Assignment 1>, <Assignment 2>]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -192,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -214,7 +229,7 @@
        "['/Users/aaro8157/PycharmProjects/arcgis-python-api/samples/02_power_users_developers/esri_logo1.png']"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -241,13 +256,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Assignment Types\n",
+    "### Assignment Types\n",
     "Assignment types are created when the workforce project is originally created. All assignments fall under one or the other assignment types. You can access these types by calling the `assignment_types` property off the `Project` item. Assignment types can be added, updated, or deleted."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -289,7 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -325,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -334,7 +349,7 @@
        "<Worker 34>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -356,7 +371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -387,13 +402,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Integrations\n",
+    "`Integration` objects are accessed by using `integrations` property off the `Project` object. Integrations can be added, updated, or deleted. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Search for all integrations\n",
+    "integrations = project.integrations.search()\n",
+    "integration = integrations[0]\n",
+    "integration.update(integration_id=\"arcgis-explorer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Web maps\n",
     "The dispatcher and worker `WebMap` objects can be accessed using the corresponding properties as shown in the following code snippet. Using the `WebMap` object, additional layers could be added or removed from either maps."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -402,7 +437,7 @@
        "arcgis.mapping._types.WebMap"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -415,7 +450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -441,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -472,12 +507,12 @@
    "metadata": {},
    "source": [
     "## Putting it all together\n",
-    "In the following snippet, a new assignment will be created at the ESRI campus. Assignments (as well as workers, assignment types, dispatchers, and tracks) are all validated prior to upload. The ensures the integrity of the workforce project."
+    "In the following snippet, a new assignment will be created at the ESRI campus. Assignments (as well as workers, assignment types, dispatchers, and integrations) are all validated prior to upload. The ensures the integrity of the workforce project."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -486,7 +521,7 @@
        "<Assignment 66>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -522,7 +557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -531,14 +566,13 @@
        "[<Dispatcher 1>]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Use batch functions to process multiple items at a time\n",
-    "project.assignments.batch_delete(project.assignments.search(where='assignmentType=3'))\n",
     "project.assignment_types.batch_delete([project.assignment_types.get(name=\"Repair\")])\n",
     "project.workers.batch_delete([project.workers.get(user_id=\"demouser_nitro\")])\n",
     "\n",
@@ -554,7 +588,12 @@
     "# Reset the dispatcher using batch update\n",
     "d1 = project.dispatchers.get(object_id=1)\n",
     "d1.contact_number = \"987-654-3210\"\n",
-    "project.dispatchers.batch_update([d1])"
+    "project.dispatchers.batch_update([d1])\n",
+    "\n",
+    "# Reset integration using batch update\n",
+    "i1 = project.integrations.get(integration_id=\"arcgis-explorer\")[0]\n",
+    "i1.integration_id = \"default-navigator\"\n",
+    "project.integrations.batch_update([i1])"
    ]
   }
  ],
@@ -574,7 +613,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/guide/13-managing-arcgis-applications/managing-workforce-projects.ipynb
+++ b/guide/13-managing-arcgis-applications/managing-workforce-projects.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "- Increased productivity—Replace time-consuming and error-prone manual workforce management processes, reduce downtime, and keep projects on schedule.\n",
     "\n",
-    "Please note that working with an offline-enabled Workforce project ensures you have a version of the Python API > 1.8.3. "
+    "Please note that working with an offline-enabled Workforce project ensures you have a version of the Python API > 1.8.2. "
    ]
   },
   {
@@ -625,7 +625,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updates Workforce notebook to reflect schema and module changes for 1.8.3 

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [x] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [x] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [x] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [x] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [x] Code refactored & split out across multiple cells, useful comments?
- [x] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [x] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [x] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
