### PR TITLE
Fix Geoenrichment part 1 for Sept Release

### DIFF
--- a/guide/16-geoenrichment-guides/part1_introduction_to_geoenrichment.ipynb
+++ b/guide/16-geoenrichment-guides/part1_introduction_to_geoenrichment.ipynb
@@ -676,11 +676,11 @@
    "metadata": {},
    "source": [
     "GeoEnrichment makes any location data intelligent by providing facts about the location. In this part of the Geoenrichment guide series, you have seen a high-level example of how `arcgis.geoenrichment` module can be used to `enrich` a dataset with various socio-demographic features, and also an introduction of the different ways in which data can be enriched. In the subsequent pages, you will learn about:\n",
-    "1. [Enriching Study Areas](part2_enrich_study_areas.ipynb) (explains where to enrich)\n",
-    "2. [Exploring Named Statistical Areas](part3_explore_named_areas.ipynb) (explains where to enrich continued)\n",
-    "3. [Enriching Data Collections and Spatially Enabled Dataframe](part4_enrich_collections_and_sedf.ipynb) (explains what datasets/variables to enrich with)\n",
-    "4. [Generating Reports](part5_generate_reports.ipynb)\n",
-    "5. [Standard Geography Queries](part6_std_geo_query.ipynb)"
+    "1. Enriching Study Areas (explains where to enrich)\n",
+    "2. Exploring Named Statistical Areas (explains where to enrich continued)\n",
+    "3. Enriching Data Collections and Spatially Enabled Dataframe (explains what datasets/variables to enrich with)\n",
+    "4. Generating Reports\n",
+    "5. Standard Geography Queries"
    ]
   }
  ],


### PR DESCRIPTION
Updated to remove links to other notebooks from conclusion section. Links to other guides in conclusion section of Geoenrichment Part 1 are generating errors during the dev site build. These links are not necessary and hence removing them.
