### PR TITLE
fix TOC and guide links in crime sample

### DIFF
--- a/samples/04_gis_analysts_data_scientists/information-extraction-from-madison-city-crime-incident-reports-using-deep-learning.ipynb
+++ b/samples/04_gis_analysts_data_scientists/information-extraction-from-madison-city-crime-incident-reports-using-deep-learning.ipynb
@@ -64,9 +64,9 @@
     "\n",
     "- Data preparation and model training workflows using arcgis.learn have a dependency on spaCy. Refer to the section \"Install deep learning dependencies of arcgis.learn module\" [on this page](https://developers.arcgis.com/python/guide/install-and-set-up/#Install-deep-learning-dependencies-for-arcgis.learn-module) for detailed documentation on installation of the dependencies.\n",
     "- Labelled data: In order for Entity Recognizer to learn, it needs to see examples that have been labelled for all the custom categories that the model is expected to extract. Labelled data for this sample notebook is located at data/EntityRecognizer/labelled_crime_reports.json\n",
-    "- To learn how to use Doccano[[2]](#References) for labelling text, please see the guide on [Labeling text using Doccano](https://developers.arcgis.com/python/sample-notebooks/labeling-text-using-doccano)\n",
+    "- To learn how to use Doccano[[2]](#References) for labelling text, please see the guide on [Labeling text using Doccano](https://developers.arcgis.com/python/guide/labeling-text-using-doccano)\n",
     "- Test documents to extract named entities are in a zipped file at data/EntityRecognizer/reports.zip\n",
-    "- To learn more on how `EntityRecognizer` works, please see the guide on [Named Entity Extraction Workflow with arcgis.learn](https://developers.arcgis.com/python/sample-notebooks/how-named-entity-recognition-works/)."
+    "- To learn more on how `EntityRecognizer` works, please see the guide on [Named Entity Extraction Workflow with arcgis.learn](https://developers.arcgis.com/python/guide/how-named-entity-recognition-works/)."
    ]
   },
   {

--- a/samples/04_gis_analysts_data_scientists/information-extraction-from-madison-city-crime-incident-reports-using-deep-learning.ipynb
+++ b/samples/04_gis_analysts_data_scientists/information-extraction-from-madison-city-crime-incident-reports-using-deep-learning.ipynb
@@ -23,8 +23,8 @@
     "<li><span><a href=\"#Validate-results\" data-toc-modified-id=\"Validate-results-5.1\">Validate results</a></span></li>\n",
     "<li><span><a href=\"#Save-and-load-trained-models\" data-toc-modified-id=\"Save-and-load-trained-models-5.2\">Save and load trained models</a></span></li>\n",
     "</ul>\n",
-    "<li><span><a href=\"#Model-inference\" data-toc-modified-id=\"Model-inference-6\">Model inference</a></span></li>\n",
-    "<li><span><a href=\"#Publishing-the-results-as-feature-layer\" data-toc-modified-id=\"Publishing-the-results-as-feature-layer-7\">Publishing the results as feature layer</a></span></li>\n",
+    "<li><span><a href=\"#Model-Inference\" data-toc-modified-id=\"Model-Inference-6\">Model Inference</a></span></li>\n",
+    "<li><span><a href=\"#Publishing-the-results-as-a-feature-layer\" data-toc-modified-id=\"Publishing-the-results-as-a-feature-layer\">Publishing the results as a feature layer</a></span></li>\n",
     "<li><span><a href=\"#Visualize-crime-incident-on-map\" data-toc-modified-id=\"Visualize-crime-incident-on-map- 8\">Visualize crime incident on map</a></span></li>\n",
     "<li><span><a href=\"#Create-a-hot-spot-map-of-crime-densities\" data-toc-modified-id=\"Create-a-hot-spot-map-of-crime-densities-9\">Create a hot spot map of crime densities</a></span></li>\n",
     "<li><span><a href=\"#Conclusion\" data-toc-modified-id=\"Conclusion-10\">Conclusion</a></span></li>\n",
@@ -1908,7 +1908,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.12"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* fixed toc links based on customer feedback
* fixed links to guide pages

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [ ] Code refactored & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
