### PR TITLE
fix gibberish characters (Chennai Floods 2015â“A Geographic Analysis)

### DIFF
--- a/items_metadata.yaml
+++ b/items_metadata.yaml
@@ -111,7 +111,7 @@ samples:
   description: The Thomas Fire was a massive wildfire that started in early December 2017 in Ventura and Santa Barbara counties and grew into California's largest fire ever.
   licenseInfo: ""
   tags: ["Data Science", "GIS", "Thomas Fire", "California"]
-- title: Chennai Floods 2015–A Geographic Analysis
+- title: Chennai Floods 2015 - A Geographic Analysis
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=44c4fc1e56654768840a03971feb1e77
   path: ./samples/04_gis_analysts_data_scientists/chennai_floods_analysis.ipynb
   thumbnail: ./static/thumbnails/chennai_floods_analysis.jpg


### PR DESCRIPTION
fix gibberish characters (Chennai Floods 2015â“A Geographic Analysis)

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [x] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [x] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [x] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [x] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [x] Code refactored & split out across multiple cells, useful comments?
- [x] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [x] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [x] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
