### PR TITLE
updated road cracks sample

### DIFF
--- a/samples/04_gis_analysts_data_scientists/vehicle_detection_and_tracking.ipynb
+++ b/samples/04_gis_analysts_data_scientists/vehicle_detection_and_tracking.ipynb
@@ -360,7 +360,7 @@
     }
    ],
    "source": [
-    "retinanet.lr_find()"
+    "lr = retinanet.lr_find()"
    ]
   },
   {
@@ -1009,7 +1009,7 @@
     }
    ],
    "source": [
-    "retinanet.fit(100, lr=4.365158322401661e-05, tensorboard=True) "
+    "retinanet.fit(100, lr=lr, tensorboard=True) "
    ]
   },
   {


### PR DESCRIPTION
Road cracks notebook had data missing for model inference functions (predict and predict video). 

Lr find value was earlier hardcoded, now it can be filled in automatically while running nb

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [x] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [ ] Code refactored & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
