### PR TITLE
add runtime for dl notebooks

### DIFF
--- a/items_metadata.yaml
+++ b/items_metadata.yaml
@@ -54,6 +54,7 @@ samples:
   snippet: Use deep learning to automate building footprints
   description: This sample shows how ArcGIS API for Python can be used to train a deep learning model to extract building footprints using satellite images. The trained model can be deployed on ArcGIS Pro or ArcGIS Enterprise to extract building footprints.
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "Building", "Footprint", "Instance", "Segmentation", "Deep Learning"]
 - title: Automate Road Surface Investigation Using Deep Learning
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=72b6c19f5944424f830b44346f0fef89
@@ -62,6 +63,7 @@ samples:
   snippet: Use deep learning to detect adn classify road cracks
   description: In this notebook, we use a great labeled dataset of asphalt distress images in order to train our model to detect as well as to classify type of road cracks.
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "Road", "Cracks", "Deep Learning"]
 - title: Reconstructing 3D buildings from Aerial LiDAR with Deep Learning
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=3b3f9bacf88c4661911cb8c0e1a95757
@@ -70,6 +72,7 @@ samples:
   snippet: Reconstruct 3D building models from aerial LiDAR
   description: In this notebook, we demonstrate how to detect instances of roof segments of various types using instance segmentation to make the process more efficient
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "Building", "Reconstruction", "MaskRCNN", "Deep Learning"]
 - title: Calculate Impervious Surfaces from Spectral Imagery
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=bfbc2594a96f48539b1a1b30996fa76a
@@ -198,6 +201,7 @@ samples:
   snippet: Categorize Brick Kilns using the Python API
   description: In this sample, we will use Deep Learning on ArcGIS Platform to detect the location and design category of all brick kilns around Delhi NCR area in India to find the brick kilns which are not following the directions from CPCB.
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "Brick Kilns", "Categorization", "Deep Learning"]
 - title: Detecting settlements using supervised classification and deep learning
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=4a4828703f1a494e89ec973086cad715
@@ -206,6 +210,7 @@ samples:
   snippet: Use deep learning to detect settlements
   description: In this notebook we have attempted to use the supervised classification approach to generate the required volumes of data which after cleaning was used to come through the requirement of larger training data for Deep Learning model.
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "Settlement", "Deep Learning", "Supervised Classification"]
 - title: Detecting Swimming Pools using Satellite Imagery and Deep Learning 
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=122fb4b5a2094f3398b1d96381022f64
@@ -214,6 +219,7 @@ samples:
   snippet: Detect swimming pools using remote sensing imagery
   description: This notebook demonstrates an end-to-end deep learning workflow in using ArcGIS API for Python. The workflow consists of three major steps. (1) extracting training data, (2) train a deep learning object detection model, (3) deploy the model for inference and create maps.
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "Swimming", "Deep Learning", "Pools"]
 - title: Detecting Super Blooms Using Satellite Image Classification
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=50d6c2001e864d44ab5278e7b439bf41
@@ -238,6 +244,7 @@ samples:
   snippet: Extract Building footprints from drone data
   description: This sample shows how ArcGIS API for Python can be used to train a deep learning model to extract building footprints from drone data.
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "Building", "Foorprint", "Deep Learning"]
 - title: Extracting Slums from Satellite Imagery
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=5b5461f3df814fc1b65539365668904d
@@ -246,6 +253,7 @@ samples:
   snippet:  Extract slum boundaries from satellite imagery
   description: This sample shows how we can extract the slum boundaries from satellite imagery using the learn module in ArcGIS API for Python. 
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "Deep Learning", "Slums", "Extracting"]
 - title: Feature Categorization using Satellite Imagery and Deep Learning
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=c5de157941034407bc719c5bde8e1ea7
@@ -262,6 +270,7 @@ samples:
   snippet: This sample demonstrates the application of spatial analysis tools such as buffer and overlay.
   description: This notebook describes a scenario wherein an analyst automates the process of identifying facilities at risk from forest fires and sharing this information with other departments such as the fire department, etc.
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "California", "Forest Fires"]
 - title: Finding a New Home
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=a4518082dbe14885b45680ee54c74aed
@@ -334,6 +343,7 @@ samples:
   snippet: Increase image resolution using the ArcGIS API for Python
   description: This sample notebook demonstrates how the SuperResolution model in arcgis.learn module can be used to increase image resolution. 
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "Super Resolution", "Deep learning"]
 - title: Information extraction from Madison city crime incident reports using Deep Learning
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=c1e38321865b40d4b01ec5de17b27442
@@ -342,6 +352,7 @@ samples:
   snippet: Extract info from crime reports
   description: In this notebook we will extract information from crime incident reports obtained from Madison police department [1]using arcgis.learn.EntityRecognizer(). 
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "Information", "Extraction", "deep Learning", "Madison", "Crime", "Featured"]
 - title: Land cover classification using sparse training data
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=b82a104720a349fe96d47f0f12ed86a8
@@ -350,6 +361,7 @@ samples:
   snippet: Perform land cover classification
   description: This notebook showcases an approach to performing land cover classification using sparse training data and multispectral imagery.
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "Sparse", "Land cover", "Classification", "Deep Learning"]
 - title: Land Cover Classification using Satellite Imagery and Deep Learning
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=8a3f6601f67049f1a311e88c7ba02125
@@ -358,6 +370,7 @@ samples:
   snippet: Use the ArcGIS API for Python for land cover classification
   description: This notebook showcases an end-to-end to land cover classification workflow using ArcGIS API for Python. 
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "Land Cover", "Classification", "Deep Learning"]
 - title: Locating a new retirement community
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=95236a13179b40c39c9fc01ab96719e3
@@ -430,6 +443,7 @@ samples:
   snippet: Use bathymetric data to detect shipwrecks
   description: In this notebook, we will use bathymetry data provided by NOAA to detect shipwrecks from the Shell Bank Basin area located near New York City in United States.
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "Shipwrecks", "Bathymetric", "Deep Learning"]
 - title: Snow Avalanche Hazard Mapping for Lake Tahoe
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=bd6e2767cb294b88b09c5cb38441131e
@@ -462,6 +476,7 @@ samples:
   snippet: Identify plant species using a tensorflow model
   description: This notebook intends to showcase this capability to train a deep learning model that can be used in mobile applications for a real time inferencing using TensorFlow Lite framework.
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "TansorFlow Lite", "Plant Species", "Deep Learning"]
 - title: Vehicle detection and tracking using deep learning
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=871057ea4c864343900f36f3bf64b675
@@ -470,6 +485,7 @@ samples:
   snippet: Use deep learning to track vehicles
   description: In this notebook, we'll demonstrate how we can use deep learning to detect vehicles and then track them in a video. 
   licenseInfo: ""
+  runtime: advanced_gpu
   tags: ["Data Science", "GIS", "Vehicle", "Detection", "Deep Learning", "Tracking", "Featured"]
 - title: Visualize monthly changes in Hirakund reservoir using video  
   url: https://geosaurus.maps.arcgis.com/home/item.html?id=8fdbf15d65674f69a947cbe449eb3647


### PR DESCRIPTION
https://github.com/ArcGIS/geosaurus/issues/5428

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [ ] Code refactored & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
