### PR TITLE
Added guide for retraining windows/doors model

### DIFF
--- a/guide/14-deep-learning/retraining_windows_doors_extraction_model.ipynb
+++ b/guide/14-deep-learning/retraining_windows_doors_extraction_model.ipynb
@@ -47,7 +47,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -71,7 +70,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The default <b>Esri Windows and Doors</b> model is accessible from within the ArcGIS Pro Interactive Object Detection tool. However, for retraining you can download the latest version from https://arcgis.com/home/item.html?id=8c0078cc7e314e31b20001d94daace5e\n",
+    "The default <b>Esri Windows and Doors</b> model is accessible from within the ArcGIS Pro Interactive Object Detection tool. However, for retraining you can download the latest version from https://arcg.is/0ya99C\n",
     "\n",
     "<b>Once downloaded:</b>\n",
     "* Copy Esri_Windows_and_Doors.dlpk to your working folder.\n",
@@ -361,7 +360,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook we saw how you can retrain the default Esri Windows and Doors Extraction model with images that better represent windows and doors in your region or dataset. Once the retrained model has been saved, you can browse to it using the ArcGIS Pro Interactive Object Detection tool and use it for inferencing in 3D scenes."
+    "In this guide we saw how you can retrain the default Esri Windows and Doors Extraction model with images that better represent windows and doors in your region or dataset. Once the retrained model has been saved, you can browse to it using the ArcGIS Pro Interactive Object Detection tool and use it for inferencing in 3D scenes."
    ]
   }
  ],


### PR DESCRIPTION
This is a new guide for retraining the default Esri Windows and Doors model that is used by the Interactive Object Detection tool in ArcGIS Pro 2.7. The notebook is being shared as a guide instead of a sample because of the additional step requiring unzipping the DLPK.

@rohitgeo can you please review.

Thanks.