### PR TITLE
Try-it Live updated sample notebooks

### DIFF
--- a/samples/04_gis_analysts_data_scientists/building_reconstruction_using_mask_rcnn.ipynb
+++ b/samples/04_gis_analysts_data_scientists/building_reconstruction_using_mask_rcnn.ipynb
@@ -419,7 +419,8 @@
    ],
    "source": [
     "# The users can visualize the learning rate of the model with comparative loss. \n",
-    "model.lr_find()"
+    "lr = model.lr_find()\n",
+    "lr"
    ]
   },
   {
@@ -526,7 +527,7 @@
     }
    ],
    "source": [
-    "model.fit(epochs=10, lr=4.365158322401661e-05)"
+    "model.fit(epochs=10, lr=lr)"
    ]
   },
   {
@@ -840,7 +841,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.7.9"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Updated sample notebooks for try-it live:

1. building_reconstruction_using_mask_rcnn
2. automate_building_footprint_extraction_using_instance_segmentation

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [x] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [x] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [x] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [x] Code refactored & split out across multiple cells, useful comments?
- [x] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [x] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [x] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [x] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
