### PR TITLE
pix2pix_guide_minor_update

### DIFF
--- a/guide/14-deep-learning/how_pix2pix_works.ipynb
+++ b/guide/14-deep-learning/how_pix2pix_works.ipynb
@@ -174,7 +174,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pix2Pix model architecture shown in figure 4 is translating from simple styled map to target styled map domain. [[4](https://arxiv.org/pdf/1905.02200.pdf)]"
+    "Pix2Pix model architecture shown in figure 4 is translating from simple styled to target styled map domain. [[4](https://arxiv.org/pdf/1905.02200.pdf)]"
    ]
   },
   {
@@ -202,7 +202,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Initially, we have to export the image chips in `Export tiles` format using `Export Training data for deep learning` tool avialable in ArcGIS Pro by providing two domains of imagery in `Input Raster` and `Additional Input Raster`, then the path is provided to `prepare_data` function in `arcgis.learn` to create a databunch, than we have to create a databunch with `prepare_data` function in `arcgis.learn`\n",
+    "Initially, we have to export the image chips in `Export tiles` format using `Export Training data for deep learning` tool avialable in ArcGIS Pro by providing two domains of imagery in `Input Raster` and `Additional Input Raster`, then the path is provided to `prepare_data` function in `arcgis.learn` to create a databunch.\n",
     "\n",
     "`data = arcgis.learn.prepare_data(path=r\"path/to/exported/data\")`"
    ]


### PR DESCRIPTION
# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [ ] Code refactored & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
