### PR TITLE
parcels notebook fixed bad links

### DIFF
--- a/samples/04_gis_analysts_data_scientists/land_parcel_extraction_using_edge_detection_deep_learning_model.ipynb
+++ b/samples/04_gis_analysts_data_scientists/land_parcel_extraction_using_edge_detection_deep_learning_model.ipynb
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +89,7 @@
    "outputs": [],
    "source": [
     "gis = GIS(\"home\")\n",
-    "ent_gis = ent_gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')"
+    "ent_gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')"
    ]
   },
   {
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -127,17 +127,17 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://pythonapi.playground.esri.com/portal/home/home/item.html?id=8202ffe4fcaf4ba9bfefe2154f98e7b8' target='_blank'>\n",
-       "                        <img src='https://pythonapi.playground.esri.com/portal/home/portalimages/desktopapp.png' class=\"itemThumbnail\">\n",
+       "                       <a href='https://pythonapi.playground.esri.com/portal/home/item.html?id=8202ffe4fcaf4ba9bfefe2154f98e7b8' target='_blank'>\n",
+       "                        <img src='https://pythonapi.playground.esri.com/portal/portalimages/desktopapp.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://pythonapi.playground.esri.com/portal/home/home/item.html?id=8202ffe4fcaf4ba9bfefe2154f98e7b8' target='_blank'><b>train_area_edgedetection_tif</b>\n",
+       "                        <a href='https://pythonapi.playground.esri.com/portal/home/item.html?id=8202ffe4fcaf4ba9bfefe2154f98e7b8' target='_blank'><b>train_area_edgedetection_tif</b>\n",
        "                        </a>\n",
-       "                        <br/>Training area raster for exporting training data<img src='https://pythonapi.playground.esri.com/portal/home/home/js/jsapi/esri/css/images/item_type_icons/imagery16.png' style=\"vertical-align:middle;\">Imagery Layer by api_data_owner\n",
+       "                        <br/>Training area raster for exporting training data<img src='https://pythonapi.playground.esri.com/portal/home/js/jsapi/esri/css/images/item_type_icons/imagery16.png' style=\"vertical-align:middle;\">Imagery Layer by api_data_owner\n",
        "                        <br/>Last Modified: January 15, 2021\n",
-       "                        <br/>0 comments, 0 views\n",
+       "                        <br/>0 comments, 1 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
@@ -146,7 +146,7 @@
        "<Item title:\"train_area_edgedetection_tif\" type:Imagery Layer owner:api_data_owner>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -936,7 +936,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -944,15 +944,15 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://pythonapi.playground.esri.com/portal/home/home/item.html?id=481f2ba520274f0fabfe470d2c8def39' target='_blank'>\n",
-       "                        <img src='https://pythonapi.playground.esri.com/portal/home/portalimages/desktopapp.png' class=\"itemThumbnail\">\n",
+       "                       <a href='https://pythonapi.playground.esri.com/portal/home/item.html?id=481f2ba520274f0fabfe470d2c8def39' target='_blank'>\n",
+       "                        <img src='https://pythonapi.playground.esri.com/portal/portalimages/desktopapp.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://pythonapi.playground.esri.com/portal/home/home/item.html?id=481f2ba520274f0fabfe470d2c8def39' target='_blank'><b>test_raster_tif</b>\n",
+       "                        <a href='https://pythonapi.playground.esri.com/portal/home/item.html?id=481f2ba520274f0fabfe470d2c8def39' target='_blank'><b>test_raster_tif</b>\n",
        "                        </a>\n",
-       "                        <br/>test raster for edge detection model<img src='https://pythonapi.playground.esri.com/portal/home/home/js/jsapi/esri/css/images/item_type_icons/imagery16.png' style=\"vertical-align:middle;\">Imagery Layer by api_data_owner\n",
+       "                        <br/>test raster for edge detection model<img src='https://pythonapi.playground.esri.com/portal/home/js/jsapi/esri/css/images/item_type_icons/imagery16.png' style=\"vertical-align:middle;\">Imagery Layer by api_data_owner\n",
        "                        <br/>Last Modified: January 18, 2021\n",
        "                        <br/>0 comments, 0 views\n",
        "                    </div>\n",
@@ -963,7 +963,7 @@
        "<Item title:\"test_raster_tif\" type:Imagery Layer owner:api_data_owner>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('https://www.arcgis.com', 'arcgis_python', 'P@ssword123')`
    - `gis = GIS(profile="your_online_profile")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal', 'arcgis_python', 'amazing_arcgis_123')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [ ] Code refactored & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [x] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
