### PR TITLE
Spelling corrections

### DIFF
--- a/guide/05-working-with-the-spatially-enabled-dataframe/introduction-to-the-spatially-enabled-dataframe.ipynb
+++ b/guide/05-working-with-the-spatially-enabled-dataframe/introduction-to-the-spatially-enabled-dataframe.ipynb
@@ -31,7 +31,7 @@
     "* [Accessing local GIS Data](#Accessing-local-GIS-data)\n",
     " * [Example: Reading a Shapefile](#Example:-Reading-a-Shapefile)\n",
     " * [Example: Reading a Featureclass from FileGDB](#Example:-Reading-a-Featureclass-from-FileGDB)\n",
-    "* [Saving Spatiall Enabled DataFrames](#Saving-Spatially-Enabled-DataFrames)\n",
+    "* [Saving Spatially Enabled DataFrames](#Saving-Spatially-Enabled-DataFrames)\n",
     " * [Export Options](#Export-Options)\n",
     " * [Exporting to a Feature Class](#Export-to-Feature-Class)\n",
     "   * [Example: Export a whole dataset to a Shapefile](#Example:-Export-a-whole-dataset-to-a-shapefile:)\n",
@@ -58,7 +58,7 @@
    "metadata": {},
    "source": [
     "## Accessing GIS data\n",
-    "GIS users need to work with both published layers on remote servers (web layers) and local data, but the ability to manipulate these datasets without permanentently copying the data is lacking.  The `Spatial Enabled DataFrame` solves this problem because it is an in-memory object that can read, write and manipulate geospatial data.\n",
+    "GIS users need to work with both published layers on remote servers (web layers) and local data, but the ability to manipulate these datasets without permanently copying the data is lacking.  The `Spatial Enabled DataFrame` solves this problem because it is an in-memory object that can read, write and manipulate geospatial data.\n",
     "\n",
     "The SEDF integrates with Esri's [`ArcPy` site-package](http://pro.arcgis.com/en/pro-app/arcpy/get-started/what-is-arcpy-.htm) as well as the open source [`pyshp`](https://github.com/GeospatialPython/pyshp/), [`shapely`](https://github.com/Toblerity/Shapely) and [`fiona`](https://github.com/Toblerity/Fiona) packages. This means the ArcGIS API for Python SEDF can use either of these geometry engines to provide you options for easily working with geospatial data regardless of your platform.  The SEDF transforms data into the formats you desire so you can use Python functionality to analyze and visualize geographic information.\n",
     "\n",
@@ -633,7 +633,7 @@
    "metadata": {},
    "source": [
     "#### Example: Feature Layer Query Results to a Spatially Enabled DataFrame\n",
-    "We'll use the `AGE_45_54` column to query the dataframe and return a new `DataFrame` with a subset of records. We can use the built-in [`zip()`](https://docs.python.org/3/library/functions.html#zip) function to print the data frame attribute field names, and then use data frame syntax to view specific attribute fields in the output:"
+    "We'll use the `AGE_45_54` column to query the data frame and return a new `DataFrame` with a subset of records. We can use the built-in [`zip()`](https://docs.python.org/3/library/functions.html#zip) function to print the data frame attribute field names, and then use data frame syntax to view specific attribute fields in the output:"
    ]
   },
   {
@@ -775,7 +775,7 @@
     " * [`shapefiles`](http://desktop.arcgis.com/en/arcmap/latest/manage-data/shapefiles/what-is-a-shapefile.htm),  \n",
     " * [`ArcGIS Server Web Services`](https://enterprise.arcgis.com/en/server/latest/publish-services/windows/what-types-of-services-can-you-publish.htm) and [`ArcGIS Online Hosted Feature Layers`](https://doc.arcgis.com/en/arcgis-online/share-maps/publish-features.htm) \n",
     " * [`OGC Services`](http://www.opengeospatial.org/standards)  \n",
-    "* If the **ArcPy** module is not installed, the SEDF [`from_featureclass`](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.features.toc.html?arcgis.features.GeoAccessor.from_featureclass#arcgis.features.GeoAccessor.from_featureclass) method only supports consuming an Esri [`shapefile`](http://desktop.arcgis.com/en/arcmap/latest/manage-data/shapefiles/what-is-a-shapefile.htm)\n",
+    "* If the **`ArcPy`** module is not installed, the SEDF [`from_featureclass`](https://esri.github.io/arcgis-python-api/apidoc/html/arcgis.features.toc.html?arcgis.features.GeoAccessor.from_featureclass#arcgis.features.GeoAccessor.from_featureclass) method only supports consuming an Esri [`shapefile`](http://desktop.arcgis.com/en/arcmap/latest/manage-data/shapefiles/what-is-a-shapefile.htm)\n",
     "> Please note that you must install the `pyshp` package to read shapefiles in environments that don't have access to `ArcPy`.\n",
     "    \n",
     "### Example: Reading a Shapefile\n",
@@ -1016,7 +1016,7 @@
    "source": [
     "### Example: Reading a Featureclass from FileGDB\n",
     "\n",
-    "> You must have `fiona` installed if you use the `from_featureclass()` method to read a featureclass from FileGDB with a Python interpreter that does not have access to `ArcPy`.\n"
+    "> You must have `fiona` installed if you use the `from_featureclass()` method to read a feature class from FileGDB with a Python interpreter that does not have access to `ArcPy`.\n"
    ]
   },
   {


### PR DESCRIPTION
\<Made a few spelling corrections and updated formatting>

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ X] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ X] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [X ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ X] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [ X] Code refactored & split out across multiple cells, useful comments?
- [X ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ X] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [X ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [X ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
