### PR TITLE
Update search string for layer in smart-mapping guide

### DIFF
--- a/guide/10-mapping-and-visualization/smart-mapping.ipynb
+++ b/guide/10-mapping-and-visualization/smart-mapping.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,48 +30,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d86ddedee4254428a8effa949a678476",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "MapView(layout=Layout(height='400px', width='100%'))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"map-static-img-preview-6fc6b383-f8a1-45cb-8edb-6ac00f4f73ec\"><img src=\"\"></img></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"map-html-embed-preview-6fc6b383-f8a1-45cb-8edb-6ac00f4f73ec\"></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "map1 = gis.map('USA',3)\n",
     "map1"
@@ -115,11 +76,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Note:** Either feature layer collection returned should work for this exercise. If the layer doesn't draw immediately, you may need to zoom in before features draw."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "freeway_item = search_result[0]\n",

--- a/guide/10-mapping-and-visualization/smart-mapping.ipynb
+++ b/guide/10-mapping-and-visualization/smart-mapping.ipynb
@@ -20,10 +20,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 1,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from arcgis.gis import *\n",
@@ -32,11 +30,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d86ddedee4254428a8effa949a678476",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "MapView(layout=Layout(height='400px', width='100%'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"map-static-img-preview-6fc6b383-f8a1-45cb-8edb-6ac00f4f73ec\"><img src=\"\"></img></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"map-html-embed-preview-6fc6b383-f8a1-45cb-8edb-6ac00f4f73ec\"></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "map1 = gis.map('USA',3)\n",
     "map1"
@@ -58,22 +93,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<Item title:\"USA Freeway System\" type:Feature Service owner:esri>]"
+       "[<Item title:\"USA Freeway System\" type:Feature Layer Collection owner:esri_dm>,\n",
+       " <Item title:\"USA Freeway System\" type:Feature Layer Collection owner:esri_dm>]"
       ]
      },
-     "execution_count": null,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "search_result = gis.content.search('title:USA freeway system AND owner:esri', \n",
+    "search_result = gis.content.search('title:USA freeway system AND owner:esri_dm', \n",
     "                                  item_type = 'Feature Layer')\n",
     "search_result"
    ]
@@ -312,7 +348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* Fixes ArcGIS/geosaurus#6699
* change owner value from `esri` to `esri_dm` and add note to clarify layers in the result
<img width="853" alt="Screen Shot 2021-08-17 at 12 52 57 PM" src="https://user-images.githubusercontent.com/1399179/129792997-56129f68-527f-4ecf-b0f8-859202e0d993.png">

---

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? First block of imports are standard libraries, second block are 3rd party libraries, third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the api\_data\_owner user?
- [ ] Code refactored & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ DavidJVitale so he can add it to the list for the next deploy 
