### PR TITLE
Admin sample - Inventory portal items

### DIFF
--- a/guide/03-the-gis/organization-inventory.ipynb
+++ b/guide/03-the-gis/organization-inventory.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "6a058936",
+   "id": "eb5374db",
    "metadata": {},
    "source": [
     "Being able to retrieve, display, analyze, and export the content within an organization portal are important tasks for any admin. Here we will leverage the [ContentManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#contentmanager) and [UserManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#usermanager) classes of the GIS module, as well as some functionality from the [Pandas](https://pandas.pydata.org/docs/index.html) library, to accomplish those tasks.\n",
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57549875",
+   "id": "255c8207",
    "metadata": {},
    "source": [
     "## Import Libraries"
@@ -35,7 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "5961fffd",
+   "id": "57228c46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "8701fab9",
+   "id": "e72eda47",
    "metadata": {},
    "outputs": [
     {
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7cdd15a5",
+   "id": "05cd7ebb",
    "metadata": {},
    "source": [
     "## Connect to ArcGIS Online"
@@ -78,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "2f532632",
+   "id": "4c403f9e",
    "metadata": {},
    "outputs": [
     {
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c03e96dd",
+   "id": "6c3c5683",
    "metadata": {},
    "source": [
     "## Querying Content"
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5a612e8",
+   "id": "fc71bbb7",
    "metadata": {},
    "source": [
     "To search for content within our organization, we can access the [ContentManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager) class via gis.content. \n",
@@ -143,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "c8af0d28",
+   "id": "480ba363",
    "metadata": {},
    "outputs": [
     {
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2fdeff32",
+   "id": "2feb66cd",
    "metadata": {},
    "source": [
     "### Searching for Content"
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e83d9594",
+   "id": "a6014647",
    "metadata": {},
    "source": [
     "If we leave the return_count parameter as its default value False, then we will receive a response dictionary containing metadata about the query as well as a list of returned items in the 'results' field.\n",
@@ -181,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "5d37c709",
+   "id": "489d9374",
    "metadata": {},
    "outputs": [
     {
@@ -210,7 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4430d775",
+   "id": "51bb8322",
    "metadata": {},
    "source": [
     "### Displaying Content"
@@ -219,7 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "8883fcc4",
+   "id": "49d75100",
    "metadata": {},
    "outputs": [
     {
@@ -313,7 +313,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c3bbec0",
+   "id": "003b4b2a",
    "metadata": {},
    "source": [
     "It is also possible to have these items returned as dictionary objects by setting the as_dict parameter:"
@@ -322,7 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "a5ee532a",
+   "id": "dff4fd98",
    "metadata": {},
    "outputs": [
     {
@@ -516,7 +516,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63e8784c",
+   "id": "83479378",
    "metadata": {},
    "source": [
     "### Sorting Content"
@@ -524,7 +524,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45eae478",
+   "id": "eb21731b",
    "metadata": {},
    "source": [
     "The sort_field and sort_order parameters of the [advanced_search()](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager.advanced_search) method can be used to sort the returned content server side.\n",
@@ -537,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "ee730f56",
+   "id": "5bb3a659",
    "metadata": {},
    "outputs": [
     {
@@ -632,7 +632,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "031b88bf",
+   "id": "ef1607ee",
    "metadata": {},
    "source": [
     "Here we return the first 3 items that the user created by setting sort_field=\"created\" and sort_order=\"asc\":"
@@ -641,7 +641,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "ff4dc727",
+   "id": "c6de47d8",
    "metadata": {},
    "outputs": [
     {
@@ -735,7 +735,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7dfc8fef",
+   "id": "da057c61",
    "metadata": {},
    "source": [
     "## Querying Organization Content"
@@ -743,7 +743,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "236b6872",
+   "id": "da8fa867",
    "metadata": {},
    "source": [
     "### Searching for Organization Members"
@@ -751,16 +751,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a61bcd8a",
+   "id": "9c8cd50f",
    "metadata": {},
    "source": [
-    "We can search for a list of the members within the organization by using the [UserManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.server.html#arcgis.gis.server.UserManager) class within the GIS module. Here we access the UserManager by calling gis.users, and use the org_search() method to return a list of organization members. The org_search() method will return all users in the organization if no parameters are provided:"
+    "We can search for a list of the members within the organization by using the [UserManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.server.html#arcgis.gis.server.UserManager) class within the GIS module. Here we access the UserManager by calling gis.users, and use the [search()](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.UserManager.search) method to return a list of organization members. The search() method will return all users in the organization if no parameters are provided:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "15f84b4a",
+   "id": "e9aa180e",
    "metadata": {},
    "outputs": [
     {
@@ -781,8 +781,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "22647b19",
+   "execution_count": 11,
+   "id": "922eb605",
    "metadata": {},
    "outputs": [
     {
@@ -800,7 +800,7 @@
        " <User username:andrew57>]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -813,8 +813,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "5f92cefc",
+   "execution_count": 12,
+   "id": "045503c4",
    "metadata": {},
    "outputs": [
     {
@@ -844,7 +844,7 @@
        "<User username:amani_geosaurus>"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -857,7 +857,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8be185fe",
+   "id": "de1a2aa8",
    "metadata": {},
    "source": [
     "### Getting Member Content"
@@ -865,7 +865,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c56cda2",
+   "id": "c65e952c",
    "metadata": {},
    "source": [
     "Similarly to above, we can set return_count=True and see how many items this user has:"
@@ -873,8 +873,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "f9f2265f",
+   "execution_count": 13,
+   "id": "7a9e92c3",
    "metadata": {},
    "outputs": [
     {
@@ -895,8 +895,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "c0f9764a",
+   "execution_count": 14,
+   "id": "d8407b03",
    "metadata": {},
    "outputs": [
     {
@@ -907,7 +907,7 @@
        " <Item title:\"geotaggedphotos1\" type:Feature Layer Collection owner:amani_geosaurus>]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -922,7 +922,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86731e14",
+   "id": "3f43b387",
    "metadata": {},
    "source": [
     "### Compiling Organization Content"
@@ -930,7 +930,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4601003",
+   "id": "3dea0b00",
    "metadata": {},
    "source": [
     "If we return all items for each user in the organization, we can compile those items into a single list representing all of the organizations content.\n",
@@ -940,15 +940,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "32189e72",
+   "execution_count": 15,
+   "id": "7dd1f076",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1845 items found in org\n"
+      "1848 items found in org\n"
      ]
     }
    ],
@@ -967,7 +967,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "417fa4d6",
+   "id": "c3efa6f9",
    "metadata": {},
    "source": [
     "## Analyzing Organization Content with Pandas"
@@ -975,7 +975,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c232bb8",
+   "id": "9c848a63",
    "metadata": {},
    "source": [
     "Let's put our compiled list into a pandas [DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) to easily view and filter our data"
@@ -983,8 +983,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "id": "c97071ad",
+   "execution_count": 16,
+   "id": "b8acee3d",
    "metadata": {},
    "outputs": [
     {
@@ -1203,7 +1203,7 @@
        "[5 rows x 51 columns]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1217,7 +1217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63914c58",
+   "id": "a371b836",
    "metadata": {},
    "source": [
     "We can use the pandas function [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) to see how many occurrences there are of each value for a particular column. Here we return the top 10 most frequently occurring item types and the number of instances they have:"
@@ -1225,15 +1225,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "id": "4b6a60e8",
+   "execution_count": 17,
+   "id": "3d641a4e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Feature Service          434\n",
-       "Feature Collection       427\n",
+       "Feature Service          435\n",
+       "Feature Collection       429\n",
        "Notebook                 342\n",
        "Shapefile                129\n",
        "StoryMap                  98\n",
@@ -1245,7 +1245,7 @@
        "Name: type, dtype: int64"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1257,7 +1257,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ed08c50",
+   "id": "6ba0e6cd",
    "metadata": {},
    "source": [
     "Another [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) example where we see the distribution of access levels for each of the items in the organization:"
@@ -1265,21 +1265,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "id": "f9a95a80",
+   "execution_count": 18,
+   "id": "ba6337fe",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "private    815\n",
-       "org        516\n",
-       "public     512\n",
+       "org        518\n",
+       "public     513\n",
        "shared       2\n",
        "Name: access, dtype: int64"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1290,7 +1290,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "870d2fbd",
+   "id": "bb949c64",
    "metadata": {},
    "source": [
     "Using the [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) function in conjunction with the [groupby()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.groupby.html) operation allows for an additional level of analysis. Here we see the breakdown of item types that each user has created:"
@@ -1298,8 +1298,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "id": "1261d700",
+   "execution_count": 19,
+   "id": "cd70598d",
    "metadata": {},
    "outputs": [
     {
@@ -1319,7 +1319,7 @@
        "Name: type, dtype: int64"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1330,8 +1330,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "id": "795cee96",
+   "execution_count": 20,
+   "id": "372d9dab",
    "metadata": {},
    "outputs": [
     {
@@ -1351,7 +1351,7 @@
        "Name: access, dtype: int64"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1363,7 +1363,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79e1bc15",
+   "id": "0a051e53",
    "metadata": {},
    "source": [
     "### Filtering the Dataset"
@@ -1371,7 +1371,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3dea15fe",
+   "id": "d7e3cb44",
    "metadata": {},
    "source": [
     "We can choose which columns we'd like to view, and the order we'd like to view them in, by providing the DataFrame with a list of strings matching column names:"
@@ -1379,8 +1379,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "id": "1c99e62d",
+   "execution_count": 21,
+   "id": "25ac238f",
    "metadata": {},
    "outputs": [
     {
@@ -1472,7 +1472,7 @@
        "4              Notebook  public  "
       ]
      },
-     "execution_count": 27,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1484,7 +1484,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db990804",
+   "id": "67f4d11c",
    "metadata": {},
    "source": [
     "Creating and applying Boolean masks is a very efficient way to the filter the rows of a DataFrame. By using standard operators such as <, >, == and != on pandas Series objects (e.g. the columns of our DataFrame), we can create a new Series of True and False values, called a mask. When this mask is applied to the original DataFrame, a new DataFrame will be returned with only the rows corresponding to where the mask had a True value.\n",
@@ -1494,8 +1494,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "id": "2b57a301",
+   "execution_count": 22,
+   "id": "8be6ea3b",
    "metadata": {},
    "outputs": [
     {
@@ -1509,7 +1509,7 @@
        "Name: access, dtype: bool"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1523,7 +1523,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b4de2cf",
+   "id": "5c0fdaf8",
    "metadata": {},
    "source": [
     "Applying this mask to our DataFrame, we return all fields for objects which have access=='public':"
@@ -1531,15 +1531,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "id": "c2dfcf3d",
+   "execution_count": 23,
+   "id": "ab2c3303",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "512 objects in filtered DataFrame\n"
+      "513 objects in filtered DataFrame\n"
      ]
     },
     {
@@ -1758,7 +1758,7 @@
        "[5 rows x 51 columns]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1770,7 +1770,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8dc62302",
+   "id": "433a42f0",
    "metadata": {},
    "source": [
     "We can apply both the column filter and Boolean mask at the same time to reduce the amount of information displayed:"
@@ -1778,8 +1778,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "id": "64b6f2a7",
+   "execution_count": 24,
+   "id": "d5984b62",
    "metadata": {},
    "outputs": [
     {
@@ -1871,7 +1871,7 @@
        "7  amani_geosaurus      Application  public  "
       ]
      },
-     "execution_count": 30,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1882,7 +1882,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2bce8bf",
+   "id": "2cc34a39",
    "metadata": {},
    "source": [
     "Another example where we create a Boolean mask for all objects of type 'Web Map':"
@@ -1890,8 +1890,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "id": "99511b85",
+   "execution_count": 25,
+   "id": "4db93840",
    "metadata": {},
    "outputs": [
     {
@@ -1972,111 +1972,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>191</th>\n",
-       "      <td>7d76c6397380497f9879df74f80f0214</td>\n",
-       "      <td>Brick Kilns around Jaipur 2019</td>\n",
-       "      <td>api_data_owner</td>\n",
-       "      <td>Web Map</td>\n",
-       "      <td>public</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>192</th>\n",
-       "      <td>e91b9226ef224e7da4f32cb034c8b94d</td>\n",
-       "      <td>Brick Klinks around Delhi 2014</td>\n",
-       "      <td>api_data_owner</td>\n",
-       "      <td>Web Map</td>\n",
-       "      <td>public</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>193</th>\n",
-       "      <td>711b1725f6334aeca2151734b37d3c50</td>\n",
-       "      <td>Brick Klinks around Delhi 2019</td>\n",
-       "      <td>api_data_owner</td>\n",
-       "      <td>Web Map</td>\n",
-       "      <td>public</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>506</th>\n",
-       "      <td>6527ca7eea2a4cad826e11f298d09500</td>\n",
-       "      <td>Coastline_India</td>\n",
-       "      <td>api_data_owner</td>\n",
-       "      <td>Web Map</td>\n",
-       "      <td>public</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>507</th>\n",
-       "      <td>a3e8eda445c34e95bdef7aa75bdd8a77</td>\n",
-       "      <td>Coastline_India_l8</td>\n",
-       "      <td>api_data_owner</td>\n",
-       "      <td>Web Map</td>\n",
-       "      <td>public</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>583</th>\n",
-       "      <td>7d4f5249de15493a9916c03e509b831c</td>\n",
-       "      <td>slums_2004</td>\n",
-       "      <td>api_data_owner</td>\n",
-       "      <td>Web Map</td>\n",
-       "      <td>public</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>584</th>\n",
-       "      <td>f3f7d8c728e74230baeed747a5322ba5</td>\n",
-       "      <td>slums_2014</td>\n",
-       "      <td>api_data_owner</td>\n",
-       "      <td>Web Map</td>\n",
-       "      <td>public</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>642</th>\n",
-       "      <td>2fecd25df8624a41b15dfc97ed4c8f98</td>\n",
-       "      <td>Superresolution Inferenced Map</td>\n",
-       "      <td>api_data_owner</td>\n",
-       "      <td>Web Map</td>\n",
-       "      <td>public</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>657</th>\n",
-       "      <td>2051a50d9370428297dc08a87db4a43f</td>\n",
-       "      <td>oma-test-map</td>\n",
-       "      <td>api_data_owner</td>\n",
-       "      <td>Web Map</td>\n",
-       "      <td>org</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>658</th>\n",
-       "      <td>7cb38a3325564607a81c0da5733bfbfc</td>\n",
-       "      <td>oma-test-map-updates</td>\n",
-       "      <td>api_data_owner</td>\n",
-       "      <td>Web Map</td>\n",
-       "      <td>private</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>659</th>\n",
-       "      <td>966cba4a3bfe487692b305d923fe2777</td>\n",
-       "      <td>oma-test-map-updates-052220</td>\n",
-       "      <td>api_data_owner</td>\n",
-       "      <td>Web Map</td>\n",
-       "      <td>private</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>673</th>\n",
-       "      <td>6b43fb3f165245e3b72eba2ff2357d98</td>\n",
-       "      <td>Parcel_extraction_results_e02</td>\n",
-       "      <td>api_data_owner</td>\n",
-       "      <td>Web Map</td>\n",
-       "      <td>private</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>783</th>\n",
-       "      <td>7fe016b30663401baf415f4dd1078d36</td>\n",
-       "      <td>Extracted land parcels</td>\n",
-       "      <td>api_data_owner</td>\n",
-       "      <td>Web Map</td>\n",
-       "      <td>public</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>996</th>\n",
+       "      <th>96</th>\n",
        "      <td>127a87ebeede4e6c919d43b600763a3b</td>\n",
        "      <td>Addresses Geocoded</td>\n",
        "      <td>api_data_owner</td>\n",
@@ -2084,7 +1980,111 @@
        "      <td>private</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1070</th>\n",
+       "      <th>291</th>\n",
+       "      <td>7d76c6397380497f9879df74f80f0214</td>\n",
+       "      <td>Brick Kilns around Jaipur 2019</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>292</th>\n",
+       "      <td>e91b9226ef224e7da4f32cb034c8b94d</td>\n",
+       "      <td>Brick Klinks around Delhi 2014</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>293</th>\n",
+       "      <td>711b1725f6334aeca2151734b37d3c50</td>\n",
+       "      <td>Brick Klinks around Delhi 2019</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>406</th>\n",
+       "      <td>6527ca7eea2a4cad826e11f298d09500</td>\n",
+       "      <td>Coastline_India</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>407</th>\n",
+       "      <td>a3e8eda445c34e95bdef7aa75bdd8a77</td>\n",
+       "      <td>Coastline_India_l8</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>483</th>\n",
+       "      <td>7d4f5249de15493a9916c03e509b831c</td>\n",
+       "      <td>slums_2004</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>484</th>\n",
+       "      <td>f3f7d8c728e74230baeed747a5322ba5</td>\n",
+       "      <td>slums_2014</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>542</th>\n",
+       "      <td>2fecd25df8624a41b15dfc97ed4c8f98</td>\n",
+       "      <td>Superresolution Inferenced Map</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>557</th>\n",
+       "      <td>2051a50d9370428297dc08a87db4a43f</td>\n",
+       "      <td>oma-test-map</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>558</th>\n",
+       "      <td>7cb38a3325564607a81c0da5733bfbfc</td>\n",
+       "      <td>oma-test-map-updates</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>private</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>559</th>\n",
+       "      <td>966cba4a3bfe487692b305d923fe2777</td>\n",
+       "      <td>oma-test-map-updates-052220</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>private</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>573</th>\n",
+       "      <td>6b43fb3f165245e3b72eba2ff2357d98</td>\n",
+       "      <td>Parcel_extraction_results_e02</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>private</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>823</th>\n",
+       "      <td>2303b34ac97b4689bd5ff851d5982a96</td>\n",
+       "      <td>USA_coastline</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>870</th>\n",
        "      <td>66db719c5a7844a0b681876f7cd4c269</td>\n",
        "      <td>wm-test-n-layers</td>\n",
        "      <td>api_data_owner</td>\n",
@@ -2092,7 +2092,7 @@
        "      <td>org</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1071</th>\n",
+       "      <th>871</th>\n",
        "      <td>d0772d26a75141f9ac11998c16b06eed</td>\n",
        "      <td>wm-test-n-layers-dgray</td>\n",
        "      <td>api_data_owner</td>\n",
@@ -2100,9 +2100,9 @@
        "      <td>org</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1263</th>\n",
-       "      <td>2303b34ac97b4689bd5ff851d5982a96</td>\n",
-       "      <td>USA_coastline</td>\n",
+       "      <th>923</th>\n",
+       "      <td>7fe016b30663401baf415f4dd1078d36</td>\n",
+       "      <td>Extracted land parcels</td>\n",
        "      <td>api_data_owner</td>\n",
        "      <td>Web Map</td>\n",
        "      <td>public</td>\n",
@@ -2116,7 +2116,7 @@
        "      <td>org</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1438</th>\n",
+       "      <th>1338</th>\n",
        "      <td>b270d508a6354c6c84510e83f94ebf19</td>\n",
        "      <td>API_downloads_across_globe</td>\n",
        "      <td>arcgis_python</td>\n",
@@ -2124,7 +2124,7 @@
        "      <td>org</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1476</th>\n",
+       "      <th>1376</th>\n",
        "      <td>ebc72a274dff4315b703e5de0a894831</td>\n",
        "      <td>Location Allocation example of Pizza Stores in...</td>\n",
        "      <td>arcgis_python</td>\n",
@@ -2132,7 +2132,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1478</th>\n",
+       "      <th>1378</th>\n",
        "      <td>27a956e9da094da98ebba3312a456078</td>\n",
        "      <td>Map_View_Google Drive Image</td>\n",
        "      <td>arcgis_python</td>\n",
@@ -2140,7 +2140,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1480</th>\n",
+       "      <th>1380</th>\n",
        "      <td>e66622a75ac14fffaf2e8223025479a0</td>\n",
        "      <td>Mobiliario Madrid</td>\n",
        "      <td>arcgis_python</td>\n",
@@ -2148,7 +2148,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1800</th>\n",
+       "      <th>1802</th>\n",
        "      <td>c0da3fa83cd34379b49c56a33247910b</td>\n",
        "      <td>wMap5_withCharts</td>\n",
        "      <td>arcgis_python</td>\n",
@@ -2156,7 +2156,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1801</th>\n",
+       "      <th>1803</th>\n",
        "      <td>393e05923b7c4d289d305273b30a1ea3</td>\n",
        "      <td>testing</td>\n",
        "      <td>DavidJVitale</td>\n",
@@ -2164,7 +2164,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1806</th>\n",
+       "      <th>1808</th>\n",
        "      <td>3c9ab685601748b9b55f06c6a529d070</td>\n",
        "      <td>Chicago Libraries 2012</td>\n",
        "      <td>jyaist_geosaurus</td>\n",
@@ -2172,7 +2172,7 @@
        "      <td>org</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1809</th>\n",
+       "      <th>1811</th>\n",
        "      <td>4aeed784e57043e49895293e576f732a</td>\n",
        "      <td>Guinea Power Plants</td>\n",
        "      <td>jyaist_geosaurus</td>\n",
@@ -2180,7 +2180,7 @@
        "      <td>shared</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1832</th>\n",
+       "      <th>1835</th>\n",
        "      <td>0c4170b6934245269ffc3f41acbb4a87</td>\n",
        "      <td>LeafPickupMap</td>\n",
        "      <td>naubry_geosaurus</td>\n",
@@ -2199,33 +2199,33 @@
        "38    54fd67f260fe413da84ed4f2d9e1dac2   \n",
        "44    a478d4172870462dae95d0b26561e3ac   \n",
        "46    ac02f94f0b8d42e59c74fdf9fb249a06   \n",
-       "191   7d76c6397380497f9879df74f80f0214   \n",
-       "192   e91b9226ef224e7da4f32cb034c8b94d   \n",
-       "193   711b1725f6334aeca2151734b37d3c50   \n",
-       "506   6527ca7eea2a4cad826e11f298d09500   \n",
-       "507   a3e8eda445c34e95bdef7aa75bdd8a77   \n",
-       "583   7d4f5249de15493a9916c03e509b831c   \n",
-       "584   f3f7d8c728e74230baeed747a5322ba5   \n",
-       "642   2fecd25df8624a41b15dfc97ed4c8f98   \n",
-       "657   2051a50d9370428297dc08a87db4a43f   \n",
-       "658   7cb38a3325564607a81c0da5733bfbfc   \n",
-       "659   966cba4a3bfe487692b305d923fe2777   \n",
-       "673   6b43fb3f165245e3b72eba2ff2357d98   \n",
-       "783   7fe016b30663401baf415f4dd1078d36   \n",
-       "996   127a87ebeede4e6c919d43b600763a3b   \n",
-       "1070  66db719c5a7844a0b681876f7cd4c269   \n",
-       "1071  d0772d26a75141f9ac11998c16b06eed   \n",
-       "1263  2303b34ac97b4689bd5ff851d5982a96   \n",
+       "96    127a87ebeede4e6c919d43b600763a3b   \n",
+       "291   7d76c6397380497f9879df74f80f0214   \n",
+       "292   e91b9226ef224e7da4f32cb034c8b94d   \n",
+       "293   711b1725f6334aeca2151734b37d3c50   \n",
+       "406   6527ca7eea2a4cad826e11f298d09500   \n",
+       "407   a3e8eda445c34e95bdef7aa75bdd8a77   \n",
+       "483   7d4f5249de15493a9916c03e509b831c   \n",
+       "484   f3f7d8c728e74230baeed747a5322ba5   \n",
+       "542   2fecd25df8624a41b15dfc97ed4c8f98   \n",
+       "557   2051a50d9370428297dc08a87db4a43f   \n",
+       "558   7cb38a3325564607a81c0da5733bfbfc   \n",
+       "559   966cba4a3bfe487692b305d923fe2777   \n",
+       "573   6b43fb3f165245e3b72eba2ff2357d98   \n",
+       "823   2303b34ac97b4689bd5ff851d5982a96   \n",
+       "870   66db719c5a7844a0b681876f7cd4c269   \n",
+       "871   d0772d26a75141f9ac11998c16b06eed   \n",
+       "923   7fe016b30663401baf415f4dd1078d36   \n",
        "1311  6d8e89f6fb0a4c8a8bb5e059846425d9   \n",
-       "1438  b270d508a6354c6c84510e83f94ebf19   \n",
-       "1476  ebc72a274dff4315b703e5de0a894831   \n",
-       "1478  27a956e9da094da98ebba3312a456078   \n",
-       "1480  e66622a75ac14fffaf2e8223025479a0   \n",
-       "1800  c0da3fa83cd34379b49c56a33247910b   \n",
-       "1801  393e05923b7c4d289d305273b30a1ea3   \n",
-       "1806  3c9ab685601748b9b55f06c6a529d070   \n",
-       "1809  4aeed784e57043e49895293e576f732a   \n",
-       "1832  0c4170b6934245269ffc3f41acbb4a87   \n",
+       "1338  b270d508a6354c6c84510e83f94ebf19   \n",
+       "1376  ebc72a274dff4315b703e5de0a894831   \n",
+       "1378  27a956e9da094da98ebba3312a456078   \n",
+       "1380  e66622a75ac14fffaf2e8223025479a0   \n",
+       "1802  c0da3fa83cd34379b49c56a33247910b   \n",
+       "1803  393e05923b7c4d289d305273b30a1ea3   \n",
+       "1808  3c9ab685601748b9b55f06c6a529d070   \n",
+       "1811  4aeed784e57043e49895293e576f732a   \n",
+       "1835  0c4170b6934245269ffc3f41acbb4a87   \n",
        "\n",
        "                                                  title             owner  \\\n",
        "6                              Lambda requests on a map   amani_geosaurus   \n",
@@ -2234,33 +2234,33 @@
        "38                          National Levee Database Map          andrew57   \n",
        "44                                   SarahAWebMapSample          andrew57   \n",
        "46               VectorTileFromOtherSiteLayerandBasemap          andrew57   \n",
-       "191                      Brick Kilns around Jaipur 2019    api_data_owner   \n",
-       "192                      Brick Klinks around Delhi 2014    api_data_owner   \n",
-       "193                      Brick Klinks around Delhi 2019    api_data_owner   \n",
-       "506                                     Coastline_India    api_data_owner   \n",
-       "507                                  Coastline_India_l8    api_data_owner   \n",
-       "583                                          slums_2004    api_data_owner   \n",
-       "584                                          slums_2014    api_data_owner   \n",
-       "642                      Superresolution Inferenced Map    api_data_owner   \n",
-       "657                                        oma-test-map    api_data_owner   \n",
-       "658                                oma-test-map-updates    api_data_owner   \n",
-       "659                         oma-test-map-updates-052220    api_data_owner   \n",
-       "673                       Parcel_extraction_results_e02    api_data_owner   \n",
-       "783                              Extracted land parcels    api_data_owner   \n",
-       "996                                  Addresses Geocoded    api_data_owner   \n",
-       "1070                                   wm-test-n-layers    api_data_owner   \n",
-       "1071                             wm-test-n-layers-dgray    api_data_owner   \n",
-       "1263                                      USA_coastline    api_data_owner   \n",
+       "96                                   Addresses Geocoded    api_data_owner   \n",
+       "291                      Brick Kilns around Jaipur 2019    api_data_owner   \n",
+       "292                      Brick Klinks around Delhi 2014    api_data_owner   \n",
+       "293                      Brick Klinks around Delhi 2019    api_data_owner   \n",
+       "406                                     Coastline_India    api_data_owner   \n",
+       "407                                  Coastline_India_l8    api_data_owner   \n",
+       "483                                          slums_2004    api_data_owner   \n",
+       "484                                          slums_2014    api_data_owner   \n",
+       "542                      Superresolution Inferenced Map    api_data_owner   \n",
+       "557                                        oma-test-map    api_data_owner   \n",
+       "558                                oma-test-map-updates    api_data_owner   \n",
+       "559                         oma-test-map-updates-052220    api_data_owner   \n",
+       "573                       Parcel_extraction_results_e02    api_data_owner   \n",
+       "823                                       USA_coastline    api_data_owner   \n",
+       "870                                    wm-test-n-layers    api_data_owner   \n",
+       "871                              wm-test-n-layers-dgray    api_data_owner   \n",
+       "923                              Extracted land parcels    api_data_owner   \n",
        "1311                                           Giraffes    ArcGISPyAPIBot   \n",
-       "1438                         API_downloads_across_globe     arcgis_python   \n",
-       "1476  Location Allocation example of Pizza Stores in...     arcgis_python   \n",
-       "1478                        Map_View_Google Drive Image     arcgis_python   \n",
-       "1480                                  Mobiliario Madrid     arcgis_python   \n",
-       "1800                                   wMap5_withCharts     arcgis_python   \n",
-       "1801                                            testing      DavidJVitale   \n",
-       "1806                             Chicago Libraries 2012  jyaist_geosaurus   \n",
-       "1809                                Guinea Power Plants  jyaist_geosaurus   \n",
-       "1832                                      LeafPickupMap  naubry_geosaurus   \n",
+       "1338                         API_downloads_across_globe     arcgis_python   \n",
+       "1376  Location Allocation example of Pizza Stores in...     arcgis_python   \n",
+       "1378                        Map_View_Google Drive Image     arcgis_python   \n",
+       "1380                                  Mobiliario Madrid     arcgis_python   \n",
+       "1802                                   wMap5_withCharts     arcgis_python   \n",
+       "1803                                            testing      DavidJVitale   \n",
+       "1808                             Chicago Libraries 2012  jyaist_geosaurus   \n",
+       "1811                                Guinea Power Plants  jyaist_geosaurus   \n",
+       "1835                                      LeafPickupMap  naubry_geosaurus   \n",
        "\n",
        "         type   access  \n",
        "6     Web Map   public  \n",
@@ -2269,36 +2269,36 @@
        "38    Web Map   public  \n",
        "44    Web Map      org  \n",
        "46    Web Map   public  \n",
-       "191   Web Map   public  \n",
-       "192   Web Map   public  \n",
-       "193   Web Map   public  \n",
-       "506   Web Map   public  \n",
-       "507   Web Map   public  \n",
-       "583   Web Map   public  \n",
-       "584   Web Map   public  \n",
-       "642   Web Map   public  \n",
-       "657   Web Map      org  \n",
-       "658   Web Map  private  \n",
-       "659   Web Map  private  \n",
-       "673   Web Map  private  \n",
-       "783   Web Map   public  \n",
-       "996   Web Map  private  \n",
-       "1070  Web Map      org  \n",
-       "1071  Web Map      org  \n",
-       "1263  Web Map   public  \n",
+       "96    Web Map  private  \n",
+       "291   Web Map   public  \n",
+       "292   Web Map   public  \n",
+       "293   Web Map   public  \n",
+       "406   Web Map   public  \n",
+       "407   Web Map   public  \n",
+       "483   Web Map   public  \n",
+       "484   Web Map   public  \n",
+       "542   Web Map   public  \n",
+       "557   Web Map      org  \n",
+       "558   Web Map  private  \n",
+       "559   Web Map  private  \n",
+       "573   Web Map  private  \n",
+       "823   Web Map   public  \n",
+       "870   Web Map      org  \n",
+       "871   Web Map      org  \n",
+       "923   Web Map   public  \n",
        "1311  Web Map      org  \n",
-       "1438  Web Map      org  \n",
-       "1476  Web Map   public  \n",
-       "1478  Web Map   public  \n",
-       "1480  Web Map   public  \n",
-       "1800  Web Map   public  \n",
-       "1801  Web Map   public  \n",
-       "1806  Web Map      org  \n",
-       "1809  Web Map   shared  \n",
-       "1832  Web Map      org  "
+       "1338  Web Map      org  \n",
+       "1376  Web Map   public  \n",
+       "1378  Web Map   public  \n",
+       "1380  Web Map   public  \n",
+       "1802  Web Map   public  \n",
+       "1803  Web Map   public  \n",
+       "1808  Web Map      org  \n",
+       "1811  Web Map   shared  \n",
+       "1835  Web Map      org  "
       ]
      },
-     "execution_count": 31,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2312,7 +2312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1567216f",
+   "id": "6b0a79b2",
    "metadata": {},
    "source": [
     "Boolean masks can also be combined to represent multiple filters. Here we combine the Web Map and Public masks to return all items in our organization which are public web maps:"
@@ -2320,8 +2320,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "id": "7dd8ded0",
+   "execution_count": 26,
+   "id": "92edfe37",
    "metadata": {},
    "outputs": [
     {
@@ -2394,7 +2394,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>191</th>\n",
+       "      <th>291</th>\n",
        "      <td>7d76c6397380497f9879df74f80f0214</td>\n",
        "      <td>Brick Kilns around Jaipur 2019</td>\n",
        "      <td>api_data_owner</td>\n",
@@ -2402,7 +2402,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>192</th>\n",
+       "      <th>292</th>\n",
        "      <td>e91b9226ef224e7da4f32cb034c8b94d</td>\n",
        "      <td>Brick Klinks around Delhi 2014</td>\n",
        "      <td>api_data_owner</td>\n",
@@ -2410,7 +2410,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>193</th>\n",
+       "      <th>293</th>\n",
        "      <td>711b1725f6334aeca2151734b37d3c50</td>\n",
        "      <td>Brick Klinks around Delhi 2019</td>\n",
        "      <td>api_data_owner</td>\n",
@@ -2418,7 +2418,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>506</th>\n",
+       "      <th>406</th>\n",
        "      <td>6527ca7eea2a4cad826e11f298d09500</td>\n",
        "      <td>Coastline_India</td>\n",
        "      <td>api_data_owner</td>\n",
@@ -2426,7 +2426,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>507</th>\n",
+       "      <th>407</th>\n",
        "      <td>a3e8eda445c34e95bdef7aa75bdd8a77</td>\n",
        "      <td>Coastline_India_l8</td>\n",
        "      <td>api_data_owner</td>\n",
@@ -2434,7 +2434,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>583</th>\n",
+       "      <th>483</th>\n",
        "      <td>7d4f5249de15493a9916c03e509b831c</td>\n",
        "      <td>slums_2004</td>\n",
        "      <td>api_data_owner</td>\n",
@@ -2442,7 +2442,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>584</th>\n",
+       "      <th>484</th>\n",
        "      <td>f3f7d8c728e74230baeed747a5322ba5</td>\n",
        "      <td>slums_2014</td>\n",
        "      <td>api_data_owner</td>\n",
@@ -2450,7 +2450,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>642</th>\n",
+       "      <th>542</th>\n",
        "      <td>2fecd25df8624a41b15dfc97ed4c8f98</td>\n",
        "      <td>Superresolution Inferenced Map</td>\n",
        "      <td>api_data_owner</td>\n",
@@ -2458,15 +2458,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>783</th>\n",
-       "      <td>7fe016b30663401baf415f4dd1078d36</td>\n",
-       "      <td>Extracted land parcels</td>\n",
-       "      <td>api_data_owner</td>\n",
-       "      <td>Web Map</td>\n",
-       "      <td>public</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1263</th>\n",
+       "      <th>823</th>\n",
        "      <td>2303b34ac97b4689bd5ff851d5982a96</td>\n",
        "      <td>USA_coastline</td>\n",
        "      <td>api_data_owner</td>\n",
@@ -2474,7 +2466,15 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1476</th>\n",
+       "      <th>923</th>\n",
+       "      <td>7fe016b30663401baf415f4dd1078d36</td>\n",
+       "      <td>Extracted land parcels</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1376</th>\n",
        "      <td>ebc72a274dff4315b703e5de0a894831</td>\n",
        "      <td>Location Allocation example of Pizza Stores in...</td>\n",
        "      <td>arcgis_python</td>\n",
@@ -2482,7 +2482,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1478</th>\n",
+       "      <th>1378</th>\n",
        "      <td>27a956e9da094da98ebba3312a456078</td>\n",
        "      <td>Map_View_Google Drive Image</td>\n",
        "      <td>arcgis_python</td>\n",
@@ -2490,7 +2490,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1480</th>\n",
+       "      <th>1380</th>\n",
        "      <td>e66622a75ac14fffaf2e8223025479a0</td>\n",
        "      <td>Mobiliario Madrid</td>\n",
        "      <td>arcgis_python</td>\n",
@@ -2498,7 +2498,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1800</th>\n",
+       "      <th>1802</th>\n",
        "      <td>c0da3fa83cd34379b49c56a33247910b</td>\n",
        "      <td>wMap5_withCharts</td>\n",
        "      <td>arcgis_python</td>\n",
@@ -2506,7 +2506,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1801</th>\n",
+       "      <th>1803</th>\n",
        "      <td>393e05923b7c4d289d305273b30a1ea3</td>\n",
        "      <td>testing</td>\n",
        "      <td>DavidJVitale</td>\n",
@@ -2524,21 +2524,21 @@
        "36    81ef30218b3f41e89019160faa4de099   \n",
        "38    54fd67f260fe413da84ed4f2d9e1dac2   \n",
        "46    ac02f94f0b8d42e59c74fdf9fb249a06   \n",
-       "191   7d76c6397380497f9879df74f80f0214   \n",
-       "192   e91b9226ef224e7da4f32cb034c8b94d   \n",
-       "193   711b1725f6334aeca2151734b37d3c50   \n",
-       "506   6527ca7eea2a4cad826e11f298d09500   \n",
-       "507   a3e8eda445c34e95bdef7aa75bdd8a77   \n",
-       "583   7d4f5249de15493a9916c03e509b831c   \n",
-       "584   f3f7d8c728e74230baeed747a5322ba5   \n",
-       "642   2fecd25df8624a41b15dfc97ed4c8f98   \n",
-       "783   7fe016b30663401baf415f4dd1078d36   \n",
-       "1263  2303b34ac97b4689bd5ff851d5982a96   \n",
-       "1476  ebc72a274dff4315b703e5de0a894831   \n",
-       "1478  27a956e9da094da98ebba3312a456078   \n",
-       "1480  e66622a75ac14fffaf2e8223025479a0   \n",
-       "1800  c0da3fa83cd34379b49c56a33247910b   \n",
-       "1801  393e05923b7c4d289d305273b30a1ea3   \n",
+       "291   7d76c6397380497f9879df74f80f0214   \n",
+       "292   e91b9226ef224e7da4f32cb034c8b94d   \n",
+       "293   711b1725f6334aeca2151734b37d3c50   \n",
+       "406   6527ca7eea2a4cad826e11f298d09500   \n",
+       "407   a3e8eda445c34e95bdef7aa75bdd8a77   \n",
+       "483   7d4f5249de15493a9916c03e509b831c   \n",
+       "484   f3f7d8c728e74230baeed747a5322ba5   \n",
+       "542   2fecd25df8624a41b15dfc97ed4c8f98   \n",
+       "823   2303b34ac97b4689bd5ff851d5982a96   \n",
+       "923   7fe016b30663401baf415f4dd1078d36   \n",
+       "1376  ebc72a274dff4315b703e5de0a894831   \n",
+       "1378  27a956e9da094da98ebba3312a456078   \n",
+       "1380  e66622a75ac14fffaf2e8223025479a0   \n",
+       "1802  c0da3fa83cd34379b49c56a33247910b   \n",
+       "1803  393e05923b7c4d289d305273b30a1ea3   \n",
        "\n",
        "                                                  title            owner  \\\n",
        "6                              Lambda requests on a map  amani_geosaurus   \n",
@@ -2546,21 +2546,21 @@
        "36                          Headless WebMap about Parks         andrew57   \n",
        "38                          National Levee Database Map         andrew57   \n",
        "46               VectorTileFromOtherSiteLayerandBasemap         andrew57   \n",
-       "191                      Brick Kilns around Jaipur 2019   api_data_owner   \n",
-       "192                      Brick Klinks around Delhi 2014   api_data_owner   \n",
-       "193                      Brick Klinks around Delhi 2019   api_data_owner   \n",
-       "506                                     Coastline_India   api_data_owner   \n",
-       "507                                  Coastline_India_l8   api_data_owner   \n",
-       "583                                          slums_2004   api_data_owner   \n",
-       "584                                          slums_2014   api_data_owner   \n",
-       "642                      Superresolution Inferenced Map   api_data_owner   \n",
-       "783                              Extracted land parcels   api_data_owner   \n",
-       "1263                                      USA_coastline   api_data_owner   \n",
-       "1476  Location Allocation example of Pizza Stores in...    arcgis_python   \n",
-       "1478                        Map_View_Google Drive Image    arcgis_python   \n",
-       "1480                                  Mobiliario Madrid    arcgis_python   \n",
-       "1800                                   wMap5_withCharts    arcgis_python   \n",
-       "1801                                            testing     DavidJVitale   \n",
+       "291                      Brick Kilns around Jaipur 2019   api_data_owner   \n",
+       "292                      Brick Klinks around Delhi 2014   api_data_owner   \n",
+       "293                      Brick Klinks around Delhi 2019   api_data_owner   \n",
+       "406                                     Coastline_India   api_data_owner   \n",
+       "407                                  Coastline_India_l8   api_data_owner   \n",
+       "483                                          slums_2004   api_data_owner   \n",
+       "484                                          slums_2014   api_data_owner   \n",
+       "542                      Superresolution Inferenced Map   api_data_owner   \n",
+       "823                                       USA_coastline   api_data_owner   \n",
+       "923                              Extracted land parcels   api_data_owner   \n",
+       "1376  Location Allocation example of Pizza Stores in...    arcgis_python   \n",
+       "1378                        Map_View_Google Drive Image    arcgis_python   \n",
+       "1380                                  Mobiliario Madrid    arcgis_python   \n",
+       "1802                                   wMap5_withCharts    arcgis_python   \n",
+       "1803                                            testing     DavidJVitale   \n",
        "\n",
        "         type  access  \n",
        "6     Web Map  public  \n",
@@ -2568,24 +2568,24 @@
        "36    Web Map  public  \n",
        "38    Web Map  public  \n",
        "46    Web Map  public  \n",
-       "191   Web Map  public  \n",
-       "192   Web Map  public  \n",
-       "193   Web Map  public  \n",
-       "506   Web Map  public  \n",
-       "507   Web Map  public  \n",
-       "583   Web Map  public  \n",
-       "584   Web Map  public  \n",
-       "642   Web Map  public  \n",
-       "783   Web Map  public  \n",
-       "1263  Web Map  public  \n",
-       "1476  Web Map  public  \n",
-       "1478  Web Map  public  \n",
-       "1480  Web Map  public  \n",
-       "1800  Web Map  public  \n",
-       "1801  Web Map  public  "
+       "291   Web Map  public  \n",
+       "292   Web Map  public  \n",
+       "293   Web Map  public  \n",
+       "406   Web Map  public  \n",
+       "407   Web Map  public  \n",
+       "483   Web Map  public  \n",
+       "484   Web Map  public  \n",
+       "542   Web Map  public  \n",
+       "823   Web Map  public  \n",
+       "923   Web Map  public  \n",
+       "1376  Web Map  public  \n",
+       "1378  Web Map  public  \n",
+       "1380  Web Map  public  \n",
+       "1802  Web Map  public  \n",
+       "1803  Web Map  public  "
       ]
      },
-     "execution_count": 32,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2601,7 +2601,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49f5fc4a",
+   "id": "fac763a2",
    "metadata": {},
    "source": [
     "The [.apply()](https://pandas.pydata.org/docs/reference/api/pandas.Series.apply.html) method can also be used to generate masks that can't be created using the standard comparison operators. As long as the function called within the apply method has a Boolean output, then the result can be used as a mask to filter rows. Here we use a [lambda](https://www.w3schools.com/python/python_lambda.asp) function to return all items which have a type that ends with the word \"Service\"."
@@ -2609,8 +2609,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "id": "4bc5ef6e",
+   "execution_count": 27,
+   "id": "7c2ae067",
    "metadata": {},
    "outputs": [
     {
@@ -2691,15 +2691,7 @@
        "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1827</th>\n",
-       "      <td>c4b35a4cd48b4cbbbc6dea300afed7f8</td>\n",
-       "      <td>UK_Primary_and_Secondary_Roads</td>\n",
-       "      <td>jyaist_geosaurus</td>\n",
-       "      <td>Feature Service</td>\n",
-       "      <td>org</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1828</th>\n",
+       "      <th>1830</th>\n",
        "      <td>f129290c5da14d7884b26951eddd6b29</td>\n",
        "      <td>KingCo_PropertyInfo</td>\n",
        "      <td>maggarwal_geosaurus</td>\n",
@@ -2707,7 +2699,15 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1831</th>\n",
+       "      <th>1832</th>\n",
+       "      <td>af59408fd19a4a1c99e14ff09967e394</td>\n",
+       "      <td>Uganda_Boundary</td>\n",
+       "      <td>maggarwal_geosaurus</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1834</th>\n",
        "      <td>42e944d92e1346f5a4229aa76841e5c2</td>\n",
        "      <td>Leaf_Pickup_Routes</td>\n",
        "      <td>naubry_geosaurus</td>\n",
@@ -2715,7 +2715,7 @@
        "      <td>org</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1834</th>\n",
+       "      <th>1837</th>\n",
        "      <td>1cc19cce694e4caf95ce4471befd55b7</td>\n",
        "      <td>Vexcel_Houston_Nadir</td>\n",
        "      <td>rohitgeo</td>\n",
@@ -2723,7 +2723,7 @@
        "      <td>public</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1843</th>\n",
+       "      <th>1846</th>\n",
        "      <td>b120ffa7170f4be0b5aaad8a284c6be5</td>\n",
        "      <td>Trailheads</td>\n",
        "      <td>yjiang_geosaurus</td>\n",
@@ -2732,7 +2732,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>450 rows × 5 columns</p>\n",
+       "<p>451 rows × 5 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -2743,11 +2743,11 @@
        "11    ffef49c345154bc5b24c8e2e39587ec4  Landfall Spotlight Article_WFL1   \n",
        "19    e0959e7018914be0931a9f15efb56c94                request_locations   \n",
        "...                                ...                              ...   \n",
-       "1827  c4b35a4cd48b4cbbbc6dea300afed7f8   UK_Primary_and_Secondary_Roads   \n",
-       "1828  f129290c5da14d7884b26951eddd6b29              KingCo_PropertyInfo   \n",
-       "1831  42e944d92e1346f5a4229aa76841e5c2               Leaf_Pickup_Routes   \n",
-       "1834  1cc19cce694e4caf95ce4471befd55b7             Vexcel_Houston_Nadir   \n",
-       "1843  b120ffa7170f4be0b5aaad8a284c6be5                       Trailheads   \n",
+       "1830  f129290c5da14d7884b26951eddd6b29              KingCo_PropertyInfo   \n",
+       "1832  af59408fd19a4a1c99e14ff09967e394                  Uganda_Boundary   \n",
+       "1834  42e944d92e1346f5a4229aa76841e5c2               Leaf_Pickup_Routes   \n",
+       "1837  1cc19cce694e4caf95ce4471befd55b7             Vexcel_Houston_Nadir   \n",
+       "1846  b120ffa7170f4be0b5aaad8a284c6be5                       Trailheads   \n",
        "\n",
        "                    owner             type  access  \n",
        "2         amani_geosaurus  Feature Service     org  \n",
@@ -2756,16 +2756,16 @@
        "11        amani_geosaurus  Feature Service  public  \n",
        "19        amani_geosaurus  Feature Service  public  \n",
        "...                   ...              ...     ...  \n",
-       "1827     jyaist_geosaurus  Feature Service     org  \n",
-       "1828  maggarwal_geosaurus  Feature Service  public  \n",
-       "1831     naubry_geosaurus  Feature Service     org  \n",
-       "1834             rohitgeo    Image Service  public  \n",
-       "1843     yjiang_geosaurus  Feature Service  public  \n",
+       "1830  maggarwal_geosaurus  Feature Service  public  \n",
+       "1832  maggarwal_geosaurus  Feature Service  public  \n",
+       "1834     naubry_geosaurus  Feature Service     org  \n",
+       "1837             rohitgeo    Image Service  public  \n",
+       "1846     yjiang_geosaurus  Feature Service  public  \n",
        "\n",
-       "[450 rows x 5 columns]"
+       "[451 rows x 5 columns]"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2779,7 +2779,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05a20701",
+   "id": "ce89cf6e",
    "metadata": {},
    "source": [
     "### Accessing Content by ID"
@@ -2787,7 +2787,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec8a7700",
+   "id": "b59f793b",
    "metadata": {},
    "source": [
     "Once we've identified an item of interest in our DataFrame, we can return the content of that item by providing its ID to the [ContentManager](https://pandas.pydata.org/docs/reference/api/pandas.Series.apply.html) .get() method. If we know the index of the object in the DataFrame (i.e. the leftmost value), then we can access that row's information using the .loc() method. From there we can get the id of the item and provide it to the get method."
@@ -2795,15 +2795,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
-   "id": "35621706",
+   "execution_count": 28,
+   "id": "27c0c0a2",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Target index: 1843\n"
+      "Target index: 1846\n"
      ]
     }
    ],
@@ -2817,8 +2817,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
-   "id": "1fd7594f",
+   "execution_count": 29,
+   "id": "a22bf3ef",
    "metadata": {},
    "outputs": [
     {
@@ -2852,7 +2852,7 @@
        "<Item title:\"Trailheads\" type:Feature Layer Collection owner:yjiang_geosaurus>"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2867,7 +2867,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6e5253b",
+   "id": "8438e2c2",
    "metadata": {},
    "source": [
     "For more information on using item ids, see this [community post](https://community.esri.com/t5/arcgis-online-blog/where-can-i-find-the-item-id-for-an-arcgis-online/ba-p/890284)."
@@ -2875,7 +2875,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d9fc08d",
+   "id": "1aa151f2",
    "metadata": {},
    "source": [
     "## Exporting Data"
@@ -2883,7 +2883,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf5d20c4",
+   "id": "704d5af6",
    "metadata": {},
    "source": [
     "Pandas provides a convenient [to_csv()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_csv.html) method which can be used to generate zipped and unzipped csv outputs. Simply provide your target path with the appropriate file extension and call the method on the DataFrame object you would like to export."
@@ -2891,8 +2891,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "id": "2e6f663e",
+   "execution_count": 30,
+   "id": "1c2defb6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2903,8 +2903,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
-   "id": "488b9fa5",
+   "execution_count": 31,
+   "id": "e713f62d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2915,8 +2915,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
-   "id": "cfb77f34",
+   "execution_count": 32,
+   "id": "7bc22234",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2927,11 +2927,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "07b3fb58",
+   "id": "060986ed",
    "metadata": {},
    "source": [
     "Pandas also provides additional methods for exporting the data as different file formats (e.g. [to_json()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html), [to_pickle()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_pickle.html), [to_excel()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_excel.html)) which behave similarly."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1208c3ac",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/guide/03-the-gis/organization-inventory.ipynb
+++ b/guide/03-the-gis/organization-inventory.ipynb
@@ -1,0 +1,2958 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6a058936",
+   "metadata": {},
+   "source": [
+    "Being able to retrieve, display, analyze, and export the content within an organization portal are important tasks for any admin. Here we will leverage the [ContentManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#contentmanager) and [UserManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#usermanager) classes of the GIS module, as well as some functionality from the [Pandas](https://pandas.pydata.org/docs/index.html) library, to accomplish those tasks.\n",
+    "\n",
+    "In this page we are going to observe how the following can be accomplished:\n",
+    "- [Import Libraries](#Import-Libraries)\n",
+    "- [Connect to ArcGIS Online](#Connect-to-ArcGIS-Online)\n",
+    "- [Querying Content](#Querying-Content)\n",
+    "    - [Searching for Content](#Searching-for-Content)\n",
+    "    - [Displaying Content](#Displaying-Content)\n",
+    "    - [Sorting Content](#Sorting-Content)\n",
+    "- [Querying Organization Content](#Querying-Organization-Content)\n",
+    "    - [Searching for Organization Members](#Searching-for-Organization-Members)\n",
+    "    - [Getting Member Content](#Getting-Member-Content)\n",
+    "    - [Compiling Organization Content](#Compiling-Organization-Content)\n",
+    "- [Analyzing Organization Content with Pandas](#Analyzing-Organization-Content-with-Pandas)\n",
+    "    - [Filtering the Dataset](#Filtering-the-Dataset)\n",
+    "    - [Accessing Content by ID](#Accessing-Content-by-ID)\n",
+    "- [Exporting Data](#Exporting-Data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57549875",
+   "metadata": {},
+   "source": [
+    "## Import Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "5961fffd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from IPython.display import display\n",
+    "\n",
+    "import arcgis\n",
+    "from arcgis.gis import GIS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8701fab9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'1.9.1'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "arcgis.__version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cdd15a5",
+   "metadata": {},
+   "source": [
+    "## Connect to ArcGIS Online"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2f532632",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"9item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/user.html?user=api_data_owner' target='_blank'>\n",
+       "                        <img src='https://geosaurus.maps.arcgis.com/home/js/arcgisonline/css/images/no-user-thumb.jpg' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\" style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/user.html?user=api_data_owner' target='_blank'><b>api_data owner</b>\n",
+       "                        </a>\n",
+       "                        <br/><br/><b>Bio</b>: None\n",
+       "                        <br/><b>First Name</b>: api_data\n",
+       "                        <br/><b>Last Name</b>: owner\n",
+       "                        <br/><b>Username</b>: api_data_owner\n",
+       "                        <br/><b>Joined</b>: April 10, 2019\n",
+       "\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<User username:api_data_owner>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "profile_name = \"my_dev_profile\"\n",
+    "\n",
+    "gis = GIS(profile=profile_name)\n",
+    "gis.users.me"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c03e96dd",
+   "metadata": {},
+   "source": [
+    "## Querying Content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5a612e8",
+   "metadata": {},
+   "source": [
+    "To search for content within our organization, we can access the [ContentManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager) class via gis.content. \n",
+    "\n",
+    "Using the [advanced_search()](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager.advanced_search) method, we can query content belonging to a user by providing the string \"owner: < username >\". By setting the return_count parameter of advanced_search to True, we can simply return a single integer representing the number of items which that user owns.\n",
+    "\n",
+    "Let's return the number of items that belong to the user currently logged in:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c8af0d28",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1240 items found for current user\n"
+     ]
+    }
+   ],
+   "source": [
+    "qe = f\"owner: {gis.users.me.username}\"\n",
+    "my_content_count = gis.content.advanced_search(query=qe,return_count=True)\n",
+    "print(my_content_count, 'items found for current user')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fdeff32",
+   "metadata": {},
+   "source": [
+    "### Searching for Content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e83d9594",
+   "metadata": {},
+   "source": [
+    "If we leave the return_count parameter as its default value False, then we will receive a response dictionary containing metadata about the query as well as a list of returned items in the 'results' field.\n",
+    "\n",
+    "By setting the max_items parameter, we can limit the number of items that are returned in the results field."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "5d37c709",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'query': 'owner: api_data_owner',\n",
+       " 'total': 1240,\n",
+       " 'start': 1,\n",
+       " 'num': 3,\n",
+       " 'nextStart': 4,\n",
+       " 'results': [<Item title:\" Exposing patterns in land fires around the globe \" type:StoryMap owner:api_data_owner>,\n",
+       "  <Item title:\" Exposing patterns in land fires around the globe \" type:StoryMap owner:api_data_owner>,\n",
+       "  <Item title:\" Exposing patterns in land fires around the globe \" type:StoryMap owner:api_data_owner>]}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "max_items = 3\n",
+    "user_content = gis.content.advanced_search(query=qe, max_items=max_items)\n",
+    "user_content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4430d775",
+   "metadata": {},
+   "source": [
+    "### Displaying Content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8883fcc4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=f1b6a842fbea45bca693c2fe6622bf70' target='_blank'>\n",
+       "                        <img src='data:image/png;base64,/9j/4AAQSkZJRgABAgAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCACFAMgDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDiPtSuBjgelXrZ+OBgVzsSsqgliau2l0Y2KsSeeK0A6OKQA89avLKAuWGKzbeWGRFO75jUz3AAPQjFFhpkk16oBUGohP8AL1zmsq4l3/OMDFVzdOqnB4rlnC7udEJWOiW5VT8xpXv06Zx7msEXhdAcHI702R3MYINQ4tPQ0TT3NlmQnJcc1PG6R5AbANYEEjFADnINXYS+75hk9ia1jHQiTNlZ03BcnkVctrgByM8VgRy73weCPar1vMF9jWUtHcpbHSJIrDitO32GAsG+YfrXPW82V+90qdbhvNAQk+wrmrxbV4vU0g1szUuboYxjnuaz/tDl/lwK1rC2N5w3y/UVX1LTmgfcAOODjvUU8M1rcbqrYgiuGPynk1LvOQKqRqVcdcmpyefpW8lyojcldMH5jwe9V2IDcc0+Z/3QGec1SMwVutclryuzVaIszSHygCeKoSyY6VJLPnvVRp1Y7ar2OpSqWGPL15py3LZVfzqnMcS4z70pfgFTz2q1TaLc00dFazY2jk0VV0mTzpRu7daKrkbOdyszy5ELAgn5fSnpGI26fjUcNxEpyT+tPa8gOQHGfTFexoedqa1tIsa471JPuMTZPFY41AQqPmUt25pF1cvuWQBs9D6UtA1LLTEgqx+Xsc1WmdScKwNU5pt7ZOQKhMzA5Aye1ZtGibNaJ8xjB5rStrfzY+WOccgDpXOwzuzg4xtresb4Ku1mw54HFEUr6jk2loaUduUVRsz2zTrgeWPkHIqeOZdoOcmoy4clnAx71s4qxipu+pFbqR8zdafErPcEBhgd6lM8SpjipbWKJfmBOc5Ncs4XdjpjPS5IILiMltwK4yMVqaXexQgrIpEjHrjtRJsNvkghAMhhVeEx3WoRYzknnFc86XK7o1VS61O4tHSJPlIAPI5qpfziU/M4GOKrjbbhfmyCeQe1QmPc2c5B5x6VtCJhJlWci3IIYsCfyoa7ixwetM1Rhb2251x/dPrVBf3lqNsZJ6sQOlZVaV5aGkKmmpbeXnPao2RZBuHX61BBICgAOTnBpZpkt0Y8D1pxpJIHUZA8vz7c5waYlvv3luCTxzVVrlWk3rye4qS4unih3Dg9qtQQnNla53W0mGbOaVd+0EH8Kzrq9lkkzKRwOMcVq6THLeR5Zdoxx70uTXQv2mhZtbl4JUkjOG70Ve/s/ERJ4ftRU+zYudM8mKF5NiLz6Uk0CIuCSHq/EUgAkxknvVW6ZZpA5ICnrXdy6HK5XY200xrpGkcfJ0GDjmiTRrpJwsQZ1IzurV0yWJSIgcZHArZEaRn69xWigmjNzaZxEiXEcoikQ7s4x61oJZv5Y4AOMnNaGsRIDHIzYIOQfWmx/vwEQZJ6+lQ4Wdi1PS5Rs4zvJYYIOKumLAyRVhrSWB0AQnPXAzii4heKHfIny9M5pcocxFHqDx4TIOOKk+3SPIqq3ynqfSsiWSNpVVSNxPNWynlBfLyfekmxtI3bO4iAEcmMn1rRh2RyffHPauUhaTO08kdzWtaE7wWJJz1qJu+xcFbc2Z7l5SoT7g4xSGVrVftUQw8fPenBggB4HNR6yXFlGIPvMP3gPpUcvcq5s6XdSapF5jy4HoK2bfbHcCIvx1OTXI+EbeW4dwCQQcnBr0KHQIJcXE0fmN2z2pxjoZzkrnN65FLf6vaWlvInlHaDnoMnrXeaT4dsoEAmPmAcY6VxOsQw6fq8TxRkBxnaGzgiuj0y/uJ0HlygY5+bpUaqTG9Yo1dc8L6fcWUv2aCKC4wCsijH5gda8Z1GG/uZ5IYgW2vsbb0yK9R1XxIqwPbHmV/l4PA47Vk6BpqQSZVQd3OcVo7ERujgXimgYwlCrYAIPWnSv5sW08Y5Irsdc0XdeSXUDNIoO35QTj6/ifaucvNFm+xGVCyyM2CDwTz/APqqlEOYxmtBPMgGevIU10UD/ZYkUEnHFYCQXUD7okOemN1aRin2rlunI5p8g+Y6JJVuY1bqgPze1FYtu0scDKA0ZI4J4BopqNtwueWpeiNfLfOOuamXEikuR/skd60YNMhkXJjBJ9TVe60mW1y8JJHZTVWZN0Ns4mLk5wQcitKS+kjRt8nTkZrIh+2nDLbOcHotQXFw8shRxsI6rjFNSsg5bstXF3JesBKfu9AOlT6fdNauQwHPQ+lZYZ+FXualjSaaQLEskjv0UDJNQ52d2aqHMrI7CC8+0Lxx6e9WZo/MiKuMgisCxuWtxHFeIYDjchkGNwBI4+hBH4VvRXkU8eIyHIGfl71rCSkro56kHB2aOY1OxCsTEuCTzUkAZI8TNgYGM1PPMJrhxtbgjKjgip4bZJpVYsFiXg7h/OpcdS4vTUgjni8wLkknvWxayxQLlyM+grO/su3uNTghVzEjkguOikc106+C9Vkt3NtLBcBQCrH5cjv+NYtWZrdWMx71ZDuCtgHAWo59WeSD7NDEWkYbWJ6in6fvtrjM1o0gDYK7e/ersmpRLckjSzFgjBQAk+maQmzT8Iv9ivkj8olpCA3y969TNxHFbF5GCBVyc+lea6bqNvCS6W7LLt4LMAPyzW9PLcw2UbNIbqRsHHADD1/WnC5lPcyfFMUd/cJPayOHXLHGcAcVJoVhraO0ySFICgHzjIb1xW14d1RJ2Npc2Xlnp8i8Z9wK1bmxungje0OEDEFenGf0q+VXJc2lY871zRdUt7xbh5xvl5DAYB7AEfhW34Qj1x7iRrsoIoU4ABBY/wD1v611TWX260EF5A0Ww4En38njnNVf7Pv9LV2gAlTJI7kjnFU4pdBc7aK+txuiK8BACH5kIwfr71Bp6w6nAsU2wM33fatJpo7m48u6iaN4/mJxycg4H6/pVWXS1hulktXZQF3YBz17D8jSlHqhxl0ZHdeCZWYSRxgpzkof19qzJfCF40m23k2J0O/nHfOfSu3tNVNhb28M0hbK7cjn5uMDPv61o3E1lOG3bVKgMQD1X/IzSUu49eh5y8V3FDIssUckYG3ZjnPfrRXUZSaBlVoycFBlskkDHPGQcjr7e9FbKxFzxRYUCBQuCTT5IFZsHgij95kFQeOhNLtkkfLMSehrFSZq0I1rEqNJuAyKoT6Ta3K+YIlLEcMODWg1i7htzkAeg602ON96quFXHT+daJvZkHG3VtJauQeQO9OinaCRGVxuGGDKehxW3qkSKpJdWbnOKxI4huUggF8jBHUd6xmkdNGT6bl+8kn1eSOWeXc69dznkk9cH174+pqbS7gRTLF5igg4XPcHkfzqukqQQsS3KAdu+4f0JrPyB86dAeBnpWdD3Ph2OrE8skubdnT3tkJiHjRkkyPmU/y/KoI7kQkQuuWPrTrC9Wa3EMsjBwR1Ga0Vs4bmYLtEhGMOvAI6/nXU6kXscPs5R3GWVsk1xE8gjyjH5WJ69K9L0rUZbCMq8YNvwBjoBiuNg8LiRRKkrRqMfMB0J4wf0rXhuZ9EiENw6TQmPaJVPAHTGPyqHDm1CUtLHoFnbafqeliLyY8svzAcE5681zr+ELxdblntWRoCM7VOCeo/Pg1Z0zW9IuLYbHFrOg274vlXPHUdKutqdzp8zTRCO4LDChflIxk59OeKhR1M3JrQqSW0kc8Mb6Zvz6IG71abTIxKlwsTCTGNrAjg+lXLPxbYXEypcxzQzcgeYhGc44B6VuQ6tYSMELryQAG/Cq5lsTyvc5y007yb0MwTCn5SeMe3/wCutgzLaBImBeNt5J7gkg/1P5VrPp1pcAuiKCecjvWPc2ktnctIMFM8jHHTv+VVpJE6xJG1KJAoZh5ZIU7z6kCri2kas1zbyZ3KAQT6ZP8AWuI1RjEj+TtEvnM6ROcDGSc/hxVPTvE9xHcoZFMa4XeuD97OevpjtSfu6NlKDlrFHYXcIiEjso3HAKEDBH+Tj8qxPsskMri3fy2ds4bpk5OPpzWwmt2OrBUDjc0fOD0JOBWFqt+NHaVrqRWi2blc+uOP/QT+Vapq2pCjJysisl27TulxnIcruQcDB6c8jmkmuIYGASUmTDMyJnJwcdOnpWLDqfl2umxo6zyz/LIQc4+XOTn3K8/XOawfEOqp/aNskMqSRJZoXI67mBI688DmspTS2OmNO8ddyfUPFN9baTGyNmFZhskVeNwwzDPBPzEdfT04JWTo+spf250WWNFguZWeEuu5kXnoT0bgDjuc0VKvJXTIdlo0bdlYpNabimcE5ANUpoI4JCSQvPfinWHiCERBU+cnutUL63uL9/PyVBO4AnvVqDByuXCgl2qMjuDWdf20gfO4BF/DNdDptq5t1aYKu0DJzwauzaVazxBUwWb371T21IW55zJaJNOFZwFY92waQ6DdyzGOzXzNy70P90jqPxr0zT/Ay3EokYYXOckYrsNN8O6bp8gTygGK4yT1rF2asdEZ8jufOOr6ZqVg6xXqMgkw4AOQcDGf6/jTtGjY6hDbxlVkkB2tJ91TjIP6V7t4r8L2F7bAsqqEyQQMEnHSvLLnw4LO5MkYKFP9Ww7Hsf5UvZ6aCdd8yZRla1uY5Xkjit54X+fB5bkDGPX1xWnZmOYYlJCPny5g2T7E89B7etZlxZulpdRtagvKR8wOAo/r2qPS7/7HpLQyxFghYghc4PUD9GzXHOM47HYqlOVuZ6/rc66TVZLPZFNFksMOUyeRnP5cVTtb172b7MJS0Ry4YsFIAyCDnGPrnvWRHr9ss5z/AKkg53pjaxGOPbnOR+VW4J7NFzH5cZulYIEBIX5Og9gSDjryKzlVqRi00dMI0ak1Z28iczm0mAhfdv2hG3dcnHIPc4P/AOuri+IvLUSROVlXgxvyuMY4PBHGPzH4YeoatafZg80YN0RgKMDZ19O4GeR3PasmS4jlughdm3R4Ulj1Ix29Mn8q1pVKijeSOWvGk52gdhdeKJ5o/PtZmBRQWTOSBnk8deg/M1Po3jrMiLfAtBM5G5OW6En045H6Vxkl7A8wlQyLDbKIztwplUlgGP8ALGOwq3rdhHaxrc6U6G1t28woQGJ3DqMjlSM9eKqUpy6ihCEL31Xl/XqesDxXqfh9IJWRLzT2Ub5o5dwj5APatm78aW8uj3N0q7yuRsbjcASMZ9+ma8O07xQy6De2MrqI5lRVQDGMnJ6fn9OPYyprsz6FJAoZfNuWlUHJYxlGxyf93sRk1HtakWrIfsaU023rbQ9O1DxBbXCWxlTyyLbz0yclSQfl9+n41x91c3d1aLcxuI5n5McZxtfHAGfTB6etYY10mS0lv0V0MCIMHnaCyjOeBz9O1dLpMtrqnlhLiOMtMrEtwFUKNw/HB9K6ov2kbs5qkfYysjGvNYulFpJA8kJl8yN1XjIViR16dfr37jL9Y8Q3NxAltqZ4SNTsYEMWKcE89ff3rqtd8OklFmRIreNyqFRjGRjJ/Hv9O9eYeILO5W8u3ubgyGFwiuBy+PkU9v7vJ/nxSUZw91lSlTn78fuLD608dlCllLsuI02Hp8zE4wD9P5UnnQXWnajcysEnCRx28aeq4Aye/CufwHrisJvKMoAYr84xxkE/0okiktdgdsYO3Cc8ev8A49ilFcuhM58+ttS3ayCxMc3mKXZTtAYHaemDg8HPOKKrboZkYSfIqYVNvUkegooRF7mtZag9qwUoOvXvXZ6Qs15DkhXUDK4ODmvNFvw0AVo8uP4s9a7fw1qy2cCNg4PDAmuuMrmckdLcloLaPMZyzfMFGTW1pIF4nzB02csWTGKbbanBNEp2oR1G0c1s2P2aV0kndjyMgdKcldEppG7p9kYoyTMrAcYU5xVPU70Wmo2AliDp5u9Sf4SBjP8A49j8TWii2CuFhlRW7LnrmprjTkkCvw7D+9WFrFN31MLxOfNslu4V3rgcDu2M/wCf854O4kDbhJAQpzx1NepyGEMYXwmRx2BNcbeWdpvmQH7rEcjmtYPoRLuclJbJK+x8KhGcGsm70spFJAo2xt12jqTx/U/rXTT2qRgr5uQQcHvVSVxMFUg5Hyg0pQT0HGVtTkE0ONrkh5Mom11zg5+XDKT+A/OpEha1Tf5cTLG/yqHOVBxnHtxW88aqpKkMuOoHaqsCeZHIHI5GCMdf8msXS0NOfU4FpnF00chY7ZMH14P/AOurl4Eja0dXVdoVC3GeO+PpitTUIJbO+ilj2IjNuZtgyRnJ5P8AWucu3Rrt0QFtnUseRwPw4OalrWxSd0aN9cu8k8kqIVljC5x/t7s59Qcj6UrrMGSytpSzSxKoZ24w4GevQYNUoZmuII0cjAbamV9f/wBR/OpvPFzdRKi+Xt8sckkKcc/me3FSr/MaZDKptw6zRI3l5hbkZ3YIH5cflV2OQR28chOXtQzBGBw/I4x1x/KomjaWSQMPuyETNnOcnB9+eRn3qVIGFkWMmRtO89zuKj+h/E0+XuCk73GI8yJ9rKBlCHecdN3A47AdPr9aSO9ltpZVjyE8pflA65wD/n6VDaCWWB7UyAGeRUAbnccj2pJ5TtYhCjrbgMCOQQ/H4j+lFrDbvuepeGvGv9pQx6PriLLHcQ8zuMujHAHJ+n1zisPxZaW2hJf6Xdzx3lwmJIZVXbkMQcn06g4/yeO06dVYsATKsQCZOVBGT+eD+f51DqWoSXt7JNdSmQkBeeSQBx/L+VWpO1jNws7oglLmMMAcBwicccA5/wD11pXUTqEYgu5jOeOrEDp+PNUplRY49m4xlCVJHQbsfT/P41LLdkQkMvWNycHjngfXp+lTYopJGhAYuQykkgDPYd+n+e9FLIxCoGUIWDNu6Zyew7dDiiqAmeGIF41XLq/y47r6fWu50WwjS2VZI8Nt+UmuQezY3XmRxnbkE7f516t4asG1KyWRwNoAG41dN3Qp6FC0SZAwQA7TheMc1cg1FxMYpjKnAySOB7108OhL98J5hJ+6Bmn6hpduE85bAlwuDGAMGuhR7GLkupjySylraWzu45Zg4GxWGR74711+lX1x5MlvcDybmMblJHDDGRXC39vObUlLYwsnzgLwRjuKks/GhW2VdTjbzYx99MAzDtwf4h655rOpDQcWbmpeJIZlWb5d3Rh0wehH9fx9qy1uLbVhNLbON+MABscjjj16Vz/iOWyngfUtOuPNtrhRvJGNrcAhu4bp/OuX0nVLnTy+1wrA5yeRUwaKnFnVX1xcQKolBzyu4dKzhdKIEiZsHGC3rXQ6RqFpqlk0eoMnmoflZh976YrjtZt47S6uo1dgsbncpzwOxH48VUmkRFM0bDzYPMikOcklfcVca2R1ZY8BiDle+a4v+27iOWJd+UAIJz0HGP611ekajHJPKzqdpHyH2P8AkVnzu9i+XqQX4VEtozCZZF6ZGQOef61k3mj21tEbqLEUvIwc857fnXT3LQFBISA+fzrIuUeRpMhXJ5wee1DimF2cYpiSGFVXa376MDPPzDjP/fVPNpeQXMMYkRZJmDIN27aQSOf88+9XL2BRfb4rZhGGyQfyP6CsuG/mNxC5HMTFlBP3effr29+Kykn0NE0wmSW0u2haPy2UAuobIxx/9Y/jV7TbozrJCU3EqCQeQeen6is25kWe4kY5YqhUHrgDp/LFXLe3ncb4toMyhBGvynIAOfT6UX01D0JoLN5EdomU4O9VDAHdweufTIx7VQjGZ2jkBBdRGFb8ufTpV5jLprGKbcrsw+UewxtP06/lVfz47+4jglHyl/kaM9zgd/pT3AfDLFb2sccsZKYckE9SQP58VUmiVVVAodwjEbhjIyef5n8qZtZFUNCxJG5WI5Iye350+fzPNRgGCCFRn8O/akBO6RzJCFkAeGHGwnAJyT9P8inXDoEaNWLbRsQBef8Aa7enXBqqiPJMgboFZQI1ycAeg60RLlyEG6dcKvv64/Wi12BYuWjb90qgsAFUA8AZyfpz+lFL5AmuC0biNNu5Sx6NjJ/kfzoqXoBvaewDxEKMMSu08jqRXoVrftp1ibe3QDYu7OTzRRVYYdQt2HjG9hjy0UTg8LntVxdbudSiMmFjUkoVHP4g0UV3UtTlqKxZu9PE9sxknkxtJODgniuA8UeH105Eu4rqRnkOQHAIX0+tFFOa0FBu5yd5LLpUs9vFJuiuEV3Q/dOfb29azLa5lWNGYhlcEbSOmKKK4o6XOybukdHa3Ti3VV4GT/OrerRh7dZhkNtC/gKKK6I6rU5nozlXg/eFyxJJ5966Ow/dRDbwSct70UVnbUtbGvAu+E5wSUyMjpWXLO8UvYlzgnpRRVpJLQl7lu2jUsUcbljdSAe+TyDUOsaJa232i4gXZJsJzjsQwI+nI/Kiis2tGadjjS5Se3C4DIAm5Rgnnv8AgMVpXN7NBG1zGdmJBuVDtzt3jr24Uf8A66KKwS1LWxmTXLPZ28ko8yWRmcsxPXOPqfuiqj5tpo/LYghQ2R6kdvTrRRVoRakkMqxI+dsca8Dv/nNM1G5kKWsIOFMCkgd+f/1UUUD6FmxhBnCZ+aJtgLDIPXt9aqMv2ezWWM/vHGGb13Fh/JRRRUrcRDCga4ZMnAIUZ574/wAfzoooqm9Rn//Z' width='200' height='133' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=f1b6a842fbea45bca693c2fe6622bf70' target='_blank'><b> Exposing patterns in land fires around the globe </b>\n",
+       "                        </a>\n",
+       "                        <br/>This story map analyzes global patterns in wildfires using spatial analysis tools in ArcGIS Pro with satellite thermal data. <img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">StoryMap by api_data_owner\n",
+       "                        <br/>Last Modified: January 12, 2021\n",
+       "                        <br/>0 comments, 1 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\" Exposing patterns in land fires around the globe \" type:StoryMap owner:api_data_owner>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=fb2cdb23cece4c49a28e928d70511aa7' target='_blank'>\n",
+       "                        <img src='data:image/png;base64,/9j/4AAQSkZJRgABAgAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCACFAMgDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDiPtSuBjgelXrZ+OBgVzsSsqgliau2l0Y2KsSeeK0A6OKQA89avLKAuWGKzbeWGRFO75jUz3AAPQjFFhpkk16oBUGohP8AL1zmsq4l3/OMDFVzdOqnB4rlnC7udEJWOiW5VT8xpXv06Zx7msEXhdAcHI702R3MYINQ4tPQ0TT3NlmQnJcc1PG6R5AbANYEEjFADnINXYS+75hk9ia1jHQiTNlZ03BcnkVctrgByM8VgRy73weCPar1vMF9jWUtHcpbHSJIrDitO32GAsG+YfrXPW82V+90qdbhvNAQk+wrmrxbV4vU0g1szUuboYxjnuaz/tDl/lwK1rC2N5w3y/UVX1LTmgfcAOODjvUU8M1rcbqrYgiuGPynk1LvOQKqRqVcdcmpyefpW8lyojcldMH5jwe9V2IDcc0+Z/3QGec1SMwVutclryuzVaIszSHygCeKoSyY6VJLPnvVRp1Y7ar2OpSqWGPL15py3LZVfzqnMcS4z70pfgFTz2q1TaLc00dFazY2jk0VV0mTzpRu7daKrkbOdyszy5ELAgn5fSnpGI26fjUcNxEpyT+tPa8gOQHGfTFexoedqa1tIsa471JPuMTZPFY41AQqPmUt25pF1cvuWQBs9D6UtA1LLTEgqx+Xsc1WmdScKwNU5pt7ZOQKhMzA5Aye1ZtGibNaJ8xjB5rStrfzY+WOccgDpXOwzuzg4xtresb4Ku1mw54HFEUr6jk2loaUduUVRsz2zTrgeWPkHIqeOZdoOcmoy4clnAx71s4qxipu+pFbqR8zdafErPcEBhgd6lM8SpjipbWKJfmBOc5Ncs4XdjpjPS5IILiMltwK4yMVqaXexQgrIpEjHrjtRJsNvkghAMhhVeEx3WoRYzknnFc86XK7o1VS61O4tHSJPlIAPI5qpfziU/M4GOKrjbbhfmyCeQe1QmPc2c5B5x6VtCJhJlWci3IIYsCfyoa7ixwetM1Rhb2251x/dPrVBf3lqNsZJ6sQOlZVaV5aGkKmmpbeXnPao2RZBuHX61BBICgAOTnBpZpkt0Y8D1pxpJIHUZA8vz7c5waYlvv3luCTxzVVrlWk3rye4qS4unih3Dg9qtQQnNla53W0mGbOaVd+0EH8Kzrq9lkkzKRwOMcVq6THLeR5Zdoxx70uTXQv2mhZtbl4JUkjOG70Ve/s/ERJ4ftRU+zYudM8mKF5NiLz6Uk0CIuCSHq/EUgAkxknvVW6ZZpA5ICnrXdy6HK5XY200xrpGkcfJ0GDjmiTRrpJwsQZ1IzurV0yWJSIgcZHArZEaRn69xWigmjNzaZxEiXEcoikQ7s4x61oJZv5Y4AOMnNaGsRIDHIzYIOQfWmx/vwEQZJ6+lQ4Wdi1PS5Rs4zvJYYIOKumLAyRVhrSWB0AQnPXAzii4heKHfIny9M5pcocxFHqDx4TIOOKk+3SPIqq3ynqfSsiWSNpVVSNxPNWynlBfLyfekmxtI3bO4iAEcmMn1rRh2RyffHPauUhaTO08kdzWtaE7wWJJz1qJu+xcFbc2Z7l5SoT7g4xSGVrVftUQw8fPenBggB4HNR6yXFlGIPvMP3gPpUcvcq5s6XdSapF5jy4HoK2bfbHcCIvx1OTXI+EbeW4dwCQQcnBr0KHQIJcXE0fmN2z2pxjoZzkrnN65FLf6vaWlvInlHaDnoMnrXeaT4dsoEAmPmAcY6VxOsQw6fq8TxRkBxnaGzgiuj0y/uJ0HlygY5+bpUaqTG9Yo1dc8L6fcWUv2aCKC4wCsijH5gda8Z1GG/uZ5IYgW2vsbb0yK9R1XxIqwPbHmV/l4PA47Vk6BpqQSZVQd3OcVo7ERujgXimgYwlCrYAIPWnSv5sW08Y5Irsdc0XdeSXUDNIoO35QTj6/ifaucvNFm+xGVCyyM2CDwTz/APqqlEOYxmtBPMgGevIU10UD/ZYkUEnHFYCQXUD7okOemN1aRin2rlunI5p8g+Y6JJVuY1bqgPze1FYtu0scDKA0ZI4J4BopqNtwueWpeiNfLfOOuamXEikuR/skd60YNMhkXJjBJ9TVe60mW1y8JJHZTVWZN0Ns4mLk5wQcitKS+kjRt8nTkZrIh+2nDLbOcHotQXFw8shRxsI6rjFNSsg5bstXF3JesBKfu9AOlT6fdNauQwHPQ+lZYZ+FXualjSaaQLEskjv0UDJNQ52d2aqHMrI7CC8+0Lxx6e9WZo/MiKuMgisCxuWtxHFeIYDjchkGNwBI4+hBH4VvRXkU8eIyHIGfl71rCSkro56kHB2aOY1OxCsTEuCTzUkAZI8TNgYGM1PPMJrhxtbgjKjgip4bZJpVYsFiXg7h/OpcdS4vTUgjni8wLkknvWxayxQLlyM+grO/su3uNTghVzEjkguOikc106+C9Vkt3NtLBcBQCrH5cjv+NYtWZrdWMx71ZDuCtgHAWo59WeSD7NDEWkYbWJ6in6fvtrjM1o0gDYK7e/ersmpRLckjSzFgjBQAk+maQmzT8Iv9ivkj8olpCA3y969TNxHFbF5GCBVyc+lea6bqNvCS6W7LLt4LMAPyzW9PLcw2UbNIbqRsHHADD1/WnC5lPcyfFMUd/cJPayOHXLHGcAcVJoVhraO0ySFICgHzjIb1xW14d1RJ2Npc2Xlnp8i8Z9wK1bmxungje0OEDEFenGf0q+VXJc2lY871zRdUt7xbh5xvl5DAYB7AEfhW34Qj1x7iRrsoIoU4ABBY/wD1v611TWX260EF5A0Ww4En38njnNVf7Pv9LV2gAlTJI7kjnFU4pdBc7aK+txuiK8BACH5kIwfr71Bp6w6nAsU2wM33fatJpo7m48u6iaN4/mJxycg4H6/pVWXS1hulktXZQF3YBz17D8jSlHqhxl0ZHdeCZWYSRxgpzkof19qzJfCF40m23k2J0O/nHfOfSu3tNVNhb28M0hbK7cjn5uMDPv61o3E1lOG3bVKgMQD1X/IzSUu49eh5y8V3FDIssUckYG3ZjnPfrRXUZSaBlVoycFBlskkDHPGQcjr7e9FbKxFzxRYUCBQuCTT5IFZsHgij95kFQeOhNLtkkfLMSehrFSZq0I1rEqNJuAyKoT6Ta3K+YIlLEcMODWg1i7htzkAeg602ON96quFXHT+daJvZkHG3VtJauQeQO9OinaCRGVxuGGDKehxW3qkSKpJdWbnOKxI4huUggF8jBHUd6xmkdNGT6bl+8kn1eSOWeXc69dznkk9cH174+pqbS7gRTLF5igg4XPcHkfzqukqQQsS3KAdu+4f0JrPyB86dAeBnpWdD3Ph2OrE8skubdnT3tkJiHjRkkyPmU/y/KoI7kQkQuuWPrTrC9Wa3EMsjBwR1Ga0Vs4bmYLtEhGMOvAI6/nXU6kXscPs5R3GWVsk1xE8gjyjH5WJ69K9L0rUZbCMq8YNvwBjoBiuNg8LiRRKkrRqMfMB0J4wf0rXhuZ9EiENw6TQmPaJVPAHTGPyqHDm1CUtLHoFnbafqeliLyY8svzAcE5681zr+ELxdblntWRoCM7VOCeo/Pg1Z0zW9IuLYbHFrOg274vlXPHUdKutqdzp8zTRCO4LDChflIxk59OeKhR1M3JrQqSW0kc8Mb6Zvz6IG71abTIxKlwsTCTGNrAjg+lXLPxbYXEypcxzQzcgeYhGc44B6VuQ6tYSMELryQAG/Cq5lsTyvc5y007yb0MwTCn5SeMe3/wCutgzLaBImBeNt5J7gkg/1P5VrPp1pcAuiKCecjvWPc2ktnctIMFM8jHHTv+VVpJE6xJG1KJAoZh5ZIU7z6kCri2kas1zbyZ3KAQT6ZP8AWuI1RjEj+TtEvnM6ROcDGSc/hxVPTvE9xHcoZFMa4XeuD97OevpjtSfu6NlKDlrFHYXcIiEjso3HAKEDBH+Tj8qxPsskMri3fy2ds4bpk5OPpzWwmt2OrBUDjc0fOD0JOBWFqt+NHaVrqRWi2blc+uOP/QT+Vapq2pCjJysisl27TulxnIcruQcDB6c8jmkmuIYGASUmTDMyJnJwcdOnpWLDqfl2umxo6zyz/LIQc4+XOTn3K8/XOawfEOqp/aNskMqSRJZoXI67mBI688DmspTS2OmNO8ddyfUPFN9baTGyNmFZhskVeNwwzDPBPzEdfT04JWTo+spf250WWNFguZWeEuu5kXnoT0bgDjuc0VKvJXTIdlo0bdlYpNabimcE5ANUpoI4JCSQvPfinWHiCERBU+cnutUL63uL9/PyVBO4AnvVqDByuXCgl2qMjuDWdf20gfO4BF/DNdDptq5t1aYKu0DJzwauzaVazxBUwWb371T21IW55zJaJNOFZwFY92waQ6DdyzGOzXzNy70P90jqPxr0zT/Ay3EokYYXOckYrsNN8O6bp8gTygGK4yT1rF2asdEZ8jufOOr6ZqVg6xXqMgkw4AOQcDGf6/jTtGjY6hDbxlVkkB2tJ91TjIP6V7t4r8L2F7bAsqqEyQQMEnHSvLLnw4LO5MkYKFP9Ww7Hsf5UvZ6aCdd8yZRla1uY5Xkjit54X+fB5bkDGPX1xWnZmOYYlJCPny5g2T7E89B7etZlxZulpdRtagvKR8wOAo/r2qPS7/7HpLQyxFghYghc4PUD9GzXHOM47HYqlOVuZ6/rc66TVZLPZFNFksMOUyeRnP5cVTtb172b7MJS0Ry4YsFIAyCDnGPrnvWRHr9ss5z/AKkg53pjaxGOPbnOR+VW4J7NFzH5cZulYIEBIX5Og9gSDjryKzlVqRi00dMI0ak1Z28iczm0mAhfdv2hG3dcnHIPc4P/AOuri+IvLUSROVlXgxvyuMY4PBHGPzH4YeoatafZg80YN0RgKMDZ19O4GeR3PasmS4jlughdm3R4Ulj1Ix29Mn8q1pVKijeSOWvGk52gdhdeKJ5o/PtZmBRQWTOSBnk8deg/M1Po3jrMiLfAtBM5G5OW6En045H6Vxkl7A8wlQyLDbKIztwplUlgGP8ALGOwq3rdhHaxrc6U6G1t28woQGJ3DqMjlSM9eKqUpy6ihCEL31Xl/XqesDxXqfh9IJWRLzT2Ub5o5dwj5APatm78aW8uj3N0q7yuRsbjcASMZ9+ma8O07xQy6De2MrqI5lRVQDGMnJ6fn9OPYyprsz6FJAoZfNuWlUHJYxlGxyf93sRk1HtakWrIfsaU023rbQ9O1DxBbXCWxlTyyLbz0yclSQfl9+n41x91c3d1aLcxuI5n5McZxtfHAGfTB6etYY10mS0lv0V0MCIMHnaCyjOeBz9O1dLpMtrqnlhLiOMtMrEtwFUKNw/HB9K6ov2kbs5qkfYysjGvNYulFpJA8kJl8yN1XjIViR16dfr37jL9Y8Q3NxAltqZ4SNTsYEMWKcE89ff3rqtd8OklFmRIreNyqFRjGRjJ/Hv9O9eYeILO5W8u3ubgyGFwiuBy+PkU9v7vJ/nxSUZw91lSlTn78fuLD608dlCllLsuI02Hp8zE4wD9P5UnnQXWnajcysEnCRx28aeq4Aye/CufwHrisJvKMoAYr84xxkE/0okiktdgdsYO3Cc8ev8A49ilFcuhM58+ttS3ayCxMc3mKXZTtAYHaemDg8HPOKKrboZkYSfIqYVNvUkegooRF7mtZag9qwUoOvXvXZ6Qs15DkhXUDK4ODmvNFvw0AVo8uP4s9a7fw1qy2cCNg4PDAmuuMrmckdLcloLaPMZyzfMFGTW1pIF4nzB02csWTGKbbanBNEp2oR1G0c1s2P2aV0kndjyMgdKcldEppG7p9kYoyTMrAcYU5xVPU70Wmo2AliDp5u9Sf4SBjP8A49j8TWii2CuFhlRW7LnrmprjTkkCvw7D+9WFrFN31MLxOfNslu4V3rgcDu2M/wCf854O4kDbhJAQpzx1NepyGEMYXwmRx2BNcbeWdpvmQH7rEcjmtYPoRLuclJbJK+x8KhGcGsm70spFJAo2xt12jqTx/U/rXTT2qRgr5uQQcHvVSVxMFUg5Hyg0pQT0HGVtTkE0ONrkh5Mom11zg5+XDKT+A/OpEha1Tf5cTLG/yqHOVBxnHtxW88aqpKkMuOoHaqsCeZHIHI5GCMdf8msXS0NOfU4FpnF00chY7ZMH14P/AOurl4Eja0dXVdoVC3GeO+PpitTUIJbO+ilj2IjNuZtgyRnJ5P8AWucu3Rrt0QFtnUseRwPw4OalrWxSd0aN9cu8k8kqIVljC5x/t7s59Qcj6UrrMGSytpSzSxKoZ24w4GevQYNUoZmuII0cjAbamV9f/wBR/OpvPFzdRKi+Xt8sckkKcc/me3FSr/MaZDKptw6zRI3l5hbkZ3YIH5cflV2OQR28chOXtQzBGBw/I4x1x/KomjaWSQMPuyETNnOcnB9+eRn3qVIGFkWMmRtO89zuKj+h/E0+XuCk73GI8yJ9rKBlCHecdN3A47AdPr9aSO9ltpZVjyE8pflA65wD/n6VDaCWWB7UyAGeRUAbnccj2pJ5TtYhCjrbgMCOQQ/H4j+lFrDbvuepeGvGv9pQx6PriLLHcQ8zuMujHAHJ+n1zisPxZaW2hJf6Xdzx3lwmJIZVXbkMQcn06g4/yeO06dVYsATKsQCZOVBGT+eD+f51DqWoSXt7JNdSmQkBeeSQBx/L+VWpO1jNws7oglLmMMAcBwicccA5/wD11pXUTqEYgu5jOeOrEDp+PNUplRY49m4xlCVJHQbsfT/P41LLdkQkMvWNycHjngfXp+lTYopJGhAYuQykkgDPYd+n+e9FLIxCoGUIWDNu6Zyew7dDiiqAmeGIF41XLq/y47r6fWu50WwjS2VZI8Nt+UmuQezY3XmRxnbkE7f516t4asG1KyWRwNoAG41dN3Qp6FC0SZAwQA7TheMc1cg1FxMYpjKnAySOB7108OhL98J5hJ+6Bmn6hpduE85bAlwuDGAMGuhR7GLkupjySylraWzu45Zg4GxWGR74711+lX1x5MlvcDybmMblJHDDGRXC39vObUlLYwsnzgLwRjuKks/GhW2VdTjbzYx99MAzDtwf4h655rOpDQcWbmpeJIZlWb5d3Rh0wehH9fx9qy1uLbVhNLbON+MABscjjj16Vz/iOWyngfUtOuPNtrhRvJGNrcAhu4bp/OuX0nVLnTy+1wrA5yeRUwaKnFnVX1xcQKolBzyu4dKzhdKIEiZsHGC3rXQ6RqFpqlk0eoMnmoflZh976YrjtZt47S6uo1dgsbncpzwOxH48VUmkRFM0bDzYPMikOcklfcVca2R1ZY8BiDle+a4v+27iOWJd+UAIJz0HGP611ekajHJPKzqdpHyH2P8AkVnzu9i+XqQX4VEtozCZZF6ZGQOef61k3mj21tEbqLEUvIwc857fnXT3LQFBISA+fzrIuUeRpMhXJ5wee1DimF2cYpiSGFVXa376MDPPzDjP/fVPNpeQXMMYkRZJmDIN27aQSOf88+9XL2BRfb4rZhGGyQfyP6CsuG/mNxC5HMTFlBP3effr29+Kykn0NE0wmSW0u2haPy2UAuobIxx/9Y/jV7TbozrJCU3EqCQeQeen6is25kWe4kY5YqhUHrgDp/LFXLe3ncb4toMyhBGvynIAOfT6UX01D0JoLN5EdomU4O9VDAHdweufTIx7VQjGZ2jkBBdRGFb8ufTpV5jLprGKbcrsw+UewxtP06/lVfz47+4jglHyl/kaM9zgd/pT3AfDLFb2sccsZKYckE9SQP58VUmiVVVAodwjEbhjIyef5n8qZtZFUNCxJG5WI5Iye350+fzPNRgGCCFRn8O/akBO6RzJCFkAeGHGwnAJyT9P8inXDoEaNWLbRsQBef8Aa7enXBqqiPJMgboFZQI1ycAeg60RLlyEG6dcKvv64/Wi12BYuWjb90qgsAFUA8AZyfpz+lFL5AmuC0biNNu5Sx6NjJ/kfzoqXoBvaewDxEKMMSu08jqRXoVrftp1ibe3QDYu7OTzRRVYYdQt2HjG9hjy0UTg8LntVxdbudSiMmFjUkoVHP4g0UV3UtTlqKxZu9PE9sxknkxtJODgniuA8UeH105Eu4rqRnkOQHAIX0+tFFOa0FBu5yd5LLpUs9vFJuiuEV3Q/dOfb29azLa5lWNGYhlcEbSOmKKK4o6XOybukdHa3Ti3VV4GT/OrerRh7dZhkNtC/gKKK6I6rU5nozlXg/eFyxJJ5966Ow/dRDbwSct70UVnbUtbGvAu+E5wSUyMjpWXLO8UvYlzgnpRRVpJLQl7lu2jUsUcbljdSAe+TyDUOsaJa232i4gXZJsJzjsQwI+nI/Kiis2tGadjjS5Se3C4DIAm5Rgnnv8AgMVpXN7NBG1zGdmJBuVDtzt3jr24Uf8A66KKwS1LWxmTXLPZ28ko8yWRmcsxPXOPqfuiqj5tpo/LYghQ2R6kdvTrRRVoRakkMqxI+dsca8Dv/nNM1G5kKWsIOFMCkgd+f/1UUUD6FmxhBnCZ+aJtgLDIPXt9aqMv2ezWWM/vHGGb13Fh/JRRRUrcRDCga4ZMnAIUZ574/wAfzoooqm9Rn//Z' width='200' height='133' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=fb2cdb23cece4c49a28e928d70511aa7' target='_blank'><b> Exposing patterns in land fires around the globe </b>\n",
+       "                        </a>\n",
+       "                        <br/> This story map analyses global patterns in wildfires using spatial analysis tools in ArcGIS Pro with satellite thermal data . <img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">StoryMap by api_data_owner\n",
+       "                        <br/>Last Modified: January 13, 2021\n",
+       "                        <br/>0 comments, 1 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\" Exposing patterns in land fires around the globe \" type:StoryMap owner:api_data_owner>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=7bfce9c3f0734d5896584b21d8fc2ba9' target='_blank'>\n",
+       "                        <img src='data:image/png;base64,/9j/4AAQSkZJRgABAgAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCACFAMgDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDiPtSuBjgelXrZ+OBgVzsSsqgliau2l0Y2KsSeeK0A6OKQA89avLKAuWGKzbeWGRFO75jUz3AAPQjFFhpkk16oBUGohP8AL1zmsq4l3/OMDFVzdOqnB4rlnC7udEJWOiW5VT8xpXv06Zx7msEXhdAcHI702R3MYINQ4tPQ0TT3NlmQnJcc1PG6R5AbANYEEjFADnINXYS+75hk9ia1jHQiTNlZ03BcnkVctrgByM8VgRy73weCPar1vMF9jWUtHcpbHSJIrDitO32GAsG+YfrXPW82V+90qdbhvNAQk+wrmrxbV4vU0g1szUuboYxjnuaz/tDl/lwK1rC2N5w3y/UVX1LTmgfcAOODjvUU8M1rcbqrYgiuGPynk1LvOQKqRqVcdcmpyefpW8lyojcldMH5jwe9V2IDcc0+Z/3QGec1SMwVutclryuzVaIszSHygCeKoSyY6VJLPnvVRp1Y7ar2OpSqWGPL15py3LZVfzqnMcS4z70pfgFTz2q1TaLc00dFazY2jk0VV0mTzpRu7daKrkbOdyszy5ELAgn5fSnpGI26fjUcNxEpyT+tPa8gOQHGfTFexoedqa1tIsa471JPuMTZPFY41AQqPmUt25pF1cvuWQBs9D6UtA1LLTEgqx+Xsc1WmdScKwNU5pt7ZOQKhMzA5Aye1ZtGibNaJ8xjB5rStrfzY+WOccgDpXOwzuzg4xtresb4Ku1mw54HFEUr6jk2loaUduUVRsz2zTrgeWPkHIqeOZdoOcmoy4clnAx71s4qxipu+pFbqR8zdafErPcEBhgd6lM8SpjipbWKJfmBOc5Ncs4XdjpjPS5IILiMltwK4yMVqaXexQgrIpEjHrjtRJsNvkghAMhhVeEx3WoRYzknnFc86XK7o1VS61O4tHSJPlIAPI5qpfziU/M4GOKrjbbhfmyCeQe1QmPc2c5B5x6VtCJhJlWci3IIYsCfyoa7ixwetM1Rhb2251x/dPrVBf3lqNsZJ6sQOlZVaV5aGkKmmpbeXnPao2RZBuHX61BBICgAOTnBpZpkt0Y8D1pxpJIHUZA8vz7c5waYlvv3luCTxzVVrlWk3rye4qS4unih3Dg9qtQQnNla53W0mGbOaVd+0EH8Kzrq9lkkzKRwOMcVq6THLeR5Zdoxx70uTXQv2mhZtbl4JUkjOG70Ve/s/ERJ4ftRU+zYudM8mKF5NiLz6Uk0CIuCSHq/EUgAkxknvVW6ZZpA5ICnrXdy6HK5XY200xrpGkcfJ0GDjmiTRrpJwsQZ1IzurV0yWJSIgcZHArZEaRn69xWigmjNzaZxEiXEcoikQ7s4x61oJZv5Y4AOMnNaGsRIDHIzYIOQfWmx/vwEQZJ6+lQ4Wdi1PS5Rs4zvJYYIOKumLAyRVhrSWB0AQnPXAzii4heKHfIny9M5pcocxFHqDx4TIOOKk+3SPIqq3ynqfSsiWSNpVVSNxPNWynlBfLyfekmxtI3bO4iAEcmMn1rRh2RyffHPauUhaTO08kdzWtaE7wWJJz1qJu+xcFbc2Z7l5SoT7g4xSGVrVftUQw8fPenBggB4HNR6yXFlGIPvMP3gPpUcvcq5s6XdSapF5jy4HoK2bfbHcCIvx1OTXI+EbeW4dwCQQcnBr0KHQIJcXE0fmN2z2pxjoZzkrnN65FLf6vaWlvInlHaDnoMnrXeaT4dsoEAmPmAcY6VxOsQw6fq8TxRkBxnaGzgiuj0y/uJ0HlygY5+bpUaqTG9Yo1dc8L6fcWUv2aCKC4wCsijH5gda8Z1GG/uZ5IYgW2vsbb0yK9R1XxIqwPbHmV/l4PA47Vk6BpqQSZVQd3OcVo7ERujgXimgYwlCrYAIPWnSv5sW08Y5Irsdc0XdeSXUDNIoO35QTj6/ifaucvNFm+xGVCyyM2CDwTz/APqqlEOYxmtBPMgGevIU10UD/ZYkUEnHFYCQXUD7okOemN1aRin2rlunI5p8g+Y6JJVuY1bqgPze1FYtu0scDKA0ZI4J4BopqNtwueWpeiNfLfOOuamXEikuR/skd60YNMhkXJjBJ9TVe60mW1y8JJHZTVWZN0Ns4mLk5wQcitKS+kjRt8nTkZrIh+2nDLbOcHotQXFw8shRxsI6rjFNSsg5bstXF3JesBKfu9AOlT6fdNauQwHPQ+lZYZ+FXualjSaaQLEskjv0UDJNQ52d2aqHMrI7CC8+0Lxx6e9WZo/MiKuMgisCxuWtxHFeIYDjchkGNwBI4+hBH4VvRXkU8eIyHIGfl71rCSkro56kHB2aOY1OxCsTEuCTzUkAZI8TNgYGM1PPMJrhxtbgjKjgip4bZJpVYsFiXg7h/OpcdS4vTUgjni8wLkknvWxayxQLlyM+grO/su3uNTghVzEjkguOikc106+C9Vkt3NtLBcBQCrH5cjv+NYtWZrdWMx71ZDuCtgHAWo59WeSD7NDEWkYbWJ6in6fvtrjM1o0gDYK7e/ersmpRLckjSzFgjBQAk+maQmzT8Iv9ivkj8olpCA3y969TNxHFbF5GCBVyc+lea6bqNvCS6W7LLt4LMAPyzW9PLcw2UbNIbqRsHHADD1/WnC5lPcyfFMUd/cJPayOHXLHGcAcVJoVhraO0ySFICgHzjIb1xW14d1RJ2Npc2Xlnp8i8Z9wK1bmxungje0OEDEFenGf0q+VXJc2lY871zRdUt7xbh5xvl5DAYB7AEfhW34Qj1x7iRrsoIoU4ABBY/wD1v611TWX260EF5A0Ww4En38njnNVf7Pv9LV2gAlTJI7kjnFU4pdBc7aK+txuiK8BACH5kIwfr71Bp6w6nAsU2wM33fatJpo7m48u6iaN4/mJxycg4H6/pVWXS1hulktXZQF3YBz17D8jSlHqhxl0ZHdeCZWYSRxgpzkof19qzJfCF40m23k2J0O/nHfOfSu3tNVNhb28M0hbK7cjn5uMDPv61o3E1lOG3bVKgMQD1X/IzSUu49eh5y8V3FDIssUckYG3ZjnPfrRXUZSaBlVoycFBlskkDHPGQcjr7e9FbKxFzxRYUCBQuCTT5IFZsHgij95kFQeOhNLtkkfLMSehrFSZq0I1rEqNJuAyKoT6Ta3K+YIlLEcMODWg1i7htzkAeg602ON96quFXHT+daJvZkHG3VtJauQeQO9OinaCRGVxuGGDKehxW3qkSKpJdWbnOKxI4huUggF8jBHUd6xmkdNGT6bl+8kn1eSOWeXc69dznkk9cH174+pqbS7gRTLF5igg4XPcHkfzqukqQQsS3KAdu+4f0JrPyB86dAeBnpWdD3Ph2OrE8skubdnT3tkJiHjRkkyPmU/y/KoI7kQkQuuWPrTrC9Wa3EMsjBwR1Ga0Vs4bmYLtEhGMOvAI6/nXU6kXscPs5R3GWVsk1xE8gjyjH5WJ69K9L0rUZbCMq8YNvwBjoBiuNg8LiRRKkrRqMfMB0J4wf0rXhuZ9EiENw6TQmPaJVPAHTGPyqHDm1CUtLHoFnbafqeliLyY8svzAcE5681zr+ELxdblntWRoCM7VOCeo/Pg1Z0zW9IuLYbHFrOg274vlXPHUdKutqdzp8zTRCO4LDChflIxk59OeKhR1M3JrQqSW0kc8Mb6Zvz6IG71abTIxKlwsTCTGNrAjg+lXLPxbYXEypcxzQzcgeYhGc44B6VuQ6tYSMELryQAG/Cq5lsTyvc5y007yb0MwTCn5SeMe3/wCutgzLaBImBeNt5J7gkg/1P5VrPp1pcAuiKCecjvWPc2ktnctIMFM8jHHTv+VVpJE6xJG1KJAoZh5ZIU7z6kCri2kas1zbyZ3KAQT6ZP8AWuI1RjEj+TtEvnM6ROcDGSc/hxVPTvE9xHcoZFMa4XeuD97OevpjtSfu6NlKDlrFHYXcIiEjso3HAKEDBH+Tj8qxPsskMri3fy2ds4bpk5OPpzWwmt2OrBUDjc0fOD0JOBWFqt+NHaVrqRWi2blc+uOP/QT+Vapq2pCjJysisl27TulxnIcruQcDB6c8jmkmuIYGASUmTDMyJnJwcdOnpWLDqfl2umxo6zyz/LIQc4+XOTn3K8/XOawfEOqp/aNskMqSRJZoXI67mBI688DmspTS2OmNO8ddyfUPFN9baTGyNmFZhskVeNwwzDPBPzEdfT04JWTo+spf250WWNFguZWeEuu5kXnoT0bgDjuc0VKvJXTIdlo0bdlYpNabimcE5ANUpoI4JCSQvPfinWHiCERBU+cnutUL63uL9/PyVBO4AnvVqDByuXCgl2qMjuDWdf20gfO4BF/DNdDptq5t1aYKu0DJzwauzaVazxBUwWb371T21IW55zJaJNOFZwFY92waQ6DdyzGOzXzNy70P90jqPxr0zT/Ay3EokYYXOckYrsNN8O6bp8gTygGK4yT1rF2asdEZ8jufOOr6ZqVg6xXqMgkw4AOQcDGf6/jTtGjY6hDbxlVkkB2tJ91TjIP6V7t4r8L2F7bAsqqEyQQMEnHSvLLnw4LO5MkYKFP9Ww7Hsf5UvZ6aCdd8yZRla1uY5Xkjit54X+fB5bkDGPX1xWnZmOYYlJCPny5g2T7E89B7etZlxZulpdRtagvKR8wOAo/r2qPS7/7HpLQyxFghYghc4PUD9GzXHOM47HYqlOVuZ6/rc66TVZLPZFNFksMOUyeRnP5cVTtb172b7MJS0Ry4YsFIAyCDnGPrnvWRHr9ss5z/AKkg53pjaxGOPbnOR+VW4J7NFzH5cZulYIEBIX5Og9gSDjryKzlVqRi00dMI0ak1Z28iczm0mAhfdv2hG3dcnHIPc4P/AOuri+IvLUSROVlXgxvyuMY4PBHGPzH4YeoatafZg80YN0RgKMDZ19O4GeR3PasmS4jlughdm3R4Ulj1Ix29Mn8q1pVKijeSOWvGk52gdhdeKJ5o/PtZmBRQWTOSBnk8deg/M1Po3jrMiLfAtBM5G5OW6En045H6Vxkl7A8wlQyLDbKIztwplUlgGP8ALGOwq3rdhHaxrc6U6G1t28woQGJ3DqMjlSM9eKqUpy6ihCEL31Xl/XqesDxXqfh9IJWRLzT2Ub5o5dwj5APatm78aW8uj3N0q7yuRsbjcASMZ9+ma8O07xQy6De2MrqI5lRVQDGMnJ6fn9OPYyprsz6FJAoZfNuWlUHJYxlGxyf93sRk1HtakWrIfsaU023rbQ9O1DxBbXCWxlTyyLbz0yclSQfl9+n41x91c3d1aLcxuI5n5McZxtfHAGfTB6etYY10mS0lv0V0MCIMHnaCyjOeBz9O1dLpMtrqnlhLiOMtMrEtwFUKNw/HB9K6ov2kbs5qkfYysjGvNYulFpJA8kJl8yN1XjIViR16dfr37jL9Y8Q3NxAltqZ4SNTsYEMWKcE89ff3rqtd8OklFmRIreNyqFRjGRjJ/Hv9O9eYeILO5W8u3ubgyGFwiuBy+PkU9v7vJ/nxSUZw91lSlTn78fuLD608dlCllLsuI02Hp8zE4wD9P5UnnQXWnajcysEnCRx28aeq4Aye/CufwHrisJvKMoAYr84xxkE/0okiktdgdsYO3Cc8ev8A49ilFcuhM58+ttS3ayCxMc3mKXZTtAYHaemDg8HPOKKrboZkYSfIqYVNvUkegooRF7mtZag9qwUoOvXvXZ6Qs15DkhXUDK4ODmvNFvw0AVo8uP4s9a7fw1qy2cCNg4PDAmuuMrmckdLcloLaPMZyzfMFGTW1pIF4nzB02csWTGKbbanBNEp2oR1G0c1s2P2aV0kndjyMgdKcldEppG7p9kYoyTMrAcYU5xVPU70Wmo2AliDp5u9Sf4SBjP8A49j8TWii2CuFhlRW7LnrmprjTkkCvw7D+9WFrFN31MLxOfNslu4V3rgcDu2M/wCf854O4kDbhJAQpzx1NepyGEMYXwmRx2BNcbeWdpvmQH7rEcjmtYPoRLuclJbJK+x8KhGcGsm70spFJAo2xt12jqTx/U/rXTT2qRgr5uQQcHvVSVxMFUg5Hyg0pQT0HGVtTkE0ONrkh5Mom11zg5+XDKT+A/OpEha1Tf5cTLG/yqHOVBxnHtxW88aqpKkMuOoHaqsCeZHIHI5GCMdf8msXS0NOfU4FpnF00chY7ZMH14P/AOurl4Eja0dXVdoVC3GeO+PpitTUIJbO+ilj2IjNuZtgyRnJ5P8AWucu3Rrt0QFtnUseRwPw4OalrWxSd0aN9cu8k8kqIVljC5x/t7s59Qcj6UrrMGSytpSzSxKoZ24w4GevQYNUoZmuII0cjAbamV9f/wBR/OpvPFzdRKi+Xt8sckkKcc/me3FSr/MaZDKptw6zRI3l5hbkZ3YIH5cflV2OQR28chOXtQzBGBw/I4x1x/KomjaWSQMPuyETNnOcnB9+eRn3qVIGFkWMmRtO89zuKj+h/E0+XuCk73GI8yJ9rKBlCHecdN3A47AdPr9aSO9ltpZVjyE8pflA65wD/n6VDaCWWB7UyAGeRUAbnccj2pJ5TtYhCjrbgMCOQQ/H4j+lFrDbvuepeGvGv9pQx6PriLLHcQ8zuMujHAHJ+n1zisPxZaW2hJf6Xdzx3lwmJIZVXbkMQcn06g4/yeO06dVYsATKsQCZOVBGT+eD+f51DqWoSXt7JNdSmQkBeeSQBx/L+VWpO1jNws7oglLmMMAcBwicccA5/wD11pXUTqEYgu5jOeOrEDp+PNUplRY49m4xlCVJHQbsfT/P41LLdkQkMvWNycHjngfXp+lTYopJGhAYuQykkgDPYd+n+e9FLIxCoGUIWDNu6Zyew7dDiiqAmeGIF41XLq/y47r6fWu50WwjS2VZI8Nt+UmuQezY3XmRxnbkE7f516t4asG1KyWRwNoAG41dN3Qp6FC0SZAwQA7TheMc1cg1FxMYpjKnAySOB7108OhL98J5hJ+6Bmn6hpduE85bAlwuDGAMGuhR7GLkupjySylraWzu45Zg4GxWGR74711+lX1x5MlvcDybmMblJHDDGRXC39vObUlLYwsnzgLwRjuKks/GhW2VdTjbzYx99MAzDtwf4h655rOpDQcWbmpeJIZlWb5d3Rh0wehH9fx9qy1uLbVhNLbON+MABscjjj16Vz/iOWyngfUtOuPNtrhRvJGNrcAhu4bp/OuX0nVLnTy+1wrA5yeRUwaKnFnVX1xcQKolBzyu4dKzhdKIEiZsHGC3rXQ6RqFpqlk0eoMnmoflZh976YrjtZt47S6uo1dgsbncpzwOxH48VUmkRFM0bDzYPMikOcklfcVca2R1ZY8BiDle+a4v+27iOWJd+UAIJz0HGP611ekajHJPKzqdpHyH2P8AkVnzu9i+XqQX4VEtozCZZF6ZGQOef61k3mj21tEbqLEUvIwc857fnXT3LQFBISA+fzrIuUeRpMhXJ5wee1DimF2cYpiSGFVXa376MDPPzDjP/fVPNpeQXMMYkRZJmDIN27aQSOf88+9XL2BRfb4rZhGGyQfyP6CsuG/mNxC5HMTFlBP3effr29+Kykn0NE0wmSW0u2haPy2UAuobIxx/9Y/jV7TbozrJCU3EqCQeQeen6is25kWe4kY5YqhUHrgDp/LFXLe3ncb4toMyhBGvynIAOfT6UX01D0JoLN5EdomU4O9VDAHdweufTIx7VQjGZ2jkBBdRGFb8ufTpV5jLprGKbcrsw+UewxtP06/lVfz47+4jglHyl/kaM9zgd/pT3AfDLFb2sccsZKYckE9SQP58VUmiVVVAodwjEbhjIyef5n8qZtZFUNCxJG5WI5Iye350+fzPNRgGCCFRn8O/akBO6RzJCFkAeGHGwnAJyT9P8inXDoEaNWLbRsQBef8Aa7enXBqqiPJMgboFZQI1ycAeg60RLlyEG6dcKvv64/Wi12BYuWjb90qgsAFUA8AZyfpz+lFL5AmuC0biNNu5Sx6NjJ/kfzoqXoBvaewDxEKMMSu08jqRXoVrftp1ibe3QDYu7OTzRRVYYdQt2HjG9hjy0UTg8LntVxdbudSiMmFjUkoVHP4g0UV3UtTlqKxZu9PE9sxknkxtJODgniuA8UeH105Eu4rqRnkOQHAIX0+tFFOa0FBu5yd5LLpUs9vFJuiuEV3Q/dOfb29azLa5lWNGYhlcEbSOmKKK4o6XOybukdHa3Ti3VV4GT/OrerRh7dZhkNtC/gKKK6I6rU5nozlXg/eFyxJJ5966Ow/dRDbwSct70UVnbUtbGvAu+E5wSUyMjpWXLO8UvYlzgnpRRVpJLQl7lu2jUsUcbljdSAe+TyDUOsaJa232i4gXZJsJzjsQwI+nI/Kiis2tGadjjS5Se3C4DIAm5Rgnnv8AgMVpXN7NBG1zGdmJBuVDtzt3jr24Uf8A66KKwS1LWxmTXLPZ28ko8yWRmcsxPXOPqfuiqj5tpo/LYghQ2R6kdvTrRRVoRakkMqxI+dsca8Dv/nNM1G5kKWsIOFMCkgd+f/1UUUD6FmxhBnCZ+aJtgLDIPXt9aqMv2ezWWM/vHGGb13Fh/JRRRUrcRDCga4ZMnAIUZ574/wAfzoooqm9Rn//Z' width='200' height='133' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=7bfce9c3f0734d5896584b21d8fc2ba9' target='_blank'><b> Exposing patterns in land fires around the globe </b>\n",
+       "                        </a>\n",
+       "                        <br/> This story map analyses global patterns in wildfires using spatial analysis tools in ArcGIS Pro with satellite thermal data . <img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">StoryMap by api_data_owner\n",
+       "                        <br/>Last Modified: February 15, 2021\n",
+       "                        <br/>0 comments, 0 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\" Exposing patterns in land fires around the globe \" type:StoryMap owner:api_data_owner>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Displaying the result items through IPython.display.display()\n",
+    "\n",
+    "for item in user_content['results']:\n",
+    "    display(item)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c3bbec0",
+   "metadata": {},
+   "source": [
+    "It is also possible to have these items returned as dictionary objects by setting the as_dict parameter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a5ee532a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'id': 'f1b6a842fbea45bca693c2fe6622bf70',\n",
+       "  'owner': 'api_data_owner',\n",
+       "  'created': 1610462632000,\n",
+       "  'isOrgItem': True,\n",
+       "  'modified': 1610462693000,\n",
+       "  'guid': None,\n",
+       "  'name': None,\n",
+       "  'title': ' Exposing patterns in land fires around the globe ',\n",
+       "  'type': 'StoryMap',\n",
+       "  'typeKeywords': ['arcgis-storymaps',\n",
+       "   'smdraftresourceid:draft_1599006014540.json',\n",
+       "   'smpublisheddate:1599006014535',\n",
+       "   'smstatuspublished',\n",
+       "   'smversiondraft:20.35.0',\n",
+       "   'smversionpublished:20.35.0',\n",
+       "   'source-0f5ef7b723cd410f8e4e298d716bcd73',\n",
+       "   'StoryMap',\n",
+       "   'Web Application'],\n",
+       "  'description': \"For decades, the NASA satellites Aqua and Terra have been monitoring potential wildfires with their MODIS sensors. In this StoryMap, I delve into the data archives to look at spatial and temporal patterns and trends.<div><br /></div><div>The\\xa0<a href='https://storymaps.arcgis.com/stories/5985c0af444c4fbbb53b92a1bf880503' rel='nofollow ugc' target='_blank'>original StoryMap</a>\\xa0has been translated into German, courtesy of\\xa0<a href='https://www.esri.de/de-de/home' rel='nofollow ugc' target='_blank'>Esri Deutschland</a>.\\xa0</div>\",\n",
+       "  'tags': ['wildfire',\n",
+       "   'fire',\n",
+       "   'MODIS',\n",
+       "   'satellite',\n",
+       "   'ArcGIS Pro',\n",
+       "   'spatial analysis'],\n",
+       "  'snippet': 'This story map analyzes global patterns in wildfires using spatial analysis tools in ArcGIS Pro with satellite thermal data. ',\n",
+       "  'thumbnail': 'thumbnail/ago_downloaded.jpg',\n",
+       "  'documentation': None,\n",
+       "  'extent': [],\n",
+       "  'categories': [],\n",
+       "  'spatialReference': None,\n",
+       "  'accessInformation': 'Esri',\n",
+       "  'licenseInfo': 'No restrictions on use or redistribution.\\xa0',\n",
+       "  'culture': 'en-us',\n",
+       "  'properties': None,\n",
+       "  'advancedSettings': None,\n",
+       "  'url': 'https://storymaps.arcgis.com/stories/f1b6a842fbea45bca693c2fe6622bf70',\n",
+       "  'proxyFilter': None,\n",
+       "  'access': 'private',\n",
+       "  'size': -1,\n",
+       "  'subInfo': 0,\n",
+       "  'appCategories': [],\n",
+       "  'industries': [],\n",
+       "  'languages': [],\n",
+       "  'largeThumbnail': None,\n",
+       "  'banner': None,\n",
+       "  'screenshots': [],\n",
+       "  'listed': False,\n",
+       "  'ownerFolder': None,\n",
+       "  'protected': False,\n",
+       "  'numComments': 0,\n",
+       "  'numRatings': 0,\n",
+       "  'avgRating': 0,\n",
+       "  'numViews': 1,\n",
+       "  'scoreCompleteness': 96,\n",
+       "  'groupDesignations': None,\n",
+       "  'contentOrigin': 'self'},\n",
+       " {'id': 'fb2cdb23cece4c49a28e928d70511aa7',\n",
+       "  'owner': 'api_data_owner',\n",
+       "  'created': 1610515804000,\n",
+       "  'isOrgItem': True,\n",
+       "  'modified': 1610515854000,\n",
+       "  'guid': None,\n",
+       "  'name': None,\n",
+       "  'title': ' Exposing patterns in land fires around the globe ',\n",
+       "  'type': 'StoryMap',\n",
+       "  'typeKeywords': ['arcgis-storymaps',\n",
+       "   'smdraftresourceid:draft_1599006014540.json',\n",
+       "   'smpublisheddate:1599006014535',\n",
+       "   'smstatuspublished',\n",
+       "   'smversiondraft:20.35.0',\n",
+       "   'smversionpublished:20.35.0',\n",
+       "   'source-0f5ef7b723cd410f8e4e298d716bcd73',\n",
+       "   'StoryMap',\n",
+       "   'Web Application'],\n",
+       "  'description': \" For decades, the NASA satellites Aqua and Terra have been monitoring potential wildfires with their MODIS sensors .  In this StoryMap, I delve into the data archives to look at spatial and temporal patterns and trends. <div><br /></div><div> The <a href='https://storymaps.arcgis.com/stories/5985c0af444c4fbbb53b92a1bf880503' rel='nofollow ugc' target='_blank'> original StoryMap </a> has been translated into German, courtesy of <a href='https://www.esri.de/de-de/home' rel='nofollow ugc' target='_blank'> Esri Germany </a> . </div>\",\n",
+       "  'tags': ['wildfire',\n",
+       "   'fire',\n",
+       "   'MODIS',\n",
+       "   'satellite',\n",
+       "   'ArcGIS Pro',\n",
+       "   'spatial analysis'],\n",
+       "  'snippet': ' This story map analyses global patterns in wildfires using spatial analysis tools in ArcGIS Pro with satellite thermal data . ',\n",
+       "  'thumbnail': 'thumbnail/ago_downloaded.jpg',\n",
+       "  'documentation': None,\n",
+       "  'extent': [],\n",
+       "  'categories': [],\n",
+       "  'spatialReference': None,\n",
+       "  'accessInformation': 'Esri',\n",
+       "  'licenseInfo': 'No restrictions on use or redistribution.\\xa0',\n",
+       "  'culture': 'en-us',\n",
+       "  'properties': None,\n",
+       "  'advancedSettings': None,\n",
+       "  'url': 'https://storymaps.arcgis.com/stories/fb2cdb23cece4c49a28e928d70511aa7',\n",
+       "  'proxyFilter': None,\n",
+       "  'access': 'private',\n",
+       "  'size': -1,\n",
+       "  'subInfo': 0,\n",
+       "  'appCategories': [],\n",
+       "  'industries': [],\n",
+       "  'languages': [],\n",
+       "  'largeThumbnail': None,\n",
+       "  'banner': None,\n",
+       "  'screenshots': [],\n",
+       "  'listed': False,\n",
+       "  'ownerFolder': None,\n",
+       "  'protected': False,\n",
+       "  'numComments': 0,\n",
+       "  'numRatings': 0,\n",
+       "  'avgRating': 0,\n",
+       "  'numViews': 1,\n",
+       "  'scoreCompleteness': 98,\n",
+       "  'groupDesignations': None,\n",
+       "  'contentOrigin': 'self'},\n",
+       " {'id': '7bfce9c3f0734d5896584b21d8fc2ba9',\n",
+       "  'owner': 'api_data_owner',\n",
+       "  'created': 1613391382000,\n",
+       "  'isOrgItem': True,\n",
+       "  'modified': 1613391500000,\n",
+       "  'guid': None,\n",
+       "  'name': None,\n",
+       "  'title': ' Exposing patterns in land fires around the globe ',\n",
+       "  'type': 'StoryMap',\n",
+       "  'typeKeywords': ['arcgis-storymaps',\n",
+       "   'smdraftresourceid:draft_1599006014540.json',\n",
+       "   'smpublisheddate:1599006014535',\n",
+       "   'smstatuspublished',\n",
+       "   'smversiondraft:20.35.0',\n",
+       "   'smversionpublished:20.35.0',\n",
+       "   'source-0f5ef7b723cd410f8e4e298d716bcd73',\n",
+       "   'StoryMap',\n",
+       "   'Web Application'],\n",
+       "  'description': \" For decades, the NASA satellites Aqua and Terra have been monitoring potential wildfires with their MODIS sensors .  In this StoryMap, I delve into the data archives to look at spatial and temporal patterns and trends. <div><br /></div><div> The <a href='https://storymaps.arcgis.com/stories/5985c0af444c4fbbb53b92a1bf880503' rel='nofollow ugc' target='_blank'> original StoryMap </a> has been translated into German, courtesy of <a href='https://www.esri.de/de-de/home' rel='nofollow ugc' target='_blank'> Esri Germany </a> . </div>\",\n",
+       "  'tags': ['wildfire',\n",
+       "   'fire',\n",
+       "   'MODIS',\n",
+       "   'satellite',\n",
+       "   'ArcGIS Pro',\n",
+       "   'spatial analysis'],\n",
+       "  'snippet': ' This story map analyses global patterns in wildfires using spatial analysis tools in ArcGIS Pro with satellite thermal data . ',\n",
+       "  'thumbnail': 'thumbnail/ago_downloaded.jpg',\n",
+       "  'documentation': None,\n",
+       "  'extent': [],\n",
+       "  'categories': [],\n",
+       "  'spatialReference': None,\n",
+       "  'accessInformation': 'Esri',\n",
+       "  'licenseInfo': 'No restrictions on use or redistribution.\\xa0',\n",
+       "  'culture': 'en-us',\n",
+       "  'properties': None,\n",
+       "  'advancedSettings': None,\n",
+       "  'url': 'https://storymaps.arcgis.com/stories/7bfce9c3f0734d5896584b21d8fc2ba9',\n",
+       "  'proxyFilter': None,\n",
+       "  'access': 'private',\n",
+       "  'size': -1,\n",
+       "  'subInfo': 0,\n",
+       "  'appCategories': [],\n",
+       "  'industries': [],\n",
+       "  'languages': [],\n",
+       "  'largeThumbnail': None,\n",
+       "  'banner': None,\n",
+       "  'screenshots': [],\n",
+       "  'listed': False,\n",
+       "  'ownerFolder': None,\n",
+       "  'protected': False,\n",
+       "  'numComments': 0,\n",
+       "  'numRatings': 0,\n",
+       "  'avgRating': 0,\n",
+       "  'numViews': 0,\n",
+       "  'scoreCompleteness': 98,\n",
+       "  'groupDesignations': None,\n",
+       "  'contentOrigin': 'self'}]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# return items as a dictionary with as_dict=True\n",
+    "\n",
+    "user_content_as_dict = gis.content.advanced_search(\n",
+    "    query=qe, max_items=max_items,as_dict=True)\n",
+    "user_content_as_dict['results']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63e8784c",
+   "metadata": {},
+   "source": [
+    "### Sorting Content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45eae478",
+   "metadata": {},
+   "source": [
+    "The sort_field and sort_order parameters of the [advanced_search()](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager.advanced_search) method can be used to sort the returned content server side.\n",
+    "\n",
+    "Possible values for sort_order are \"asc\" for ascending or increasing order and \"desc\" for descending or decreasing order. Default values for the sort_field and sort_order parameters are \"title\" and \"asc\", respectively.\n",
+    "\n",
+    "In this next example we'll search for the last 3 items that the current user modified by setting sort_field=\"modified\" and sort_order=\"desc\":"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ee730f56",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=2647a386f5a04917b74cc4f40a48f57f' target='_blank'>\n",
+       "                        <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAACFCAIAAACR/CB7AAAACXBIWXMAAAsTAAALEwEAmpwYAAAKT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdpr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61MbU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllirSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79up+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6VhlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lOk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7RyFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3IveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+BZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5pDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5qPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIsOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5hCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9rGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1dT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aXDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7vPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3SPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKaRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21e2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfVP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAgY0hSTQAAeiUAAICDAAD5/wAAgOkAAHUwAADqYAAAOpgAABdvkl/FRgAAsuRJREFUeNps/dmTZllyH4j5cs65y7fGnhGRW2VlV3UVursAEN0USIyIMWJIysZkJMeMkgjRRmOCONxmSAyNIz3rWX+GnvQwpgeZNGOaESkNQBJogECv1dVdlVmVS2TsEd92t7O46+F+X2RWc7LMyqIqMyPud64f95//3P3n+M/+n68AFABUFQAQEQABFAEVVFURMcaoooAgogig698FACBC6L9AAgARUVBWVNCUEgIiIjEhIAAIQpIkotD/LiIixpiYSKH/fgig6wdA7B9p80vXTwfIiv0fJKYECgpsjDGMgESkqgqQEFQSACrAKMNfOSgX17cn8/ZG7dZglOru3s50SpePXMhB8sG0zKgSd7bsmpD2x1mqbk2stibDV6cVunEYTH5+et7Y0aKNLH5aWOzav/69Jx/sZhmKRjbWAIICgCgigoKoKgNo/9C6PmQABBIAURBVBEQEVQgCCYAgAWAKsW2ai5vVwkz/vz9+ucSiJmvQMIJEERZVAAWRyJJijIBASKDYdi0RZXkekZgJgKaF+yuPBqRhdn76a996PL+tn53PX9y2O7vjj+6Nn11Ur2/1qkmeVFVFhNkkwLcn/vb8EcmxdkYCgbRi2eUampJpFTxbG1WUICcXuhpt0UQ0iKCqoHj3+hT7FwwKQEyqQGwU1wahAADY21b/j66PbP1/QHoDQUBQUCRGYu4tghAFgw+ACOvvpaqqvdH0Z39n1hs77437zu5VFYlEEiIRoiICIBEjsYIqIAEoqIIKkqoAIiNsT8cuhaBUV1FjNIzz+W3rVhOm4/E4qIoAMKvqbD7Lodwq7O5kizF1TPPVCs1gHiEoG9GDzOwPjduePjkYZqmxGDvIRUEQAMD1J6kAiglgbW3rD9W/NBXAuPktVIgCSQAIjLIKkFLGrigHFQ+WiYMryFDyXcagqI0SgCKhyvrnEKCoEiIRWWtFRQEVEEEBtHRuOipwed0u68Pt0TKEV/Pw/OVNiPLssqt4kEyZY5tCZGYijPKOXcFbwwIkABPEM5KSESABjIpBGdGygRBaYkNsowiSof7FAoAiKoJi/1ZEQBVUFQGAiIgNECAi9X4GCABhY1UA2FsYIgFiAk0AgARIxMRMQARMTMRs1iYI/Td665bWT9Fbz/qL/gn6P4MIoAprtwRqmJjJsjHGGJMRZ4KMQCzkBHMwjtaeMvhusVgMy+Lb7z86KAhCMygspxCIp/eOd+/fL6dbyyCzVb1azax68c1iPnv/vSfbWzt79w6z8fSiajt0kmg7o28/2P32g71vvXdkFSwDaHTOJHzXuW5exNd/KYACSv9JUREREBJATJAURCAEiAEQTNuKkrltAueDhCigzBhjws3f7i9pf38UQFLqb12WZb7zqgKiIgkRmhCzDBklNcvJyH749ODevf3C0pubZWuyaPJIxMQCCkghps3j9//CTRDTJKnzEZCDCBnuuoaIuhBcNojACsmhdI0nk/uo1lpSVQJRFVVQIAFUIAVWQAVOqkkxKQggkbHGERtiQ4bJsAKKUn9bQhREUkUAUkVRVUA21mUFECfVGFNMMcZARJ3vRGQwGDCbzT3uj0wVpDcv3Xjit/emfxVIUcWsX4qggrM5ubJLEJCRc/JSBtjOy6PdHUyJCKKkk8v5ZDDcdvqr94cD8R++fzS1Ka3Sokpfvb5uI9xC9vL89unD46f3hhOb3n/wcL7wq1Usi3yyt2eKURQc2fCr96dPpm4vh4MxM0JSFnQAiVEFwAMAixIogVACXb+cu/ckAOtYoygRNEKMSUVAQCKEBFFhUfk26en14sfPX4MhlAokJYVI0Ord+1ZEUiQkFgAlAgBrbAghd5mmCJoYcWdnp+V86WE2m91enLZBrjyoxCyt1HcgUjI5X3chArL0vgAU114WGICBWJEBGJJlVCRkk8Q7VlZltilBAqLgXVyxupCMzcqYOiMABIiAgoxrKKB3T795odC7DMG1L1rfSUIAFREFwnUAFQAVUAQkZmaTREQEAJHI+5aIAKAsByJJRACUmDc/qj827L3U167/OuJrH2IREAjIkCFS46KkployY5TYqQ6dzSA6aUwiJvUJhOyiTc9evhlRd//hvcwtYvDv3z9cvLz46s3txPK4TOerJrbx/PzMpNnDvXuOOcvd+Wlb3psuZ/Wi7pDsX/r1gwfk9nOwDtBgDIkt0zqIq64/fxKlNcoCxndcmK5hAigACiBCf3DIqAqSIAGEqKcXV3nuVk03r5uUW4aYVBQhAQH2GA5UkRCTqMoaT8QQFZSJAfvQAgi6WFTPFqGaxYKZWa9nyz/+8qpq9enj4z9/cSVJWbzREMEgodxFhU0I2cQTREBU6V+7KgIok/YxjgEiUFIgZEFMCoiSQmeAGDbuCiG9g6DfvlRdHxpuYPvaCnrQ3UMlIlq/cnyLtBVUYlw7biQRISJrLBuOEVUEAJlIVOCtcd2B3M03eYuu7mI/EDOTBaZIpBozJwgpaVKBnft7WRf38ngyX7IqACrmjcY3i/ZwbG6j85AtFtV2jinRrFUf9HoxXyI92dq5mp1NhpkCxRQBtByWP399dr3gVd0Su8Wqu+4WeYnDcV7d+u2trQQYkzrm/qQIoAcPCiA9kHwnDr7NTTYfDxEYSQQEgBCSAgAURS4pSUqDIp+FYJA8rF06KrACIGqPoURE+0ChIqqgzLzOa1QVcL5cNqEtjLPEEcGTeX46z1z2Gx88fATm9iRGHwxA3OBdxN5uvvbQ/UvHt8GDAFVECQEQCCIAR8yjoRBDREYNuUOTlBkwoSoSaML1Q+PXEjJ45+KtX/rbwwJQBALcXBNZ/2+RdPcXSAEUqLcvohjj5pvpL/2U9SfYXJu731dd2y4gECEg9RemkVhwKilibC2zgFEbtnfHD50/vbmCJGRMWY6auplLHNvRs9tYaXa9WN43xXi7vFylRYoZGZ/i4d7ehV80ZJsu+lAFPxmOBj//wbOl3YpKTPjjn1+vaNUNdTwZLFfL4WQEkQEAIxECKhCpAPcmgmgQ397Ru8xQ3724vZUh9qZGBA5xd3u7qldF1Y4i3jSNAAG/xQMIQIgigncgTrWPHrqGC+t4IpJCVBJNSgGNZrnn0oMFNZ3gg/fu/ejstPPRbIKN6rtpOL6TcmwMbO1ZelRPSYkAGAKCjZSvkKNpEQS1zRhIARVJgb/mqNbPCP/eldMecxNhf2PWZtTDcFCVnqEgRBDRlOKdywshWGv7h4sxpiRMLCIppY11bpyj9la6OaP1v2mdBBH1HEZSTAKkbFPI2uV+pgelcdo9e36STLNol2gJkRnMoCgVzTLBy5v5i/N5QrNYVkVZPnm0E9G2yRwcPshQt3J9cLivgGTsqlo1zWqxnHVqlk1g4xSwTRLI1EKzuq3azgcJAsjOe+i8hs7HNsSgMYEmEAFQkF9G8G8vpQok6VPyDQhHYAMpheGgHJalTX46yGN4CwBQ+3CBChBT0g3LAwhERLTO8NcXs090rL1dVZAPh7v3vjqvcDBVUz47mS1q70NanzhC7wLfAsKveQ7doJQ7r4WCJEgJSUFJRRSCWjCBKZQouloYBVRUxd4xv/3UsPHq77qoOxvug6Oq3DEFhD2B9DZWUh8YkUDXuYy1tmmbEJSIVEFUY4qiwkDvJJibB9B3AzEAKCFvUlACYlEFxTHneTP7zsO9J0fbK5f/v/7gT0fDyfe//5PczwNuYX6oCWbnt4PpcL5Y1KlNzaowg/FwtKjqH/30zJstifH28uKwhEF3e/9o9/6jg+bsbITp+vr84nbewtiWYy/ARJjl+XS8tZ3tbhXNcjEYlwjQJgAA7QRjhxLVlcyZZUBSsIqISKjvuPo+6t8BZLiDDgAMkILMZzdFOaiq1dHe9uHW9E8+vVq23eZSA/bxVkWS9LdQQRGxZw0FhJSQqTermJJXnLUhmi07Hv/Zv/vpyk0c4Ivzmy+ulwK5YQCRdWB9Gw3hXTOAOyZuYwykmNYOkgnIQERjFTH4itFy0z7emxIC8Prz6Yanehe8v3sm/a1Z+yxEYGbDpnfkgCAivR30pMSd8YkqEbEx/Z9BRCbOnEsxiogx5g4q/vvRETbExF3qu04akIEsAEMbp27w0fERLldZG3acfbq/m0GC8T033rGEJcQcQ1zeBl/nDIfjbEDJd93W7t7f+O1PLMrWKNsd2icPjq2h2IXTs9nloll43X/yza2HH0A5WXlJQFFkvmoCZWeL+vs/ezbe36sUKoDEEBACsAKJiAimlFICEY0xxpju7jr+Et4iYAYiJAIkIALnIAQPAHVTg+jr57+4vaoXi/rtW1VAABEVkRBDSnGdGK3z5d5vUR86UhJRCaBuMPr5y7NsCMtkItg2QidUdSkvCiRSFXjnvW/w9B1VDneJlULvOHuOlxKSIAayRto8rrSajQxOiI8m47/xm0/4u7/7+5ZURfTtLcKvw827cAQ9coM7z9aDKlVmAgURAQXZmAgCsDG9tROSqKYYVMFZG1M0bNq2FVFmoypr5nMT/r7+LnTN4PdBEMEYTsT9g+RqH+2ND0f2xee/GJTT89MzGzz4cGO2t0bTrYy5vom+/uAb9zNOIxN/ZW+8O5m+vLycloMRJi5Hv/LeVG/PPWZd0y06WakJWLy8unG7+5+eLD57PadiiMwxdsblfrXICvf46aOuldfni9fni2I0vLqBLIMyc5aA8twaIgJjEFCICDfVCf36ma65aNwETQVGCCHO5rPJePr81ZtFvZxHu4wW6N17JhKTrD2WbLAJcv+TmJg4rTM4tdYKQNN1eZ69Oq1WmlfKhtCS2nzYRCUVhCTIv+RB7o4dNnEM30XzaARZe5YAeZLmU222CkNdR5381idPS8uGNfIajiF8zWd/HWEpfJ3pfzdIbW7SHTZDBAXjrLMuhEBMSVIIATQaY0SFiduuTSJE69wQFO5s6y3vsPmcesdhvUWCnFRIZO9o4ob8xcVtR+4nP/nZR08+2J4UVdf8N7+4NLH94Hj72eXnu8ePFteXO+NylGXDsBzu7f7oxH75+qw7W1zo4MPdD6pu9vllNTRWpevUawK09l/+0U+1mGTjaafICkgUEesIry5ns7Y2PqUUY4zP3txOBtu/9sH+qATHubFACoyABKIG317JX/ZYPZqMoKCYEojCqm4R8eDgwPu0u7PdkbzwgUwpEDasKqhKSlFUEfWOYRaRzesnIBFRBDXWhBCUOSuKWlKqYsAMFJhN9NDUrSmGMYrbANl3fBW848MA3nkR74RIRBACQaBM6o8eHLz/jYME2orGhf03/+ZzciCsgSBYje8yrYjvpH1f/wI3VZd37gomEGRCJjLEbNgYAOyzv/45iNBaa9gAQBKJMa5ZPngbgRHvKiC9ja+Lhuv0ShQQjDWE1KeuhuGr+fWnF+d/dnGVfeMpT/cS8shlR2Xx4cja2zf7mf+1bxwcP9ybLRcYdcBZmTlHYA2vuuRTCu3KpO6jxwdFxrPITcStgr7zeO9733lKEG8Wi4SsyCIKiqLklWvli3l70chc7Fyyi5V+dTX71z/+8myZkiMkQAYlWGev75zdBrLr3UUV2FS+VFXEx0DGDEfFqlppSjs7O3VdIxIpaFJDBKC+62IKMfqU4t2tExVmBkSR1GMvYk6ppzwpKXrFVkhEGROIJySyNklCBNF3f8m7VcIe84jK+glV10Cor/yG1qZuoPVf+PDhX/z43t7QNXV2fpH/2WcvT1feTAZ5aFdEELDnMzaU1aZC90vUw11BRr+GgjaP8daFKqyZh/V/EhGAxJSYyVrjvVdVxLfBQd9moxt8tr4ZqBvrVAUEUkVFJBCGtIr+IgZM6cent0/2DwLjm/OzB5PBbzzcnzWlJch3pq9bMfngdla386hTeriLxDzZ3t7f3j378pUxJrPmW994eJXc6uz81x+Xjw+mFZiKvvkHn75pfGRXSIwKIKoREYEFhNAZNUoIIK0EqfxlK9PAIxbSaJlUgMgQ/k/cznVE6W1LQQVCiIiAxCEGYgwx1KtVce9gNIHLeVc4YEJJKcWQRPpTXp/2hoVYp9MACn1utDYRUZWkhhiQQdUxYEwKqD27rQpAm4fZUIn6S7wSvkuWbzC4OpIC/TaFo61dY+yrs+4nv1hcNWERvMkLMyjLb/7qznwG3//hc3UjgDszWn+h+j+Jut5JRtfYiDYAnHBT1da31gKbeAe4pmHeAW53yQHcua+vVbLvjFdVRQWRFYBUxa8GmfokZPOzWdWsVlvEw9XVMH84KQdtMfjJ6ytb2J9cLwSy+aqzooHt+Y+/6nw4PtzaeYDds9OA1nNuUrM7HL//zeNH43R99nr74eP9raKpVsYaHztYM4OqYLokCRSBGZjRCCXUlKJ8/uZyf3KUScgtAArqL7M1+HUOp6cYokSQ/ug4y3NkqOuuLAqT1SdnF0pbg0GRfI2EwfsYAwMQUqL++vV+XQEgpvi2SknYX2AAVOlNkRMiSCJUVBUEBEUQAFB6J2O68w36FmZtSrR3xdyegJecZC+Tv/7Jk4NJ9sPPz3/2enbVuqUxlTXOGnN9e/3pT4xPiMjvFHDe/pyv1Yg35Yu3L/6tl3nnuWSdA/cRtUdIhAhIxhhQXVbLu7qQviWx3mFcEe9++gb+b6hRQEEARKMycMTdTcSsEwCXr3zjo+7s36PtnWqx/KPPXs04V+sbND5EUptMeVb5UbtMOb85vy5gqCrPXpxsO50tFu/tHdxezH92dS2i1fniTevYlBmBDy04C6CokpQFUIBUNYoaQlBC5iDw5fnN0+Ptgx3HJIRomHonh3esNcIvofi7u9QzfEFT6mS2XBYuN4QdmCbEGAOqImAMsS9dIyEm3DTkbFIpEdhUOwC0b1XQvpySRJQEBVEYVVQE10Q2Qk/3693NX7NHmwzxrlSl7/BYCoAQ2dfHe8XDqfvxszc/P21OagmO2yyvJTaSTBPFeqjqdQvNWxz1dcz+1sIQepruHXCteMdvgqJ+De/fcVpKawImJfHeZ1m+sVB9Bx5+nfl913XBhiRcf3xg1Pfv7XxQTDUb/PGffxrA1zmBK0+rLr44m5+en5md1o00ddzM1DqxWSOCUSaDPJLOZrdfXL0YZPTi5OyrBIuoZ6tPu7riwlVtml5endbU2WnuLzNbBhUAYEkRWIEUEVRAUt/AoYBqiwD65cnVdw/vJ1EHrAJKIKLMCP9eNLyzCCbTB622i9fLxcXZmc2swZXL3f7u4bMvLn1oHWEMUVQMMUBQVQBBpLecIbxFP9i3Em1qbYZIABiUEIjZcuoiJLCoaWPh/Es0+DtVna+VQRUUgRAgUTKi08K8tzed3y6+OJ2/aZwvJl5iqwJsJCYTwV0vamCbD8dtT8S9SyLhXdcUfD1PxHcqFW/xlqooIt/R9O/iJ0QE9J0HxKIo3mHh8K44e8dkEL4F75v+kDXjSkgJiBBI0iS3xwOJFP/Wb/1ao1o59//4gz+/ITfzKRtuLWUQEgxUdzJaQgqYlNPHe5NRl4SzIOGvfes9tuIx+7Nf3Mxvb126PX7y+PuvbobD4uLqcjg9bOsaUmNMFsAAAqNGUaD+syQQNYSIEBWBbExuUcckYIBC0tRGdrhh6TZFKtwA9s2N7IvYq8pXVX11eX19M0NEZ01eDP7Nz3/YDQ9Hg7Kp6pQiEREjCkkfyu4Odd1oicS0Tq4Ro0RDBvseFSZHzEAhBdSYlBOSUY8AgqgEKL8MAjeGBLLxs3e+TFABiDA9PTo43hl+9ovnJ0uYJZNQrGMSzIRYLalx+WgKplg08ZcSwI1VwbvNDnc8+NtyKq57TddeR/Wdwt/d518XqPv2LGfdxu++W0lYf5+vtcpsHqivaIlC0k3NLcVRwUUuZd5puBro4rBrfu3Bg8IOGrGnPgCGsSyOcP4fffJ0z4nT1SQPv7pP331/d5Djqqr3cT6OtxjD+eXlMOP/xa8/fLRFxvCH++5v/+Vv/odPh3/zVw/ff3AgsUVQVKUkgAKqKGA0GlCUjjSyEir6ICGZN6etCvguqRAi0teAFso6tqxNre96A4Dgg+/ifLEk61Z1433IipyKQWJeVQtJCQGZjcg6sBITESH21dd12WPDYKKq0rrtEQjQIBIoSgxJu5gSoQAhiEICRFD69+jod+kRXDNR78AeRSFN04Frq+pV5VY8pXzgCKTrTBuHnUwCECWfggeyYBxrIhUCIRVWNAqKHMgoshIrGkWOjIICmAATIAWiSC6CU2BRBmQEXpvIutzQ3whBVEXJMmeNEZCenV9XqUAJEmMilMSSUIWSYmRVA0CgAJIQBUkBVUnBkHIG6cmEQToVTcwrH9hX4zh/mKcPhrJnZd/4oZ/fKxjqVQJ16Pe47mZvbJjZej7NbbtctsFcLbwQfetwiOq/fPnio4c7D4c296vbizfbZXhwsFVqyxJInSJLfzZKREwEKYYQAymAJGZzU7UvL699F0E1s0yG360VCoAqJUEBSApJUQRSkhCECJnBz68Xq1lelkju+fWyVaMCGbOqEGPfi4NICgRICuu87u3dhHWZP0nqwSggCAiqqmiMKWM0bLBPA9GQWlWSDelNIAzRiqKAIAmahBiIhFAgKaoQACYFMknv52Kr+fM3N5/fwsKrpEjiDWnujBGADmkgqwy8alQABkWVHioyAkZQoEAM76ChSH3brSgFBUxoAhriHJQioCii9oQsKKKgSs+KKQgoEAQNEZKxxtqMjTNsekiAACBCoMIIFhMqkDIAESIK9i1jxH2bYd9AMnVm3M0kaRJTpeInJ7NA6aOj/KNJ/F9+sP3JgP5nh+MpdB++/9gYvG7VGvfJwwPOS5D26cHUSnvbyI9fNX/8i1Mh+Na2rdW+uplv8WrbxNA2C49/9IMv6ovro5HJSCixECcBAEYgURSAoBIRANFBAoAOzauba1FfFtZa7Xvb7yK+9iyWYkyQEiQBEfCh60KnpKNRuTfKg3Sc2+Fk51WFiUtICimyYSJEAmuNIBrjFDAJgABsOi2ZGRBEpe/47Xl5UU2IkFQVgS1pAAEDZFGFLFCOaEERlDAJKqAKqwKQKEcgQUyIQoAkgCBkEUSBTZTvPhwd5ubLi9WKBshM6plUMLUahEAJ6OnhdL/EPK1calp0gfOALnLeQhYNs/o8tayJNbBG1kAKACxgE1jSaKG1YVbGWS6rHAJuTvKuNaGPmAkxAnbKCY0SCoJhLDJnncmynMiRyYVsAs6EbSQnxoBLzIqIwA7ZoRgNGQirx9RQqo4OdlQjIKjS+eWNoE0gBHJ0sIPJ35/k9wZ2d5hDiBEpsrtt5HSecLi7FDPdmra+cwfHX1ze1AgddlZjkZWWjSyuwddG43x+XRjNQ/MXv/l4UmBpRWLtWAFTUhElUew7uaWPagAK5AFvl1WboH/vUfvSnqakqe8VFUhJk2gSEYUkKIqLZdXEpOUwT5wbt9CuE44JEECSbCpdGlPsW9f6+QMEsMauu4k2XSExRtU7jkYFVLSP3pjQCFpRAgVNYIhJ1awhik3ICa2AAQCjgdWjCkMgFQBU6gEcCGKOcVIAa1u1K5CQOQIkUcPJKXBLXrNI33q0983jreNSXHebwAA7QfIhejItJKCQScsajCajkVVMAlKTwEUoGcRJu8Vt0V1NsYV2Tl+nbvsIkJAEWdFGZVWjSpqEUoviDSETJeSgpCZDLrOALrJNjsR65sQWyZCSRXUMjoQ1OI6aVlDYypaQj1o0L8+vj588SIBgXR0pst2ZDC2kw90JqkciBmmp+MnJ6rSGq1TOvLHOPb84iw5bSskaQdcuViPmw+m2IS0cPjzYeXq8ezwu6/OLX3nvwMr1zoCttgximKD3ogqkCBvOWlRdMXz+6vR//KM///Fnz/rEZF1xpq8VQlXRMCGBdbl1uQj+9GefX0Xz9PGH+7t7i3aBZED0rqdo012jgBBCMMZYazcDCCi98aiKiMim0bwn+ZP2pi+AiTJFq0AAYEjUNxw7SxE0xahCLlLuyQIga3TgDaqVYDUpoCojJFAV4KffeGgsoQHvV5McunqpSEEzlAEACwUfZvwv/k//9QDDMGOUeBsthbakZLRTiJAhilrhhAaQBAiACBCVBVwkQxAI4gDDtz54/MGjw9tV1URQ4E1vyLqipGi0T+WASSVnKkinDkPoCJQAnMuRmYxLSUsEIAtkg1JrgYEsGMsOrUEwCiTACcUYeHV2+ebk1XTv8MVN96OXN9c1jONssVwmNzJIOUNKcTAoDUgK7W2AJlFS9+LVyf0Hx//6+z/c2p6+f6+4aeWyU7XFN4fZJLe7B8df/fxn9/fHBpSLkUldnuLA5S8uX+dO7+3vXV/furIUVFEjCghoSPteMUQgwL2Ju3zxDN3g8f37hsla7jNH3YzlKAKuR1QAAJRBBHJn5/NVo8WLq7P9gx0r8HKFYvIYomNEYxGRDTvrkO4aGRhEQCFJumuuVFGknhPYtC2pIrIiAbKQQwQUMSAWQ6Y+N5J8ZdgpmYQmoEUggmDAM4iocdABqoCN5BgiQ2qpLOQaFq+OD/ZvhK7mAa1N6CIYgExISerDIfE//Ed/v+RYOBoW2cX17UGR7k/o4ZggNrMQEpSkeSBKyBFJ0TgRVulnaBIRgLDC/v5Bwd11JYs2qZq+BvM2FiILEIPY5EsMhTYDDB/c33KkXbO0KKjRMYLKIM8MJWD2hJEQGAwyIbHNPdsEJMqKJog3BJ0dtcq3C//FedUVu97lH+0OtranSnnOwtIyYYoeIBXoY/TXN/OgBNnw7OKKQH/zkw8e2QZo+OVNrHW4Cw2kJqrZ3x6NcqOktRjULjcuA+PGdmC1W1Yq4H3qsa0qgiZGIuopQFSAuLx2kG6W7b29nWHGee54w2XL3UTVZhCqh1ltHc5Oz64vLtWVX80u3n/8cGqK5xVUXkTUGEwiKUnfIbIexfFeZU0ZJknvNtIRUlo3wGFPSQmyIjAisjUaM+gshFzqaaYmVg+PdqvlKmhSdkIGQAkEtO/usk49oAmUCbLVYFVaKrWbTXLdmuzK1v6L04WSjYoJMbJB8GVo/uqvfWBIuhxNbogR/8MPt3OjWwPjAJ9dIy7Nl1ccIRds7rJlRbHqrVRB7coMhGwj+IPn5+O0nKkVyAAIIG4qQn0xGxjEaNjB+mh3cjSd5oxW64P748NJrsTz5TIbTL54edL5hRApGiS2YHIgIAWkRjrFgkARhACODw5uL15HW6wMv6rrCGUwQ1b+7OTVGOoEVMb5x994TGw1+iLPC4IPd6nId7//5WIOoyq2U8QC4yS0x/n2rilX0V1J3LbFuBxiwE6qKIaL4fxqbkaZaXSvKEvwi7Or96YH41i8XnXXac1+U09OQt/niMK5LbYcua9ev/no0beJejwE68klxTuT6glAAkAJsa1Kx6+uTvf2dn7405/tua3GF0SGUDZVPxWRmOK6k7YPjQJsGCIArecWCElEgO76vnsuVVmUMBhBJ52DxkJ4uDdw4otsON7Oj3cmr+bhs9MlCggooEQyAZgEBTgBJSQEIBSSBKDJjp/fVDFc3LrSs5tMxvF2phpql4oUh0DxpjWjQcnqlVJh+P5ISLqBpNh240R5TbnPMyShRT9hqIA+pIcHWXt9EaM63k/AbYAO6dpnPrMihhDhnTKZiAJKYSHz1a/fL58+2KZ2zhBDbLroi6EzloudSTL2vemDm6r99OVLU0yuFyugzEjWqDbEaMiGYCSU1lrD+6rDAk4lVCGwxuTFWddF0On44YPjUebS4jVnedsFYqo6r5nB7uZoa/wtuv+vny9JRX2dgVYRTey2rb/o4rPr+ew6HN87fFCmNq5a5MqmrNh6HdI38xGn+tuP3ueOWy1kHqYPD//Ns3Nl51PsgQ2z6Tk7tJlaarsQrGaW7obFVaDnXfqjYQJJEKIipFFZfPj0yR99/0+ePjl88Ojh8+vmX//kM3FlP1hNyEmFiJP0cxP91FN/tiJB+vZRJsa7RvVNbU0kEZKKMsaCINewMyRsqt3t4njHNjc39+/dUwqfvz6ZvZ5Ps51GfSRooglcAucmxoRlFE1RmIUAQLwBvwxGdfrFVajzGNF9dDxx0N1en9tETpiFmmjMol7mBFG7gIbZOkyLpjFEeT4swvWvTIsca7UBVImpHG398RdnHx3v5buJAReduZi1MZt8eXrRuO0oSgC6Kb/3To6JQBO31RiW3znaM/EqI48aUkbBageRSK00qNk4d0eDbD+778rx5Wz15uyabfbs6jICbm1PR8vZwPGDg1HquuNx8mP3i5lvnN/fHnnPZ7PlddMNxscpSRcTC6w8JKHlqhlt7Zw1MYNMWlks6pzTOLNPto+fv3rxwtgxzR/tcnDdqyXMwTZnl3v3B9J2562+amNRAGTksNse8fn5YjooF4su7+pRoVa7NvZsEsSUVJSNUYSqC8fT8bK6dCMnAJqA+Z3is67T5iSQonjfSQo8GNjC3n/vyWB79PkXJy9b8PnUdyIARCwqv1RgxLfNcAoKRGSMWU8bEBKQgNz1izMiEWYUxkZKbffzbGurGJVU0mo4DORvm6BDrL9xVHqXf3V20yYAHCrmnUQi6MQKhoFDjQFBj/e3/FUV7KSJzhmXNLHFF5+/fLztnjyciu9qsC9PZ41pDBqq6roT9WDywtUCDG5ajGeXzdODHfTVvakLKUwmEwC8rpafSXU4UIupZMNlSltbVx4GHv/kfOaKga4ny96t90DOsG3if/DBQ1hdskmDwqXgOzGqMSV1xhQcEXVRL5rGw3WzCGmYD9/P2e7mk8nOn3/51W88/bC8bur5zZEz02lZyrzDOD7elZCGQxM7SYfbzy9v/+zTn/gxV138a3/5L5zPawDOpoPPX5/edvQb33pcJ3Px7PTeZPDk3mDbpDcX7Vk039uH95yeXr361pNf++mL69Q1g8IcHz12nf3RD0+z0dabizcHWVuOd25WkqEfZC6H2fOf/iSHQbRci6gq9cX1nucDPLu6FN+NBiMfNLPvNNtuhu372cvVqr25uUELVIzqW39yvaTF6qTjL66qqEVEABBiTnez6hv7XGeCIgRvhTMSpB68K6qoEokqMGHmMrJ2p2CzPH1yMB5YP3ZxaDmz7DW17ezlydXhvYO90WARdZJvgc2+vPFfXi00sLFFrZwZktWls05t+b1fO+r+8NlZc2uy3LQddw0rGq39efsrv/bxJGXXxpncfP+nP+Z/8E9/TzUG1UZUwSSBNkgEYovsuxwXmVtlKTTzKwthmLlhOdx13dCyeIFqHhZzi2l/khvnVqt5EGJy8m5PM5kn9/d/9cFwnxccm9yZmFLTdZgVIhBDSDEkSW3bzWa3oWstgAEZl2Y0tHVYHu5Odkb56vz1di45h6nD1N5GP0+KVReOR8ShzdWTtNuj4v3Hj+4f3vv8fKFuUHltk758feYFjw/3f/jjH57P0qzFnGLuZ7vTURX1ZrX8zsEgg3Y+Xzx98ORnL64dyG/cY0v8/Lr9+XUSzpvV4pPHO89OXm4fPpZQQfI+hUVbrwQDl0GZQAQpcy5JAqSMLcVmf6t8sp0f7058iI6pL0IkABFICpogRWiaNiY5X1a/eH3x4qrymJ9erX7SdGIGmTfR9KyoqBK+VcqAvlqqotKTrYBJUo+uiImZCannNog5d7kxxlracmEEy3sDUH97vD+0FBvfJvFNRDFFYeXy6ppALfjtYbY9LKVZ5NL6FL0bm7j8aN9hSlV0efDh+sXOQHenpa0uH91zW6b7zY8fpds33zjcybo5cppuTfLM8X/+T/7TzNmILGDQN9F3KXZMMi09dlGczlPFkHNWND5Zmz+YTAroUtBVQ2SyUTHsmpUP9fGWO7j/4PXlqvEATHfRUFA5rD7exoG/9EEWdS3Iym7ZhlVVV019fX0zr9ub2bJqG5vlKWfKKXHqpOE8OYm5D9b7JdNwOKmqFRrrLb9ZJCx3bKzZZMyurlubOakuW58+vYqvrlY3s8WianyEvd2tjw+MYTq/abpok1/ulzAoy59/+eI3H+8caCvJldOjqTSfnbUPdre/OVgCwp9+frYaHrddKFP61SfTy2b56rLa2yoKg1npsvFo2UlnRj7hGkZuKuQxdA8PJu/dP+Dq7MH+vulLMb1hCfgQUtJ+1AIAq85fRfri5GIWzFWjMyp94oRWrRUkJsU7ZQHEfm6izw0BQJIQYG9Sqmqscc4xMTMDIyHleUYIKSlqtP7m8U52b+JAWvHLtlleryohqdV6yFnbLM8hhWY1p9SOM97N+WiruFiGWbI2zH7nO8dk8xc33l988VsfH33juOja2ScPd+7vm/d2BiPoHuxtNYsbzpVSZ5tuPyv5n//zfwJEbYoAOsiQMBHq3va4XV45mwcQcNZxESNYV8QQXeoYNSmydZXEZt6krq41jNlvj0rjytmyU5WEAkCojAhd17bzm6Ojg6ghL7LKt8h8fnV5M7tJKbI1dUwms2CojaGltGgrNQiMsW0yNrOLcyZo2M4Xc5vlQtwIYDa+WdSOdVjm88iJHEDYKg1nGeRTy/zBwfDx4c5icf744f5WnA2Gg/2dvcLAx+8fTm26vjxllW/vlyPWgJmY4bSgl69ef+e9oz3XWpV2uPvZZadoc5FHx5Ofnc9Wnp/slAbqvMgT26E1uYHKV0NPLZskgkSgrIQPJjgOq9zEw50dQiRcU/ABpGmTeCCBmPRyNm+V//jLS823KjUtmGgMSA7GqCMUBgBFIrKKoD3XAIrUl/mln3da98mAGmPYcEoiCioOMKCjOqhFHun8wTC+d1DeXp4Ug8KnxjhNgpoxGcsEzlDVxMtlBYbFd4Wj3ZGOBsTZ6ORGLMuTbf3q1bkPzfc+PNgrI6cbCe12iRZq6lpHaliLwgkLifrFKiPgf/xP/n7Vdlme+9TF5AeDgWVMvo0RgKBtKitACqNimEIoLafkQwyikSi2qc2gmI5sKMqd6dby9ReHezsnb84fH+1FWTVttFxK8gl51cnlspMwg9BYiEy6XC3YIBIu6xUZ9Opv64Va9MGT4UVVqcL2aHozm013pk3smCEz1Ha17xqNCKrEqAQI3UnnTm/n25OyCz52TU7x3ig7tNWY24PdIoTbEVlGhrA83jJjkxymnVGxVZjxqPCagBRArhbt0x07cmneqbXmecWvZ41irhhPLhcXjeXU/AcfHbeLcyZXB7J+tW9akXYKg5O0biVRoMi4FS4+Lvja149293NDfW2njWnpu+vb1bQYz65vP/vyZWfzn748Pedpo5iIERGlaTl31rJfAYBzWQzBgkrylBUAABARDIJCXwZU2kB7QMPrvl1FQ6V1wYMmU1jxHw/rp9vC2rTtqkuQDW0bVpKw6jpHwmGFnFedWQrVAkU5snnRVOcNytH23k++uIhAx+O0Wi0PB+1HjycpzCQFg6IQfdc5V/RW7qMPXcdczJuacuT/+v/4+8tqBYbrprGGY/B5lrVtk9lMRIbFIHNZWWQSkyQhRGO59UEBhoNh1xIMMsM+z0c/eHa6t7Pjvc+tfnC/+MZg3AQ5i10p3YHrPj4s0u15lMH9yeQgM9i2ne011Hg4HGZFtqobNmys7XXeiMgaE5vOOYdEkmQ0Gjtr8sz5rjPGKkJKaVE3Mxn84HW1TEYBM6kMGSRug+cMS5dZNKiaMQFA09SM4H3s9UiKPFNJmYHovQ+dqqLLbus0T/lnfvqnL+dgMgcJyNxqOcrN77xfZhI/f3M1HE5iu7rEMl3MHhy/93OJ1zUgABEpIDBtuzTy1dH9w2mZO2aB3rdQ0wVNtvL0g1983thiiXyyqGocqAL2YJsYCIda7TnPqc5TvcVxwu2jLTtbLgIwWAeiRKi6xvSIa8mM9ZQLEhMZTgkSCGPiETffPswnxkcMYhjJJ/Ft1JpLQWDMJZkYw2zZCJCCLoO5aUvg8TwMv3p1YQYwLejY6e7O8GBqpblZ3F423itoiLHtOkmpbqrouxgDMV3fLoAoxMD/2e/9vWI4uJnPDTP1rf8xMnPo4nA4bLvWWcOaDLNzdlU31lFI0WbZwDpTxZhXhfWpwX93ifv3jo20D/Zy56/SSq60/PR28f7W4K99+/CDSfrowXQywMNt10l323kvYbZcZEWel4WCIqHJnBKWeWmtvb6+KfJ8b7Llve/aNoSAYEhRk1jipqubri2HAyC+ifnrme8CVIvb3QLbunFZHkRaSBCloEx8dEZVNcudKM0WSzaGjcnyDBS6apE7E33XNW0c7P/i5VU02afz8qLyjoilU4iI4Oav//rT3Lps/OSpeOmuTv7wTff+/Uf1bftv62sMZd9r2Q+N5IZ2OVxffPXx06cSOmJUpKaTWHubDb+4vD3tpLb5L86uOpcrZOvhOVXh3GrYd93HxyNubv/C06Nd0/36k91v3hv+4sXrFRaRM6sCoNhHw6T9rOW6fxDJMBMqcd2KZbWFyr2i3oZZ7G6Ecd62KreLqlnB9qVMxxkOcpcANXbsCgEajPOrxn5xk1/fyvmMypE7vlfvOpqkqDg3WqduKeqXXVjVVReCqpZ5OZvPAQENtqEjk7XBoyX+r/7Ff9G03WBQKqj33redZVMWpTVmNpsVeS6SHJJv21XdCFCUUA4GiOhjyu1wEefk8oXu//+ezSsxq8Xt1FEb8I/Olp/NEc32mLvjwsvq2nvfNG+UfA344up6UDgkar2vmno2X5Dh2XzWp+4ppulkoqJbw1E/vFfmRVN3BrCtKkzKlpKEBIIos9ub4aB4uDN2qSocFYOyH7jwQL4ODFRmBXFSEZ8ismWbOee6rus6j8yFQdTknLte1HF8lESOptnt5ZuQfCeoxB8fjz6ehMdTe1Da+WpVpXxocGzo51fh9fK2i3yVICXHRH3HpSLFEKfk72/n+3t7jgkJO0FJkKr4o2cv/vz1xUzdVe07zhohSiSSVIGQIxnSkEszIv9kb3g8NgOodzL0zYInh68WsUtkQVOKqCoqIGjWLNkmWwQg6vsPc6MwNe1hvniwZQm7qqtNQYDLGiZf3Y7P5mXenQyLuomVBedjIiJjeOmLqzTNbOZj2t1SF55jV+cCCZeha31sgkgTU5ZnAmqdiSn1tQHDLKRN541zisL/7Pf/kQKwMSEGVW3rdlgOANQgjcdjSckal0IgSIPROCoaQzEGY82ibutscnOzerPK/7tX0FFxXutiUQHALA3+ZBEbM+XOhtQ4bbLh9psKn53eZtaBbzG2TfBt14UYEdE4EyWBQlPXoevyPIshLBbz5P1wOIwpdq1vVq2KaEwqajJjnfVdMxqVuXgK9SSTgrywYTbWsnMuegKEKNKlkBllVEBWk4lA17Vd1wkAG+PrWhXVOrd9/OnJ/HCrfG/oj0d0ejVb4aBS/qufHDy0rWK2kszXy7i63BkXIWiRj1429aUY8i6iAewTNBRVH/Fg7HB5nmfF9ngISDEpEhlxMxz87Hq5SjaCU5MlQY29BicAITLpRkzmm8fb2ixKY/YODhZif/DV9XWjyBZURSKCxhBoPf+MfV27b1clYiGbqHCy3CvqD3eQwzyB58IwtFVsb+Heq9W2UfvhQZfxIkhCLbquM5YcUut54XFvos4sRnaxbZrb+WI0shHCxc21BwDjat8lSb1uU9d2eVleX162vhVLZDI01PmO/8vf/4fG2CQp+qCghXN5liGiM261WuV5roohkrPYdB6stZb79oxyNL4UfTC5/9OT9t/FPSe+5kmifFb7hdhVMiRqJC7BdkF+fnL7Yk63Yfr08DBdvTgaZedVjYh1U2/v7DRNMx1PDGLXtACQ50UIfjwctk17u5gLQN02qphnee6y2e3tbH47m98qaNd1eZGVuRHvsyxvoiRVAJSYjGSmyFpIXfQDayxDl1RMDgpN2w6Hw7OLi9F4SxTElLeerrX89Muzbx5PR+l6ISaVey9nPrLxVyeXs/rH52mFw/fuTT7awbZtGjt9MM5en1dfiCt0mDCtqXVSAlByhdFS2kf3DwZFjohJMSSoGv2DT7+6BgdcKpAPSZOSCiIw9eU9Qc46tE2iCfvtrT2w+cms++Pnty8XIZJBFNVeKliJETcjgcQEhETExAoYonEkBV68t6c7UA1yuq1mySqBn8nw0u/NQnE4uj4qK46yWrESCchgUICkUTGcrS4n5s2jYxzgChYhuhJMVbepEaFsGIBBgw+eiMgwAVVV5UPY3tmOkIzNgSimjv/xf/H3VaSr67Ic9BOvBFi4rK2bzGUIEBJ2an29MM64rDAIg6IwxIvZ5e4w8KyZ7Ox+9uZUqIxgI3IgCqn7xmD7aJpfrN54s9MKsnGk/oN75mASm+YSMibjYgiGOc+y48Oj8zdvNMrB3n4xKOfzmXPOh9D5gIyL5aL1YTiazBbz1ncH+/uxCwf794QwK/LLFkVAyM3qqOrJDZJI8tG3EowkjMYYFiGQbDB+/voyz62xpvN+d3cnJeiAKx7+6fOLn7yaRS6uT7+8d+/gv/nB1XkDiayEelqOPl2Wp3HcLW9Ws9vHW6YL8MMXF2OXrN95LlwnZE39HElMiVRVOVF8enCvMGFnOhSFGOHqcvGnn32ZPXz61fWqbbqu8wSqSXouswfhoEmAE7lAZnlz5aPMvf23n50+m8tKnGFLmgQsIhjui4Z3uIrIMBH1E/QlpwNXPRi1Tq4fb00uri+SxWW7WjV6Fg6ulnaYxY+PLm3sJEyNOV7pkg1Ya+plVbftg6PR1F6u6jd5SkDDCinE29qDywtk533IMxaRvMgB1HvvnPXRI2qUuFo2q9VKNfHf/U//V0wUY6xWq5jiaDBEVWNM13S9olWX5HyetoYGIWVFmSHVdRNC2BoMYtNcBErOzG5uZjC0Gglir57VtbHu6qx0TcpA0pMt/vaW//ZRd332CzMetdaGxdJZOyhLJqoXq2E5mA6HvumCpMy6uqryvFh2tclcVpT5cLBoWmNtkWfOZpbcxdXVeDK+mc8im91xbrNMgQzK7apjl0WRVQhtbKejcsgmKTmjbeKz29XAGWNMkkTM3qcqmeez8OwqdtmkidgE+epsMX78XrXSulkwdCVA7Fpr0PpZLVk2Hiu5FOWrs/PG3Luch2DEqKpokiQglIREahBs5JuPtzQlYhMjqOCfvnj18+t60RFwMkSsCXttVyLo+yRALKvGoBI7oZubxavb9joNxBaJrPK6U6QfXmEmJmOtERXDBqgfHkLDaRsvvlEsH4/13vbQGQKm27ZaiZ/J/uvVPYf4yT2fy+Wy09qTF0gs1qGKtEHnSkdbBdSXtThMgBlDUaTZTWITO59nmUocFpmKxhBiiOxsVdcqmmWOmMejie86xcD/2e/9b1NMhk1ZFGRMijEBrdo4W3VlWZajUSfutkr7I84cGeuaxZKJgFzV0hfV/n970T2fhaq1AfMMGiueADrJr1zWClMtQWMG/rceZR8O6pt5csQDO/CrGiRlxlaLRbWsXZGzqFHwPqrhnZ2tFILvfDYcMHNUqeqG2EgSIgohghefPFuq6kVR4JZTI141RqBkRzfzJaBet8u8zEqRqcvnXWdQZ1VLxQh96zLHTKFt6y5cB/vj16sVjyNmCW3gMtjyo8Ps5MWpyyw79zufvP8r2W2u8yf3j1/P0pc3zWKxujcs2mz7+7dV0RGTCECSqCKA/biFzkXZa6Hzw50JqEEAQ/zpzfLSG6FcoBNJiglBkSwT9S2RxlijkVODEoIdatLOFJ4KTA1kma57kBARd3d3mrYlpBAjEThr18NLSoX1709mHxTdANoUpFOtfVfFehnSy2p3qe8N0/yjrZt6QQ3aYKNgs2pFQRANMV6r6ebXlFKL247NIlzu7u6XHbXSSoqYEkpkJkkhhmAcF4NyMZ8TYp5nvm0AeFgUVbXif/xPfg8FUxDmLHe5ZfiqKv/1RfdZtd14H+3oT0/NNw/HI24ltVc3Nyn621V4E3f+359Xny1pVkFITjiPCsiclDYMtLBqQlSD90v/ZBxdWjWpWXpNMR9kWAzKFOui68aTx29ig74blOPRztFq0Z6dfDEtBw/2Hl2eXk9dmWeDyktW5IXhIi+WdRPSqgPfxG7V1WKpjnEVYuvb2ufP6uFVHQuKe1P1XcOGGl95RB8lJR0XOWpU5Hp+vTfKa8z/5UuOxB3nWUIjCRCj0OnlIlGhpmwDfLjdvpe5ycHwWNL+OL68Xp235uWsO6nCwwf3bxeLyCCSjEZVTWBUkqgwUZQkCQoyZUbf/3f/Lnr9/CpeNIqoGIUUUQGB1yMza5VPFYWogGhSDIKYRAkiopIKqRCiSnLMPkIUo0mBDdlOkihrIHLeHkxe3JdmQtgUPtWhtspaL7q6ovK2e5LS2OO8cK+SmDbkGkfRGxjo5XLQwrS0v0irgaIZDkYWmgAxhdhWdRva0WTqQ0DDitz6rvWhGAxEQLqaRELonLPOueQ70Li7tc3/+3/0nyQICTu0YIwsFs3n18VJHNRmyxZFdfI8h/T+g73b25sbb251ZMotKbb/zReXt7S16vqMBjfT9IRIfUs/r2unJCI2zo+3RyKpjc3euMh9J/5aiqE1ru3wIg7n1UXy+Po2fXkTCa2yJrVNg3s7O+dvXjMDQOh80tBZY+ZV47Fzo0HAtGybosx9jMaa4XAYfWoSlqzbpViToqCzNgYfBGKIREyomXURNLOMmL6c8/NmRNIK9SoIETAoJlCjSJ0PTPajY8jqesnJ+jAZZ8mObhqNtuwU29mtoPWcawooQQAFGTT2spaC2LTJEjx/faJ5Gbv4otJajWgkgXVPC/FapY94LVInfUxcj2cSIoAQMSNuCswIRDFq0oRAZDjLWZQUUQBdoGl5M1n6e9PxZfAhNMvoFbVN0CVtg1EplfRwIsyXeZFarlpW7YqmzuoKdopFmQ8FYubUQlBSazPDIABd1xIb79teP9daKyIxBMvGh6AAzmVZlk2nk8xYEeG/9Xt/b9akgPmi8avq4nSuJ6u9LtvtlJrO73dnf+M3vnG6ap+9ufpyWfz4PNnRwb/6k09vcThLhlX6BLufkMQeK7xVJ0FAsM5866MnJydniQdAuJ+n6uxkd3/Y2uHl+aLhrR9eh4NpLrxzqTsXadzV/um3PjmdtYkGYABBS6ttswwJm+V8MCzb6Cvpll2z9G0Xw7AsAcAY430nvj7YKqwuCkpBhEwRW28QuxgRMMYkIk1bZeWADSSJn17TeesMCGASRKUEmAgTKgMAswGQCV8NwM815TZzBNbar05nWu6mFN+b5su66+yIU6sxApL0jaSb5qlW6er6tkHbcm6NebkInli0Lx5v5nWZeikoVZUk2Cuq3E2j4J0qK/ZK5r1UH6EiCFuLIIPJdLGqCVCQTOJxXn285SZb9tnVqqVZVXWt2i7E0ppyVFQeyWxnUS1qrNz59fZFfW8k51vbQ+fMblln1ueFmc2vymEWOi+SVJXZACj107AiRDAcliH44aAURTYOkMbTKbMpipL7/TP/0e/9n2+a0ZtbW+kwHzpfvPe6mlYKjsO26f7io9Fivvrjl7M3S/hyRjVvrzqkYjTzmtA6fDs0QYS8bh5VXe+tAASIsbu4nF3Nm5sOW99Oc4opD4NB3S67xn553b6m6fZo8uV5dxnKueRdG3/0xYs6lVcVtJKmW7vTrYFiurquBoU1luq28hLZmBDCeDhESMyUYohJmGBsQ7u69ikqufmiTj4wat3VLsuNywEppeBTZFQFfX7RNDgQNAIQEQWYFIyqgtnIVcSPj0Y7NjQJmMj4tnT45dnNpedC6v/5+zs3NzeVZgYliUqvBrCWclFBFDR5WVQCyyDz5XKWWIgJlWTdhder8PX7f/q+UMJ+gn49Eu6cy1xmjTWGY4gpibE2JikyY0kgeWdhtvDkLEBCIFQcFd3B8OLV7VdXaacdRI7UUjYqR0PnEpdvZrGWcapUtNzNw2Q/96b75mHw/lU+iIXMjDHESIaZeZBlmc26ukmqxnDoGmvIIKgoihSZ812XBIlYRazLmroCVe+9sYaf/s1/MYtlS1u1Dq9W/mWV1zhweTvxV3/1/RyaxY9mw3br0Ys3M+ACyCpiiDFpIpR+WZKu75cAaEoiktjYu4YsIkjIastWswS4qLs0eu/lqtl3HcJ4hcVpKm5WBs3ER/ExBGXMBquEtboqYqv27OJs3lT3D459u9qajjLrWJFEh0XZLZc2t9aYzvusKDzAdGAvri7McExkbZbvbG2RRDHY+SBASYStdFHaZpnlrCk2nldUAqFRm9SyMumdciBYxm8d7uXpEhIBqond0GgLZhHkYRG+vSW+WV1XPpLrB6N6CRddRzFAiJBEmYFQ0ES0CoKQSOntuhdGBJS0nrMRkSTST7oTYZblIUaRhIi9UJEmQWctxhy7ySBMR/mqtsEKJUG1BjF0q50DuGrgYr4/g3xiVYgGeZ48vpqP5lgEOxgXAUaXe/l5aWNdVdafF3kM4LmNzmR5VnStBC85xbppkAiJSWQ6GWWGx2WpIpkx08m4Wq6UrbWsIiIJNYXg88w5Zv7O/+6/DAwtpA7By7imoYVuJzv/yw8nx/pawP5guf3pySzPS8tgNKAh0AAxMMjGM/UKYhK8t8yiymR1o8TXq/QIGkDjkywCny2lqpe7OX5xumiF51IEmnZR22oG2ogpooICK1MDdlZ1Js+rppIQHx7uvnn5FQNYoJytQZSYohFrmRl9iK4crKqK8kKAoKd0QFKobeFiktaLIKrG1ndJQgrV8e6oHI5e3TQm1QZIKV9PtOCdBIr4WbU/qLRJXPLuoAyhUmfLUfnNPbsFy9zSovW3qQzSI6Mk74hOMARakwQSZS2TwIR3wqHERGzuetjfLhRCRKQsy1JKqkJEzCx9tyoR27xwKYvzD4/17NWzoHsr6qwaAEsgAOZsoVU9lHZSyf7WuJ2U4KtlnQYvVvst5yEupzRrl+MHExm7RrqllfGw2F61YlIpEiwRq7U2L23MsixEiVHIKIFYTbtbk8lwq8gsgpZF3nReQ2Cm0rnRMI9dOywKTZG/+/f+6VoKVzmpAaStNP8r33D7XDnqisHwdJHmjWFCkZSks9bEKJKUlAR6l48AQCCGWTQBgHMFrTUgEYAUlUBZQZCCQhnr3/xw+vykW7qt4WjatVi3YbFcGgvEyQCpJGIlFEJKaAFle3fSLGfvPzgcOiMxZVkWJK2q1WA8rGPDzKratdWwzG4WtYBKrBWBrZXoJfigsUvqEyJzirVPwixMkGK9PchbH47y1byJno0iMgS9E+5CqBt4/wGgTzJAbBqvsfENS52rzxmzslh5/6LK0WQAihLkHWlLAFJwiNJrQBnEfkURIL3dpSAxpXQnYaAqPYXO3KM1YOL+hGOI/b4wtJZT9WDbbevnB/tby3hvro1Vx8KKIWHmYZyz/saH5vQ6TrYsVV8xwlVX3MC92OkYV9/cukzti+1J0Oi3p7sk3NZRHFhy42meoeS5c9YOnBLZ1ke21hg6Pti7t7d99ubEdykGT4iL2fzo+Gi1WlgCQt3ZHpMmx6gxUBYGLpTOD210RI3DcFDoPVg6qH/28uT5l8+e7mU2LCW0SVXZKGECSMjyVslorUeRVGJMKlA3ddM26xFvJFY1mgwEp76g+GuPd6+f/fRNV5zH7OS6iU1obk4KC0IGbIbgLSqDkASjwaCGBLNVjG7w5z/7xWzpNcXz2WUTo0dsk08h5c6BxFHp2NfGuhRSzggYq2q5qJbouBOIkmIKKcUutmgQmSLwsvOxOn+65T/Yar/1ZJSla8YaKPaSlEjWOttaO/MNZPbN7U2rWkeJYaXt9Xwxa01Wh4DdwkkA6VtITT/31hf/FFwCTmBBARVBEoIArK0KEPtuKjbcbxCS9QSzGsNvVYMJDZuUJMSgAGSMArFhSM3I1Fuuq2fXUTyJRgJBAiWleHwP7+89y9yby9NLVuk8DbfvJwiO8r0M7g/873xyDHHuBuBlVoUTMFXQK6GbJK2PK5SmzDSmGELnLEH0zXJ28vLl61ev7h/ds6SDPNPQ7e1MZzdnuSVCefLoeOBwkPP+1mh/e8Tf/d3fV0hAESgZBUL99W9Ojumrl1fNg4NxUzz8v/1Y2iST6VaMwRknQSUmXs+LawzeGEMAQRXIAK3baUViCB0zE5OmwJBY/SePpnvYfnExP8XjxDkBv7m89YCuGCACqUJEVQYkFSC0AMyAKZLXYSQQ9j64e8PZ65sbDwxUtvHGip0MBvf3J/cPdsqyvLy8dfnAmoJBuqgduVnAgGzY5oYzEqVFFykmbyEjo3VoGVZdqHe5OSgoRbqtk6XocOyTNf6q0ItvDKsuLOow5IxTjGxyL4JsK8wdwW4uZLLrheUh+9ayAYOKqkkFQJiE+/FDVAVA5jtBc0SUJNjL/qlgP8NMYAyr9IrSTERE7IPvus4YCwDCho3NdZ6n+dP39rKuaWDnPLosQmUJwJQpMOvHR3SY44/Pt37zvgyPHn16cvDlqQmM6Ha4+vRbj5oMdZwXEDQ3+bzyJmNtfJ7bsaW2qkfDcbVcLJMfFjl33bfee7A1gKP9o85HdmaSF2XmcmfzzL05Pz0+PLq5utqeTAYEDMlQYor8vb/7X92NfyREQHh6kI2Wn3fRvlnEkB/96KQhxNl8vre31zQNMqWUkBAQjOGyLNf9QEnvNoD1A7iZc4RoUC3hqMzHk8np5c3NsvZ2PIu0mt3MZrPRaKSqzLzWJcC1PMGdZG//dRIoHFrysdOBqUV8Vgy7BOBCZvOb2Q2TvZkvIqpPUGZme5hVy5mKWONQdeBM6toYIgIwZapoRQz62pP3CdFm2cAJg3Y723Z3C94/HFzO6k7k0TQ92M3IzwGU2IbQMqhoQqbZqlLKHGmMVcrpYHtvubhhHKhVItZNn/tdVMSNwLhudgp9fVej9vJDeZ734n2iYJ1TVd/5tfaqCpOdFsWge/5XPjkqbX6+KncnSzfWi9OjW5OGPnMSW+fbNDHVyw+25XRmb9rw45fzGvfU6aPBKjYXv/rQfnyYNasaAEISQzzZmjLK9vbYGPRtGJblIHPDMr+4usyNBU1J02A4qmrfep/lmVGxhp3jlGQZ4vz6+uHRvWHmcssqMijLInf83f/N76/zkX5JGEIZbu7hZaf5s9Xg09fLubeDQamqs9nMGLM+JFAEEJWu7ZDQGJNipHWzGxKCMeysVUkGxTGm4K+vr2d19AkuZlUjxKkblIMYE1IvFNYLSa4lxTaLotamKqqGkEgiWDZp6nDVVMIuHzuDuFyugDLfaRs6Z+jj949zbA+3dw2oUbUSTWwKx2VRuMw2fsLWZcYQdnUkm2chaeNDDIkokMzC4oU01xdN3nFxv+y26Kb2XgEdphA9qQhApxE5X9RNij6JX7Q3truZDrLFqurAKbJov6NKcbMJ5t0lvriBYX0ofEcyr1djk5TWmXVKod/Ll+e5tTbPyizN/9KDi0fjcL1IPzwzg+7mG/cVmupVm5eyEMQIA47zUXjxvadDa0fO3I6tuTfmj+537w3rB3vw/g6YdrmslmgMKKhIjN3+1oQhhaZBk42KbGdUTgf5/s5+lrnxZGTzbHYzJ5vfzma72xNMrbXEpER0drN0Kk8fHGeYEJgJLVOKwehmLZ3CekvKyfmtPB6dLXTpjq7bS1ERkSIvVLWu663phJmTpK7zMYpztj8XIjCMMQoREDMzEWg5LAuC65ubuq5VpPJhOhwMMo4Q2bpeO7l3USmm9fiu9gIEvYBGH1BAkUPUTrNk6DZtj5wi1ah6czPbLss8G4Bw3bSlRaYwsJqNLGkxtq5TqJrWWAbOz2arm6qZNRNp/OHOBKH13RKS7Y25hbaMxvrEai1pQlUq2tAUedWyywdFXF0popJDwphANWUWqrZKVlfz6sGj7OTqi0dHj+avUyILjEZiEE0p9raFCKqplxySJAJijGHiGCMQIKGmtfhxPx8RQgcg/RgqMxd50bZtiGFA828/saG9mq2K/cOH+3w9WM5+5zuLz/7b5dXoUJK+58Jvf2K37aMQXh5OssNsmR3sdd3s7PoHR3uPzShfXt4ORrvdKDSt39/fvby65RRYotEQm8pTKreGDEFDzKm4mc9MmbPLfIx+sdybTpfXV8e7EyIMIagAJXn66BGHjlE7HxQTWlPa3PQem4kUUDQoIGRjHUxendy+qLrVKgynk67zhrnIC2tt3dRN3ezs7IyGQyKTUjLGEFHX1ICUO5cXOSiEEKIPl4sZJt903hUDMjyxFlEpBYcpkVvvtdzEAsum895as2Yp+l3cvYI5SkzURhZDs26UyWoINkMYDKYgISAMi9wSZ5mtq2sLYCWBhBzVAeXOsMVoYCaV8avpaDvi8Go225rSeOCWdauAkblNvtFypxgxaRv9bgn1aj5fzNLAxyh1lYgoz9gQdSEJokqXWcuInY95Pvjq9Gww3AdeMU2TgmEDTJgQdW1VCG9Jht6GQghrbj3pRjtW310ymlLyPhhmssYHr6BIypaXOgm8fdGmavly6y9cTc1W6Ba/+zc+/L/8Dzi2s2/t/vQh2uBFOKhc1nq5aldNFZ5+fEgLH9pmOiqQhVSd5fOTU7LGZS5KwigPjo4WTZczgkpd18Oh3RqNhDRI3NveTl0cDQuiHHyUlFDAEe8MMiMJVLHf9yxJbYwK/N2/+/sAKJJUktWYiFXCGMOPZ9n1CrbLrPK+x5rOOURI0ed5VtWr1WrZNF3XeWbuum44yEP0IfrLq4uuazvf3s5uRFI5GJis9NIvrjAJOWkvVka9jBNslnimlJjoboH521AIgIxIYBN3mCxOEvoxrfZc5ldzWxS5MS+/+rLMCxAoDR/tTYwGiIiiKpI7ZwxYhFHpdiaDvYOMEucusfiui4bykBDEQAhAzJgIu+HADW3btfXW2A5dV7jMhxiJNdVt3V4vl6uuTfWSKaXYVs3K5VhhVte7sQ0zP0puqEhW11u1rDUpiUpS7fWuNirRCv1GNGbuZfg2AhmKvTqjioIgoSYwxmzE8Wm5oD/46eqWDqa2HcD5ZHuyivf/5Z/+KLbyVz7gj3bPDWV1J0sfu/lqe/dJW0nnR10DlqOhQVRERzfXlyGmwWAwWy27FIlwOBhICKNBTqBsjCqQaNvV1rBFrlb17nSKobYQJa43ORikcZlL7JhYI6xVd1QkRf7u7/5+T/MiAoEq6sHO7uXZ+asKSJE1KJOoxBSYOXgvmqy1qprnvZ62zGY3wfu6WjZVHTrfj12Aap7lhk1IoEBJ1BgbBeJ6m/g7VUXcbCckertP9W4N1B2XEZMhI6gpGc5Tkc6b2c1oOphf3QwLUxRuPB5f3cyXy8XOyG3lFhOramZtU1fMrJAMpDKz7epsdVM9ebS3nF8lN0k+V7VEmCFF9DbNfGyMSdRU07EZlCE0IdadsVndBQlV8F3lu0AaIs5WAAwGtxqRqnhyOzeP7u2/uCXhUlNiDQKoitbYEPzbZVcbNbYk6wV9yIhACnLHZuGdsKyCJO3lPVTBECd0t1XWmf1ost/45OjlSXi5CH/yxfx2Rb/3Hz94b3ITI11VdHY5d1nWLWal1fnNiQZvSF2ZtcEkhNniamd6sLM1NQZLZ4vMJcHclYU1CLWzDqJYckrJIJd5AQqMVqMnEsSUkkHDqEggBMmYjJJXJcZeBYliFP6Lf/ef9dQwIibRnKlaLi6WnQ+RWQVJQRCBCL3vJEVmVpG+IAoghqnIMmuZmF3m8iJns94q2JcmRElEmAhVCJTX+x2U1rqiuM6V7lYe4Nvds8y2b9TvYVtSYTQC0HZNYRtBnrVNbIMxPh8Ur8+vupAOj48HVneHBasLMTIDW1JAaxhAmWE02D7Y2S1zXq5uLyrNsSAbASsVJ3Z7lHyyKQZCGqbUMjaObNQokoa59WHuHBfj3dkq1em9GnZ4iKsar8KD02pwfx/L9svbFURVISvI/d48jWIN36mD3qmaI4GCEqOqqibcrHd8q7ANBNovggaVNCgL66wqR0KAZCCcvHq1jHtqHt3WJ//xb314Pz9tl5dnizBf3O7tb7fN0g3K22VbDifDrWnV1JLMV6eXWWYLY9CWkEJmUL0flgXbfD5fTCdjhujrRWbRGVZCYu6873wkzgwziPZ7mAGYlEhF0amqlRTBgBISEzCR4e/+r/9pn8p2XWuICHG5XK5Wq6IcbNKZt5qiw9GwaRpCYsMpriVyAEH61GXzC9/daql0txZVN7Ft45ne7nGEzUTvup7fZ+NpvdcKCSUJG1ZVBDJYdJoxlo7i42996+zshFRLmxuKq67zXX20vycx2MyJpJQiEKUUs9xJik1TgQKzgsKqHrDOiTyh9ZQ10uaEzhlrsgBeySAXSerhqAipE+iKXJkH9YpjKIoi0GB4PpuE0dZl3JtSe8RnDwar6VhqkLlkDRcupZ4JHZRFTLHfZfx2J5GqMWZ9JndMF6x1HmWt3H13PoCIKSZY1/p7scTqvRF8clD/pe90++5sOTvLixGjsSVWq2WWWREs3PDy4irPsoO9/avzxc3NYjWvqmU1X622t7aTREMMbI1663BVdxN7f5wVtQ8t9FvgOQbtuoiFOnQmso0GKBIoKEa1hNakLgp3ajNrNsrsyp/8rf88+qAizFDmOZGeX1zs7OyGGIhos4oXASCllGIKMfQvuK9k9XlLz/X1w1uiSkwpps30CNPGcN6RodevbWu52xm36UNa396eLtssNheRzYA51GaACoc7uGquxxg+vLczskIWFq0fjcZNW++OJ9VqBUi9jRvDVbXMMmeYRLxlNS57cb4ohlp1eQf3Lpamaz9pww6Z2VCDUm2QxKMtspvZwhgTuzBwg2Xty+GAjDf2ctmZm+qj2lgCHsWbX3lvN5GSMStvl51BzIyCddYSqwoixN6B6dsdsikJMxFSv1IUAJh5c5J3+2bWiD7GmCS1XRuCt5YB8fDe4NeevP72wfVUTicmaySbLauM9cWrK6Lc0NCasqv9aHtvPr91lo6ODgG6+8f7944OFsvm5es3D46OM4YU2qE1hhFYQRZsNVmz8p1TJuSqakbDcepCBmJTRNWOBpkGSiaAzSDk0nosrXWZMb27qVYVf/fv/GNmYqYsy7pmeXJ6urd7z4fYK7ZuyshrK0gpIWJfm4sx9pa03gS+KX71DEI/iqTat63BesELcS92iICyFupec4MbAUVZL95GBIX1S7hzaERMxAQRmxbZGRzmy/e3pD1/8Y3DrYOdwc7B4RcvXudFkbo6N64cDMo875W9ANRmxhqjzC4jgBhSum6WbOliZq4XWT6ipTfzlLFcFZKETWz90HAVnQTFiJC0XSbKzKI6G46SxBRiFmUs2BwUqeu6F1fNy6VZpulofDy7qShhwrtJCfK+7ReF9tXAdcxD6Oe3eizf++weZtzxDqDARCmlHuMjgmVu6tqHkOLg7EX7nYdPxnze1JOEw6ubS2b96kVjaHB5sfBeLq5ufvSLLwTi/s745OTLxw92B0O7XC3zfOuL5y+n4yF2NTN35njpnbUGCnfW7v/hHz3bn+5MBxBCGAyGyccxFl5My/llMFewN8ZYWhOjFtLUyS2LByNOKIKAKSTDzL/xd/5hUeZ57lDl9OTVzvZeF5IQgcYNQUV3BiQizHznwPr1B3d0HyLKO8X9jUrw3e4nfGe9l96ttdxAircBEd9uwaR12y7crXI1qqAELGrRWtNOwyuOcX9vqxgNzs8u6ybtb28NLY6m09ntVe7soCiiRGJkQzFJAoOciInQ7E1GEiJZdXm7V57kozMo3LZprv0wmuOiKJ1p2s5nJAa6xw/u3TuctCk0XWM5BqKCpwZWJjqbdbdp2MJYoFwmd3VbiSk85YZAJHVtW62WPnR9j2hvN7hZ39L/6q+riKjoWvuK14K5vUoRM/cBElFEUi/OHYRq9/j1l19++/3iuvX1cjmdbl/c1Cnaly9fVPViPr/dOjiC4WQ0LjIn2+Pt6aA0xv3i2SukbP/Bky+/+Pmjw23vDv+v/7b96RlLxOdfyr/6+UhT+VsfHRqzQITOtwhKxM8XxR+eDP7ll/z8bP50pxhhp0KA5rN2779/Ft8bc45dnuUpJWOsmU4nIYSry8vbm9ud7e0QErHxKVrCnhrtDUtRichZt7e/9+bNG8NmvXBsQzj1Lx43id7devp36qnar/fdrAHplYS174NQVQHZ9ETA3U5x3dhVb2Y9V4ICVolgkBnd3b833N3zKj9//tXVxaIstxfnV996+uiL588lCYTU7YyHmRE1yQdjyHeBGZJI4ZwJ8f5WvjXFwPbqZbNq75fL9sHB/ZlJr87H0VyngySCOweTyYhi5S8u37y5WRTDe0tPt4vd7WE73pqnZXlel14dkxVpq6oZ5EUnmghIUlOvQJSYVAhAe85P0hrIE5GsNzAK9hJFJApKfWsDQYqJiYkhhmiMUaagoFEIJGCeYLmQ5sCl8xUtq2to9eLqxgsZrX/7r/+VLobH5fCPX7XnM4T6s/3cL7oMsTvYHp1enD6kIUb41vuPgLKfvnEncZ9MtJfzJ0eFgck3PhicpT86zndTExgUTPKkf/j57XP4lrX2d397PJ79NGE+KoqQb/+rn57M7O7cp4OBqMJwMPFdy3/h7/yDs/OzEMP2zg6oDTFhH71gvaf5bqFYf9V6izFs1vbxzk7XO4zZq0MbNsysmgD6NWYRgWkDmxB7xRhCRNG3+1r7CEG4JrT6R+mpnXXYBWAMCRnEHY0+727fHI3HmQpLfPr++83qdqfMofPHTx4tlu3RZKsKy+3xcFZ3TOhImZ0hMKzGIDnM8mJxO8NWJtP0Pz4//uRhM81neTfcHrT/yfcWMTxJOEihvrl6RTg9u1jI4NFF9fCy3WrMWDmeziYz/zCqY4Bmtex8IIUUYsacgUCKIYS+SLNZiAv9+kBjTH90/YdiMqAgkvo94T20EhFJYgx73xJjSlFSKDO7NzRHQxmNSvarXVfcz2krO3l6PA22uK59OR1ezmf/7R9MXy6q+s3/cPzex//qM5dvPbTdm5eXLxfLVTcz5c7++w8ODvbGAxPmOPrvfthWsOdj3fniy9miaunll4uXr+j1+RfTfDIqSwGMal+stt/E7S24/p1HdluuodiymeVs+uxqsZU3v/3+o9xKu6qbVWWR+ei3/vZgMHQuE9EYxRorvewE6ToCIhKRc663BmttjLEv8N1p6PSos1dZ1TWm6eGEvrv+kfom9s2Gw3W+06N0IlxPbW7Y9nXTPOrb3WF33JYyZoS8PXieVbPdcjQtSmmavaHZ25vsbm8h4U3dTvL83mBUDAe174qitAaJkckgKaA4Z3pR7LIonAGU8P2X93/lnv34QTUd69HDfAyPkjzaOTRbJt/fHXahuQ231+HRZfvBAkYdmC4N6zRaCaa2qqu6340lEnVdM9bovYrA11Z+IiIw8VrTQ7S/ScaYJNJ3s/Xn30sVZc71O1dFlJBGo1FG+o398L579XBcHQ5Xj7ap7N5k8WR5pp+fDz492/vDn8J5mMbpwzgsJ9sf3R+9NLX5dHVUB7u1/8S1tUl1a129PG8W12enZ7+45c+q3RpLA2rErGCrooQuq5Ob+/z8zRfzy3PfYpIobuvlTFvKfbf69r396L0WxiA9GaUPdnAMbbtaWCKNgSzyX/7df56SrHff9NbU76tDuQtK1tjOd/377nn2Xlejn+leL2/pd36ovkXbG+zZGxAR9f2668L+WnYH++/wrtvrt44ZZlkXMLGXu0gxsWFRtWSTKioejF8/GuY7k0mq21i1pixXjV8EgmL79Pz0wd5ukaBDTUSZY9RebkAAJc+zpmktkzWm7hqVtDUoPl++/N7jIaXbH/xc//BPTT28+PHJH3Q3L9nPP/3Fj5PJs8Gokt2ZR84WRrJYYdd2IS0hRtUEKgBCIH1pA1QQSEFTTMTUe/HeH4vKuqGPqZ946Zft9v+57mwmstY0TduLNfTVEeLMU/beTvOoPL+/Sx/tG9tef/z+7uHurg6yP329+tIP2/KewIARm8X5bb394N792ckf/vZH+z96WV4tR0/2cql/cvDw3uXLM8v8+P79n79uL/xDS9W9werbD7uPD5btbQpp0khhyXznyRjq+cCNX7x+dnBv5+y6voS96+XqgYSjHZeK8Y//7AePtpw0ty6SYRYJROBjw9/5m/+HDdvZL1O620/3FgeklEDXFdEsy+qqZsPW2J59eXfF6l35r2976+HC2/uqtL6Rb53VO+Q7UT+TnSRZY6TvTd2sCelNk5nZGKRef8wdjE5vv/z5/sEBdmF/+2DZ+bbpas8vXs329stRZnzTntRVOZpgbEEDGcMmMVNKiZCA7LJtXJbZouQoD9+jPVXOsg/2Bk/fz2N7NZbWN6vdqaswm8s3X54czJopwZRSSlXluyVDhymoEiqsN1OJ3i0PR+JeDUb1bastvt2xB7TWDeX1XwG9K/UQc1WtmLhfYxNjQMAQkxd4sue/MW2ODvZY9LMf/NnuvYnQ7n//WfpqPuhoxwexJjwqJo/3wqtKP39jjh8ND/XVr3zyaz+/uTja2ZbrN7evND/+xjI7mowGo0E5LsePpvMjvpn4z++13Xc+APJXu67YN9eTePW973ywqpZPnrx39uxPDvfufXYzIjAfHfAh31ZqD7f3DEoEwKQ+hto3YJAyw7/6t/+hJN3Mtek66+25+H7lFhEoGGP6z7zpflxrm9z1a6/r9ip3e84RvgbC+u0bfYKz2U+49nAikiT1zFpMsScatI+1khBpvc4KNITgQwhh1XViaTi2Lx/v2tvbeTNf7o4mBN04w73x3nS0dz4/nQ5yIvz8+jp24d7OyDBGBcSoKgDINm8DBNXahzp4J2yDDsPkJruGkL46P12J91d8uHe0tZXr+MM/e7ZzbnCuK5+oq9uYJGITUSFZANmwJ4rQeyNIkpJojJGQNq58DS16moWJmdhZJ0lEhYhSipuFEtob4iazFmY2xpDA/pA+eYij7rTpUkjDJ4/fv21un7+K//JkS9zW7nTql/MAeFRc5XzxVXco7E9Ot18sOHz1f2/K7528Od3Nvnh8b/sPL+79POwxxVJnY3g26L78aOvefukHO4WtikNbPR6/3M2qh6WLocrG9uT09nsfTXYm+39+NiTQg3L10MytHWdxLiEFlUwhILjMRJRls+Jf/Vv/4Je2qoIqIimSArGxzEY1xRh7c/PeG2N6LGVdKYoIjMgIkiQxMxvuL+Ia3ffTQj371bcSkopElcQEiAKaDFpGYiIAtWwBlJEQUHops56K3hDyhIjomBnQe9z9eFe++8H9eRJTG8sZOFu1i+Eoh3ldYHEb4sw325PdUDcWE2kAsiqkQKqSoJ17XAUOQYwBr/YXl2fzWz25ri5akcg3V6+K4fikvv/9r+pFcyBtZZPB0AEkkYhqLDlRIWZE0vVCLgIglT7o9tdmPczUU3HWmM3C7L4CTWQYQIkpz/IYIxL1HGFPQMQQETkGsTYzzpW2/N43FvcHlG9RWHjvY17uXV7LS74fa7+qQjJMOo2ZP78q7QBtZ3zpLdbWPfjsDJeQ7+3sN1efqzm4andwef5RfnFQDEoz2dl52NR+2dZ1GBZ8cnMzZW6z0fTFyULj+PbsYjrJ/j+vss+bA2PzNzfN73zn4OLilDEhgSQvDCmBjyErs6vrBX/yt/6BQq/t/DatIyZjTc8II2GM3lkHCkycZVnnu77D37Ajoh6k90WwngMkpr4okWLqcX0fT5l4w0rgnZ8DgBTXU3W9CeHbGvRmqvNtWfquSRUUNIrz0Lx3bzZ7Q017vj2cNl3dtL4NftlUnFlPcjG/fu/4vtOQOeLM9J2IsZ85Zndxu1wsVovZ9bAYKJrap3wwODk9a5NWi+V0MI04+Pl5fd4c3MrCCne+6ydLezCYJN3t3EIkBSV4W0rvP10/vty7nE3FkHvA3kfDlCIihhBjimVZ1lXNzEScUjRsAMHa/z9Zb/pry5Xdh61h711VZ7zjm8lHNsmeyWZPamuKYkWxgsB2W4ZsxwHswJZtWLENIciHAMkH/wvOHxDYiBElAewAHmNHgizJklqt1tDqVpPdHN/jm++745mqag9r5cOuqnPYfiRAvvvuPe+cql17r/Vbv8GWRdn6NokAltemTZHKtj4bW5zo8rcebv7V0+OLRolANRJDZVMJ1agIl/Ha4dx8/dW0Pjt/f3MgQAnYsd+fT1cyO2ldCqvbxxNnNo/PnqV2fbSPFydnk3ER/PmNl1/fH8V6vVwuL72vv/QjP9JcLL77/ffLyfQMD6t09VOfsIvnj67OrgBhPBoDCnJC5rpNgMRvfP1v95pbxJzOgcDMzhUiIiopRpG4nQAquMJlSEB7O2giIlQkzCSQvLcP0MOAdSVJ26T1PuM3hzTmS7wbIZubiIyi7R6q/ZAGc3xrSMWnrtdffW320QdX9z/4AIjme7Mo8Wh6UCBd2z84mM6bdo0pOEOA+UURDHvFVQtXq9pZc/1wPyRd1i244sGTp240BsHZeFQVNB7H0fGnHjw5btIlRGBi0CF0OE8/0bAhpm26ekeIBbYmf3Mv3uokN4TIxFlDISIhhO45TElFs4lhSlFV29YzcVmVucy1hRWfHl4tv/1odHjr9je/63/jw4MPVkdJrv/E3fPPzf2PvTp+ebT46mtnn5/JVz9TXyzCo0U8OTnZyHQZRgKRTLlcrc+W7SZgpCIpLRr96FzfPaOTCzhdbh7zpwkWn7lz4CpTUSycO9jbu7g4LUejxbP1KzdvVHS6b+SLt0v/7P0U0risAGG1Ws3395UjkqlGR6A2LywdkMncCRNRSDE3KSlF1bSNMVbZm+9tNhtjjQgWzuX6gEmtcwBQ17XuBpTnvg+H+OpuUoS7uSjIu/TcLWGm/9m8FrdYVx/QwJBisFdX9XHxVMLhKy9ed66a7c8sq9+0ZenCpg7LVcBQElYj10TPZJRoHfy68UtPmzZc25vtjceny+WqDU0EYPf9d35w4/rtvdnIWLGj6R+9qyeXLEGRYagC8yCvw0mgmyIPnzrv0Dmmiw2rKHE+6yFPWpk5r6d8NWJK1pgkKfsqDj2QtR0vXJJUVYUgNmhTTlbFyy/OT+r2zN361N35xV9+Xb40bV4bpbtFO49Xm/vPP3M4Txe+pRvvrswzuhN5xmGpiqhE6Dy4JsLnP/vyxfnqtLbPm/nC3vZw8NLn3vy1e9XnXpDXDo5UWkNFOZq6ojw8PDx58vjunZcnhaX6/MvX7TFunB1dv3H79OkzBGh9U5QFGvfw8dn5eXN11fAbX/87PYAEPYgCTFxWlagG72NKsLMaiCjGGFM0xhAZJHLOxRhVk/deRPLEfugT82Y+RIjvVvT92LnLu0b6WNOkuSohypg99qnXw4FIhCDorTvD48VHm5dfHa8ePdw7OAaUZbN8uLzaxLDxLVh0hdmbjMkAMTE6ZQ4qjerTs1ZB9iej0sCyjes2umLchHj95g31yRoAa//jW+Pvn+7V1QVBpTF2QvgMkYAS4a7QtMMUAHNsRIjRFXYoMLoWh7DjKfQNMiAQojGmaZs8nBgQaUJKkvL8o2kbHwTVjkbpVil/43NPPj/f/7Gb5Sv6bCTqwMR1y242u3795qtf4fFKq0/9m7ffv9KjiawIZAXEoBijNYRubKri5KN3QpAmlYDagEGEp4/frszB5w+e3Rnf1Gpk2AG577/zwWQ8LVO7jv5qVc+KfRE9GFeVG4/Aoy0uLy9u3bq5Xm8WCzm72DRt3Kxb/sJf+AWRmIt1RptblbIsgbBtmxzXiSADr1YVRCSP4lPUFGJKKbRBIW3hS2EABiACzh1eV2EkGWh93WnSpc4mRBWN0BuR5aOTDKsK5rtBJJJyuTZseIjImljSZnzjOyfF116Gxtq9tNjff+Fof9ICX8bFERz4zdrYwthSoiJar4IWVNr1JmzqejxRA6Pz5XrdNnXdMpBCPS31spn+h49unoU7CooNptiobtPdEdFalx85wgSaiDSPGQCFGIiBGZkQQIwhJgsAxprMBBGVYbCQ6y1RSSmFEHr+DFhrMy8eNMbQWiZnDTj80TvNX//Ccnm+Pj/zxntW55sWEUfVCFipcGAJoCi4/dzx6GK1LiS2CYIkhZFzcMue3Dkonp/HWMwTVJjEFjBSo8Zt6PDu4cmP7LXTNCF7RbVgSsdHh4bA0fTp4+dP14/m5oWr1ZVyeXl2ikRN62/furO4XBV2dLHcrDZXV4ulK0b85s/9bVdkXQOCUk7yZOaQYowJERCVdgBMyjLL7siiXL1iDlffIqX9OLDjvEDe8HKhMIARA9OoE/vmGk9z9jCy6Sp9YxgQVSUzVwdoo3sFQGLy3htbvV3P/ovRh4tbP1HVz0DrwhlH1XExtoUtrGEEstjypTWcom0aWojxWo7nkydPziKoV9mfjytKh+P5aZz93oPpSl6IMcToQURVtpE2uQy1LsaYAbs8Px6O8mFaP0AvCkRMWT2RJOWZVQbfATHGOBqNNpuajVHV7BWSQdGYYlQ01gFbY/iOOftLb8xnSh/cuzwcjSbWxmYz298XBjOqvCQqDVKS2BBGGzdfvd6+eYCHN++8d1YTUkHyS//lqz9+s37jekn+YtM2Ss7YqjBXKDLS8mc/W33qALBFr56pQLZgrVflEg4P7M1b83e/8+2DoxuzybgN0biRtVw37cXl5Y2bN64d78+nk8P9PYjJJEmxiV2NrIKAIQRJEjUhYkodzw4BVboqx7DpzkSvhN1RiAx56oyIhm0IIeM3w9Anxuis6yGrjhjTcblUMgBrjcUeyxjofjFGAGTmjAkNKH8eOypkIjmuGo/NcvHKS//7bz/5W19+wTVvLVYnrrzT1Ath3mza+f4sqorMWr+MpvEUVusNFQerzTIaupTKjo7PQ8PBJ2guvTzH6zGqQ2zb1jLlaUH3rgC6ojtPzzUNxKG8qvK2lAeCuXHOly6llOddSVLuH/NGRYRXl1eGOeZr2KN8+djNeU0A4IFSMXr7d35naqqqKsfHe46xOD4AQwU7SFKOKrAOxGP0YAsypoXpyJ19rXz0xk8fPZT9//fXv3VQXCOhF4/geO/azxUHdaLEIcYLiS6FA1x+yIGgAk4O2QqRAlaTA4lpvUEZ37775tGTj96J7Xr/6FYr5gff/qM3v/jFw6NjV42axfl0ZKwxJZf8xtd/YThZmK120KTuZIYr9hyEfITl7qZtW2fLzPUTlTyBz98Qo2ScghABpYtZByDOHj09FWKH35eBrpQSo803aegnDBskUhE2PLwH3JkdAiAROcPjVL+zql49tN94+9nnXp6cXj55dupnczV2FFDWfuPKQiQgSCpmcXLrDz7ke88nj5Yg5Sd+8PjWhyfX7p/uPbw6UAxTu7m3nJhUishmvTbMoLo9BTEXUr2Tlaa+HVRCyriMsWaXHmOsCyHkDiam2OHsOjQ0HZM7y1nzX0FIrnAEiqmxjAXjtLA/cQPv4OLo7qsvXbNFNUkSG/U0KSiS1K2ophgxAaJBZEyJN6doJrU4gXi9Cl957Q6lWnhfyBTGcHNRmWZUr4vVgr11WoSrpyNjz08fOi6JNKVAlkASI2F18x/92w/fq/nTN4vKoMaoaOt6M9/bN9bVm7pw9v0PP7hx6843vvl7/ObP/e1+aofWuhj8Tnix9vpKHSrrfCFy89LPKLp9azwZE1LwsXBlroTy0sqZjJBZoP3x12Ec2ZJVEQhVwLIT6QaLojIw4iELV2Qwueva/Z6ACqoCkq7wILrxj42fLCPVqbx2HK+WOtuH0GgIoZpOLlYX8zmVjM/1tf/rV5+e4meu0q1FPHiytMt0tVTxllvrUmu/dscum/K8JUTSFBETQrah6Hhj24WhCXUnrn5I5NoO4PPHwQHAE40qkpvs7MGWmx5Jgh2Nu1teADAdjYpCppPrx/bsZ19/4av40c1rs+rGHS4igEkgdjYGZ9PVstk0TNZOJqiqTZvWa1Jsga88VNCWtk1ijWkx1MglIaISkBM2ogssR4GL3/mDP1CcTSxOCiz2DtGQxkZ8azQBNS1Xv/F++0DLN1482NelCfWzk1NEOb+8vL5/9Pz08fWXXprPqqvL1dVyzW/8+V9A6vDsEFqkPOZTRhQRRCXsKqedZNihABdABVTRFBO2PhBbYk6SkCipsDWqqIpIjIgCoqpJhJCQLCIDkAIpEiAhcufUQqT9YKhn7XQcflGVzMDsE0eJO7fglKI10LbteFT8zGcO/u13Lvfv3JGH39bZ0Z6zEywIyBQuaDEzzT/5Vv0s3Y0pqG5AosSgkTgphjS2k9hUr7/IR7Pwg5PXSC+apkYCRUgJJL95zA6ieUHnKMKdfEqiPCTtLxQwk6buAE0xYhfcpCnGnHWCqCKR2PaA8DDMUZW42dSFyi/95LXb4SS2Lc+nUTepTbBpwVkzGYeQjGAxnSnxZlNDU6MIS2aw4vhwxtWouWifPHw0P76OdoSqiC2kgJR8qJ0bI1v2bVjV//Lh6MbRNf/4nflLn42rRb1ejaYziApsrNGvfeq1b7735J1n6fka1na/nd2+fucTrxxVcXKwXkVpw2YVzs+uUCP/yF/5+3kql2nXukNYyWz/zHxPKfVuZLAFohSGaTyiQUKRZIxNMVrniqIkyiVqF2ovmqx11K1jHuQVgx46dwbDMacfp3nhkHc8bJ+93xAhkrEJqYLm0Vn9g+fxy59e/sp3jv6zHz86uf9EpZ44c7x/eHpytkxhOrJPy88/OoW6rVOKmquc7Uw8SYEPLj68+fLe+/eoiWcpCYKNofsUPSanHawAkA/t4WjOlzFvVApqjUVCEci1IyImifmaD/Ou/qHlAQ/L1b21NiEdTF/8H/7M/qGkJCfl9BDK0rkRC4D3CYGLwhROlzX4sFiu5kfH9WLz7NnzhFCUZRO8m84hxk0bjm6+SMYCGkCN589IApQEnNRHBWBkq/zNE/32ibwxXlw9v4S2rkZjsiwIBJiW68KOU2o+XNvvyUsfnoW9ik8Xq+slnhPeHE+qyfTZw7qyeO2G4c/92b8BAEVZtG2roOPROEelc/ZQEM2nUmYW5FIUd/b94fESBVWgLHZASCnFEHPRaq3J036izgPRGIPA2ElKpa+zKEnq2ojOJ6NDt5m5O1kQdgHJPrAvFzigqighmkldHP3pzx89fBx/9aP0M68ePbk6dxptDseazx48uPcf3sfFxuZiJo8KjDFFUcQUfUhucuDXt++975rZ8mA8izH54FW0S7vsDQz7iTsASu5bQcE664M3xuRnz5jBxAAJKT+foim/GsAO4QxQIdcPuYTAPHV1o6rSs//6k77xbTErqJhIaEnT+vS8LEtyhqpSQbXxPqSiqjbeT6fzvYM9ZAygo9kEjVldXk2PrxMgIMZmRSxpvfR1zZaRAGIia5FcWq8nhb51Bi/fONqPV9VoDISIYG2RRLkqgfDOjdlb3/nOKK3++pf3P+3f+xeP6J8+Of7eB6Nfu3/vX73Pv7/Y/17Yuxzd4Ne//jdzN0dIo2rUtE0+VgAwy+fzn241W13uCxmTCaLacT7JqGSNb0/ry+2bQoyRia0zxJgD3yUJInc4RF/F775+X4TpMEcaNOraC352zsp+X5OYgA0phdU7H8yPDp6uL4//5Hm4tidheXo8n04mk8eLFaD+ydVBG8eKXScxGU9MXv2qhUm3q8vXbyxHow+eXN2GGAwbYkkSAAzsDHOGoX1mtmY8M9fmeWFRFw4AiBijDLYUMYWsbN5hmyn0Trc99SPTiHBs3S/97M3ZZkWVsMxBN5BaWK8LRFWlqgBDosLOAQBVpRo6ffjAlVzuT2q/Mc5q3RbjCToDbVg+fVSMbWhWYLjc299cXBXjCTEEn5aLjTXFJDXfOonfam69fpgctePRqBiN02YTUKSasbFE6U+9euPHX51dL+O4sjcXH77o5N0GLcyFA9m1F3l6lfjLP/93mVmkE/RlsxdCMqaDIp1zmb0kvRDAWgsAo9GIqCjLMZJBZE2eUFUjaCICVAFI1jJTtvZIKQWJiZlTjEdHR5fLK5HIDKjSCSa6LQkIugoGCbsZZV9a6YCNaRYKZ5VH16Yx5bYciWzA+mzjIvqobhn09vhDWpM5cCdP78+ODu492XvGE6PeEVTjok1hDhviyzZSSO2c5d7Tzfpy/WdeHx2UZ++drEUPS1xff+FavQJMkaEVyosbGFFR8+QKCfMe3z9yBSIjGQAG0WymkheiJMn7GZIjNoCswN2glrK7ZASVorBf+Mz1N/k9Nz2kq+e+GnFco3hkaDYrlBgVqBiRqcC3ZIkKY5hc4eyoQKaCzep8iUTWFuvnZ/XZ5Xq1tASsyJXbPD+t5mMqLEQDqCNEmySuzvdH7r0LuX1t/sn9kASJDRm2ikgM+Vhk4atz3WzMeO/69aNbN6/95rvnWE7aEBEcICdB/vJf+kVn3Xg8qutaQWOM49Go9W0uofLAK4SQMfcu9k2Ssy7EoIBE1LYtM6sk6CtuESlcYW2HZmUSSN7bVNQYs1pcTU1qmhrZCjLqtmDaAREAMwRPnQoyD006bWeuq7q5tXYc+YEZ2CMCqoqarhXra2U9mkyxgoPp9dVlc/Ti9KP7SYp9b/cd11++q4f2WzHC+mqmOn7aBHHH0Ry+/6wO7dVf+9qNtF7c36RqnbycrijVWJnYxhiIDBtDBIMkBHszZAUlNt2nUQXVDM2klERTB24hIplu0oBAxBkrzvOPrHY7Oz3/2dcPEGLz/FlxcAwWBSgCF0c3aO86lxWSJr9OTZtSVBFEpCSMBK5C58qqMIX1qXn46EG7qMejarY3gxTRGVcUVBaQBJKqClVFBCVBQ/i7T+J7y2IszTSeTKcOTQVW0TIwKwBLwNDSaA7VFMrJP/vj5++uixQbAMqTUBHl1//830wp+daz4aIoQoiZepXbN2YKPlhniSj4QEzGmNl0FmLI5KIYIihIEmM6mysFnU6n2ZnIOZcHiLBjXA4Ahghj2/hoXJkUCGg4YgZAKB+EhJRNXftDMFdylOOSYVudwMDQ74EISCIxRSV70rJGqKh59P73mmBC20Y53StnIdSli3N6dmxOFk1zFm4+q0stNiM0JsnJkycK1Ch/84kuQrGPT/6r19tb09VBOZHGiLRHR9dCVJ9SDO1w7hPTMP7KKvouq1KHmgxFU6/BxI4Tn5G8TNjNiaRAXV9C7qc/PYHV03K8J6lFQGBrypmiUWQk0VhrbCEoINiiQCASXV8sgazagtiBtezM4fHRbDJzZcEqoNBGb2dTUNAkqBI3m0xOdGDbxfPzYD5spidX61ev23T5bFTNoolcFCBJY5K6AU04vdHg3r2m+Ke/cx9slYVGuZhhEH7967+QTzfvfT7jhlpymLB2VXxW1IggoGFW0exi4ZxNKR98dlRVCrDZbLz3uTAaGIL5b+34a4qNEhmXcXQA2s3N3jId8peoY7ECAHP3ncyMgzQRlIj7PUN2aKvZKzCRMZeb6dOV6uglZ86uH4+0qarq8edennz+WvvyYbw4fzTau/neA4eyr+G8bpI1sH9tf+9o79rENpsWPK3Wm8er+Q/e92e+ugjhcOSW6814sre/f7RcXnUDCcKeIaLMDMCDrVwIoZubgea+uGdwGMpZOgAKWhZlilEBCPIXydrip+66kX8O3sXFpZlUSEbWLVkn2IA0lEQlcQQuHBBDTH6xdGLAFjCaMFUKrIBRAS2TM2gImW1VgrMxtKSAhrlJGCIDoBKmsDc2p1ebU77OJvnzZy/sT03lwEe/aVw1JTdCSw0c/J+/+u1/+Z1zz5NRWDY4QYnaG5KbvKrWm3Xhis1mo6pZqJMzpRTUOZebpjzkAoXWt1kBZiywYd9uJEU21nsffNgV1bRtq6r53ByYe9kXylIpKplYr522QgFEIWZ0SkUI3cCuUVTuDz4A7Kh2MCAgor0xeF6FGTbLrrIMBAaWcP37y3Rv/erDgHtw4hftZ8prz5ZvnZ7d++wnP/eN7z2Z7X+pSI0Wt7SZNgQQnq6uZgtoREcJEhS3Ft61k7ECIKbzFthxQto0q6qqRMV7z8yqrEIqAsiI3ZwnhACEhJy3YmsMEsYQY4qIEgWIMmXZtW0rKtPpdL3aACqSFKZuwUyh3iDAZJSWz1iNJir8MqBYtnXdEmi92ZjaVFXFbJwh2Bvx2CgEAUOgACOhOdMawyYl3/p1aS0tG20CzmY+iAMEkLbZiG9Gs5IeXt6Im7fT3ntn6ae+8unTx+8fHrzi14tFK/vTeajTP/zVy6u0QdqT1DB5j8ZqS4A9wR3483/ub4YYBm5nURR1U+e8FFe44EOGajrxKlKS1DFAkNhwCGHACHKnk1NWVDWEkOtZZu4mOXnFaNd+Z5usHrnRQaLTuVFjDpuhgUOyhdhoSI2HYSqU1cP9pKXz0hBVmxV8XdXGTRxtdPxwVVzyi7993yedHJV0+fjtWzdv3ZLHL+kPjL9f7R8vlpWkTZCUQgghgAIQRvQ+eYCIGkUpCydjTNWoQqAYU0pCxFngJZKssZnbmK+JiBAxoKQUJUkmo/adcUZYUEGtdW3TgAIRWmf+1JfuvuG+J9gEV1C6SpSAFUkSBbSwWl04C4qRiMqqZMeL1SWUZAzH1oOvGaLSGOKlSY+RROMKUwOpTV7Ry9nz88IUFFqp122sWwyCUTmamZuNCO3xOwv3n91af/jw5MXpvFnBxdJ84w8/+uW3NmsaOaYGnNGIgDKwonpyFL/5F/9Od0syICMpiwczXsWGY4yZVjAajbz3Q2WdUnLOta0f2Hx5vJ+ZRoMBAVNuhXpjsV6ej8qDQAOox15zYAt10w+FrQRIVbOr1o7mB3p/DRiIEkOKT+aNDW4RWReKoIWmkLCVcu2JmJ+f6UUc8+HdQuK0BHaBD66ta3+y2TOURCTG1DGMiSxZqwWqTYEVU65KY0xZGSkyaFKAqKeUadfrZqpW7zWXUk8B6kQWma+BmbvWPRoKIBI3V2dfvrXcQKpVSNa1IJCShaghaXAliwbklBASRjSCBuzEIKtGr+o92H/xze/duHlAzUONmxRrBZ8kEhrfNNPpNElwVsFJtNFjQEdSmsVmxRheah7sGbwXXHH+zu8+bH9/vf8v7ps/0RcXPCsKx2HTJGTNbOE8WNvaUfHX/srf062aufMjDSHkT5fvB2DnKGeMGVxAcveHPc9dVIqyyA1gV7gSZc7uwBAU0Xw1QSEj713/RgPMDr17fD7oGPsHegd439VdKw2V4DDP3jbt3e8zjwAABCASKCZMniESEBap1uLRxeiti9mllJ+5M9k36U+eVM9SAWFj0lgpWWuRcFzyj372YLW8QGNM4fKMOYsuJWmIEQBBkXgYG+hARyYiY00/DtJuQE+IgzdIx8amTjfQhacAM5Epqklp/UUdtU0UUgJiybVZ77+CiGohSogQTIEqwbdNImALidaziZmWYk0KkoJEAQwobWyswYQJSvLQthS9elcwj0YfPV9eXcUU7P5IZ5vzt1fj328+8Ta/9mDFlbYvjVqrQd3ISIith1yf6FABdW09f+HnfhGBslsRo1EAYwtEsmwLV1nrfIhsrAKqYut9TMlap8BZ+LtDANTgAyBYZ3PB45wLISgYBTbsRLWT7WfFBJk8UtbOrCfjg9yFWQDpsAcNKwd2lle3AHFLQwXtZ95dnnt21cpehR21MD9ToogElCNtmJAKoyPLl83k7PLsEy+O7j9yp3CtNZuiOWzcrLTNf/uluP7wV37yi6996trms8V7Dy9X7CYO9c7BstmQKUzLpca21DJik/k1AJJNChVAVDabOutKVEG0MzDL9kzZYaYbP+rWkJyZALAcz98/SS/fKqV+J4U948gVVYwhpiAJk0AEEGJSXdm6TpbhsE01s6ZUJxGQMDKpMBJi9ApoWAmRCQ1SSWSTmqAkrbRuVCibRyeXUfhgvi/NZlpMx6Z8+bXPv/Xg5Euz059/GX98tnr5rn/rfnOxSV5IUxOS2mxjSZ2BXhf38pW//A9CjIZtto4xbAGAkHN3s15vvA/MxlmXYZXZbF7XTYfTYNcwDlNTAIgxqaq1NqVERIBsDLfeO2epT2FgZunog92mMoDpCrt2NcOgkKBj2SH8MC9+62yzyyztRbB52e2YUHbAZsa7t0ewAuY85/Oz2sCTvSTHVB0f3Qv11Z3Z8rX9zd6Mn18tp1wU/vSlV6//yIvtK0fr12+tK1OfXCTBmcdNwmBpmjkPgEpkhvdpjck7X3bEzK4qSRL3DABEVOChC7bO0QDD6/zR4/Wt49EYFmK0qWtSNWCVOan6mJB5DWsMe6LBm3ND1bpZE1nvkzInxZgU2ax9VOAkCMiKGEVFAZgSgKi6ogCkpcf1ul2cnh4fzmWOpmrc6vSre6PX9sPxaH00YigP//0H2kIZUygNFdU4f8K8H29PjJ/+hf95NBrnKDBVyMx/JGSkmKJhY51VgJhSkuQKl0RijGw4cx9yC91ZNhANlmKDZTliPkNZJBGBtTZbumWhayfbJ8rjat1dVt0gvEOtehqdDi4PnZh4uC0ft+TvBj4ZWuvk7ZTVPQOvc2t4AsiIgDHqdKM3BYtPfcLeeAEfPL7xpVf9l1+UvXnRrOrWh6krDuZ2MmpnTmeTMqw3Z8uT8axBmABOBfYMYlkWqZOfdO4mGX/L9buKWGOgf0oQdUclZnYfklxXpNQ2YemLa479wez85Lw1RlGIuIiAPiS0dtN49eMRLxmMrydtuzHOtBGVy3UTNk0QMm2COmobZbFuzi+XicymCUCcgMjYummdIe/96aKNQvvT+d5kujlr1nFdUCrqVVlwshhnN375txfv12VUIRBCBeJsIKCwZQsDAH/uz/2CNSajTZkLKqplWVjONr15RA+9sbHEEJg5xqAq2eN4cFybz+be+240NPDW2QzUyrJ03vu+ZjKd/HSrG8Rd0sjW9HagAtLWDGIL0+/ODXVrrJgdiwEgJRmsR7qKpNdryFBbkgJHB4U1Jrm4bMzF+fztB4/Wye6ZGi++/+D0aszVzOKtO9YDFFD9ydP12/ceVsX1hd+Y4AvXGpvaDYn1TBiTovLuHEB7dVj+OCFGJlIQUMnQKHbOfpxvhKoa5pQSAam2PmyenYAvp3uz/QA1G2UuBGDTtnk3svP5M3P8ZJ1Umvm4ADaX63a1CQE0ASagxab1Ces2hQRBNAEqYhvSpvVADJJKaxzT1WL9wUdPiauYsF6cH44nSCY4Q1wUgc/d3j/7QRlTbVENUdJtAc2GRXQ4L/jLP//3mrbJyLtK7vWKrhYBzVu3ghrDhGSYRYUIrbGiSkAxJRVARQAMPhKyChDv6ABTfg0ybAQUgHOmTD6fBu+/Qe+Vn2Imzs96x1wF3Fl5+LHJD35se8smWqgo0NthIxL0L9WboOYHjIEI+hk6GEOGLcYmknArJwZniOV8jJ+/RhfPpQmnb3z21sa3CYt7T07ffvz4/PIqIdz78MN9LFibcgrXp/5oury5t2naBuydFBMRRWwTlAyShakdyG4yEGOYDJERBdHOI6O36Tb9KAwQmQCRq/OVffq8feHocLk+8+weLffXVNa0/x+++dG//97s996pPjydL+Hgxnz57Grx9OGmMOVKgnEuhBi8Z+cIgQwlgItmU5RVjFGShIgjVzmDBrk049c+cSs0V6bQvWOcJWAwWFWjsNbpjf/1Nx88az1LLqNZevo4AEiSPGjOt8bkAysfbYw0Go06zlBMzCaDe/30FLEDlHsRlyJjB9Z364DyuknZDn8YZUQfEZGtRQRrnSRJg9OrwtY4ubep2QIHsC2Uut5QYasGg7ymB4J4Hl3Txwwj4OPHa0f9FAAkxi2rzpoksllvmJhRDE+jokQtCgwhffrVFy/X0ijVUn7/3keJXVGNjXHr0BwdHf/UV9/8/bffPVMv9dNxxeLhpeP995+dpNFBDC0rchsBsShKUI0p5WuTRAixB/ZoEInkHb2DTwEBtR8wxJDwidh/8/vnmA64mPs0ZRfqTQB5k6uAGFetvvOInzybxURfeLlK6QdGZ8uz5Xw6enZ6XpXt9Rs3mrZdt+Fs2W6a84PZ1KKZkFu3Yb1ejw3XV1GlPN7fr5vnY39c1zIeE6flskp/+Cw98Xdtu0k2wWD9AjpoQ/LRJCigwF/8+V8cLu5A88i9HnHmD2FmBg/7CQ2Di66KQtiawmQOXBqUzaqUyVIDTNphnj0bhjszre6yMnEmJQ9LISMOtOsCj1suzaAkUwBC3p563TJVgC7qqdv5qHP5YmZCHkyUstUsISGopFZtgSkezegLL5hw+ejbb/3R8dHh83W49+xsBewBUaSqytD6+WwyK831O7c/ujwxGgtmkmhc7RBOm6nYIvklCipCSkn6LVNVkWhQ8HQyyf6Uz5OPTpFhTQaWY0ySkoVRSkWkaQtFpCuva+CEVkCwlzTCVSpbuYXN1fHsNKgNiotNk8C0ihuflnXjIwS0Meli0wjZGP18b4/QEhsH1C5Hk4JHrsEIDbbqEhr3x8u7/8932jqSodj5C9BQ6XYa99yM50XGX/r5/75tW2JWVcOdX0MuO7VPGuoOoIFermKMCT5YNv19zfyE7J0sgLJTQXO3lgHZmAG477XnxB2RHAb7qO1vYSfJCLd6r21i1oA19OqDrdc16tBU0g6puvM0U1HpLK+zlquz88+fRUAjVHL61Vd5X09+8P23vvin/9Szk+VKo88ZxQKZs0hEi8XSM37w0aOE5ISCAqLTuLp+dP3hBbVQKhMkKyl0psi9WcFg7rqFsqD3+OtOGBKVbLPTqdVFjAAzqGxQW0xTiiPWEalTjN22ATq2IhjuHplD9zxGAYSYVJEFJKak2YI/KYAQY900ivTg/sPD/aPFYn18NAdtFX1RFabQ8UTqyWv/+D+e/+6j+SKUVbpcM3Nvd8VsiIZxbRe32xnyfunnfjE1NVECQwhsXJG6TF5VyPt2pxLsoFWFDIqyMTE2opkXjwqCqEAdij4cVWy4m/BpEk05qyhD1VlbNtgC5jWdqbqwsxCI8ja2xeCGpZZvRE/9o11j+qFgA9VsgNYpXWEr70ckhDgp0FBK0v2pQcMFlcX8k4cXn5qefeubv/PKG599dHkW1UbwAIIgTChgNAGxHU2ny9AoUUxi2SooAwIWbbLTqTb1GmCEZm4p5opEAAhVY5lUIm5QOXMqVZX75NUQgjEIKDnLwBVFHmwjMZiUiBQsIqutlaNQoxQYba4BCDmp4VG8NV8euCs0ZVzXZZFEOYrm/DYiRE3G2pyG4S/09c/effek+N5zvrnHZJdPH5wdHhwF3Gxo7x//f/qWHzWBSCIJtjpmCNgJ8kLH2sA8cOsI2UjIP/k3/qfJdOrKUggLaxUUO1MeyfZfIYRc41DnDjqcTmIte98iEaBm42kAtc5mWDKfkpqlntkbKw+ToA+V2UG/uhlONijryqxBBQSy9bj9IfYmIGxNTbd+8v1j0Bs9bCGuIRFBEBMqgkbfaNI2gYoaNsQcTOMb85OfG0/8uY5nNSXBYdslBVSh/O5FNYRoyTDbFDUpOrYjq6YYb6IcUvzMDfv5uwXFxys/jgARCtVCQjTu0oKYOBYQFcl1eld6di5tighF4YghxM7MnIgQaPsxlAmY0BCa3JEREzEKYMHlSwdo5blv/Wu3bk4nsKkRiGOIiigKRBBTyBfm7o0XiJffeX96mg6+/EKzWS5LO6rGrTcH//g3Lh7HO0ECJ9RMcRGfayYFzf4JCFsfjj7zB/nNv/r3mwCqUBWcQmuNUaXsxZpXUkcO6nonygBjPxYMWQyYd/UUUzfJ72gtnWplmH4MkBIAIJkhN5oGVqjCUMXj4FjUU0oGI7zdXWk3kKcv6rs4xR14lAbkQlSHeWJiUCCA0nfzaxCRpBIowEan8O4eT5dpGSkTbI0ig2bvq+wg1tWA0SsojUYTwyaGZBnAaFJfugKbZ3p179O3ixtH9u5BKuPZXuE3aiOMASoRQc7LiGCriQNCEE1DzAfg1m+sIzTjkGYF3T3qta+qkgQ1lm1zde36aN8lJ8vKlglgWlVNs85zM0aZlpSCVwW78tf35NWbN770aT60V34FRZHcBP/5b+v3lq+t+LKsZ0pRd+6HMcb0XjodLaBn8We/Kv7KX/4HTGxxs1f5uvYpqjWF4SJpzGtLAYyhzjRmQB8BVIS5G0F0nxYQAYvC5WnjcO44a621u1a2IgLIfRn+MXHO4JfcgQJbN0Dd9aLZAonDNrZTfnVTNiJA6Cwt+wO07x8VFXP1GDUg41YVBCKx3Uf6yTfT4v7iNF1RyUhEygoxMyCJsqumqvYmuaghNETgHLMzksK0LEJsRtYaW86me7P48Hq5eeWw+fxNOZrRyTNIdpRwJSlPURPoNqcjK386YQERks3Tz9xq5CKmJxdldROJioh2RgUKSilEvrii28d6MEMnxaiU0jgAberWunJi6e7hNLQtUgltNZ+FGS/3iw+in1Xj6SpeNXj3371T1ThFCJhUqQuXzAx151xVVZkvmssY6tPR86Lnr/93f7eYpnl6+8lHvAlxf38/hjb4BtBSdoSO2ofA9P7jqj54kSQSt2hmX9bE1Lmj5PrJGIfEkiRFkSQAqEmZLSB1MEfqUq+GgfcOM3lb1Q7Gax/zHx5ULtuePJtcdqsqA2wDpxk6fKI/alVJBTTmk7/nSohVMtH/9FcPTt79QVNZtuTIeIiAKcP7oqKAgmDYhtazAcwtS4oinlHBSwF0ZzI9mlrQJmlLuFcWpQUZQ/zEXD/zqdG1sXvvIUSQGGP/GaWHWAARmLIajzovFpWyLHv/AQCEEELPOWVDlCTmzgMJkQPQGPlwPtncntQWq3q9MMyz+UxBrcJ+ZcaMe9N5VH2yatxobzaZ+BrOLltX8cW6/s474YPm0GqL0SSzJjWDW7qIzOaz1XIFAGRsCDGJAFKGnwkVAfirX/+Zew/3dGOb/Ymj4vLyYjKrJpNRiF7UG3aqJBrynhF8CDGGGLNMiRGJqCiKXPd066mHQ13hYohsCgViY4iNNS4lAUBCHmKZiDD1/AjqCv18hqZMYxpWT38KDhU4drO/DggFRFDMXR5l7XU/tBYFTSodCtZ/ZxYK9iTg3BUKKgDySuXyydlnXzxcXJ1O53MfvFgEgS6+GoCUEoAqUuYvII5chYDVuMAk07IajYq9CTnCSTUCEMukLI4Yk3pjZ2k1Rv8r94JKH18FAJAAFUEBBdB2rpOw7Rq99/m+5rVlmIftqm3WRIiqohHJgBKAgNGwWnz+etTCPX56UVRWgi8Zj/cmeyNnXHW1XFpDe4d3J7zX+vcqd2xMePLkwWKZbr382W8/oC6CJPcNCtk/xll3tbhiw8651seiKESHWQgQABukkk9eeeFqdvwpM3bI5uja9fWmrdsacWNt2GzOU9xkiqmIZHMV5k65kG90vamH8yi7rGT72uCDc647d2Oy1lpjC1cEn2eFMtRbnWsUYIxpGDdRrjS3dfpOudUbfcNONT78l5lxh0uDPcsZQEX7K9DbUvTZGgMEB4qaICUuz/jlPzg/vlUcxs0GSjv1xiKPXGmAWAFVDWplZMwq0ZNqs1lNylITNAkDm7C19wDDdrlZixolQ876tg7Lszq40lWdchVgm1fYy0Dy2e2s7WYmxEM4Q2dZ3qeQp5R88FmskQVCmbUTQlzGyXk72lydjMeF7dWOdVMvmiaINk3wbbi4eP7t736zjbZJYTwaO+bXXnv55NmDKNKiJG5I5vl25+y3lFJZlkTUNG0m8BWFc9Z1U9Fs3fuf//X/5fa1uGovwnIMzHXbAEESxUiGcTYbh+gBTFmW1JGIOh1YN0DN4VUmp0CTs65rGVRTSghIZNmwqDCbFGOIgbjT7XRPImZ0NBMvB2NBUtBqVHUc+ZySRZQhNGZiNgMGO5RuO8EW2zJfO4cF6VMmMziyxfSHEV5/FCKissDlehPN5BMT5PUqzA17UcaUkko62D/wXqyheWFmVdkmcdYWxhZMe2O3auN6cX7rcDwqitg0ztk2Nj6SD3Rx9nx/VhKktbv5z761PmlGudDrOPvawYyiQpQtfTgb1Aym8HkTTpL6kD1MkrIH7I5PYofnWes20X/htWu33dpM9lFTjLEsS0DwgIvFOomA8NH+/IVbs1FRnJ0+fbYiZnGGkoR3H3vFa8k0rBVSnIwnIYZqVIUQ8s011sYkxEzExtqUEqpawyG0/Opf+IeXF8UyxRDteDLJ9jqGHKgh4tPTs7ppnKsWi8V4NEFE6/IDxM65yWSaJDnnRIXRAqAkjTEBaM4J0x0b6uzp0+kpiPMcIOOlwzBatxFqqXefws6AX0EBci5Gp9KBjzvF7y6vnuPVMYQwy+F1x1tvINVsyYPYOw+ykMUEKh7l9U/cfXM++t7JA2ZkSzGqtbZuaiSS4CG0L9y+sVqt2qa9fetGihv0zWXtbxxM90pGAYMoKk3TRuDo5ehgrzDJB/nl3z17a3UI6Ehl60LQqT+yybTbUvgBEDCmqKIpRRFlNiGEDq5WSZI6ho0iAisOlCTl0t6Za7m4v2pRIUhKqrEwZtm0o8nEIFXWVZVWTlfnV3uH+++ewPH+COO6LGkVZ6ebQ+XEkFAwRhmPTNPGAWdUERElBAUpC9c2de/8afjNv/i36hhFXALYbFZFUbKxohpSBGJix1waQgB0zmqSKImQcjmfUiI0IkBooyQiBkQ2JuYY6e7vl1zmO8tojA9eOszdQGbvIBGhJMkpINQZKnUkywyKDOyaLlVA++S6AejMnn/EmWrVDxw7XGvoZQh3jCC2XpW7B2kHbCREBWxCPFluJnI+Bvjgo/uXzxf7B8frsKnm7ta0vDnZh4Trph05dOVovVwcjauL1aaNfmTMtdmEEFJKjo2z5WLdjku0EAH5u+fXv3FvZqiMkAhQREA1xysM7KPsvqagxpgMK/bNTdfTVFUBkpiREEQioIXORL2jmzATEpfYfvVOVP/s8NrNEFof47Q08xKvljFIUpWiMHW7KYvyYDYF4bM1zrmdjqww3T+dftC2NmBZrGPiycx+5rY5PbkKanrhQjfesMbUmw0o5NNWAagsi6JwOXXCGJNpLU3dVFWpCkVRgGrwaTIZAYQ2rLs2hDjPikTEmhGhM8YUrkhJUkpseDwej8fjTITPIv31Zh186A23cOgECdE5x4YNszHGWmuswV5R2InydoyP/lMPXNyRFg6+xX0J9XFy/JYLPLxOR/rrkVuJue0SBYTK2qcbgNuvf3qPX7v52lfuvnFrdN14dhFuzafzMc72RpfL9bJtZqX51I1rslzdOZi/+fKtT9ycQ9sQgKbomxZVDFOK8ez84t6z5b/+43VLM5PEiopIfzQPo/3OPAt7G4t8CTp3sX5XblsvKiEEH7w1tn+QcGsvDQggrx3Da6Nn+3O3qpcpRTZusayVCzRiCxQMotGZ4vnJaUxiCjstfDkqFpsNKU4xFCDKvAzQutE+Pr8F792dLIcB2QBVFq7I3osxdR5p/GN/7X80xlRlhUQxBCJUhbIsQgiSUtM0GUERCHdfut20qxhRdwwXmEGwIQ6gHGM01hSFU5W6rrO0euC/S8ZZ+lYOkaw1GaxKSRBpOplki84YoisKa21MMZfc20HhMP4b6DQAu5dS4ePWHb25SNYCMXE3UcAudUzzIdTnxG6JX1kRQFBSvHfvwbX54YHlF154wZlqvapPTy9W6s2InpydqSnnZXVYEIR2Mp0WzjIETrEqxxIDqk6qqvVtNnQoRyNT7n3zaRVJrC4TMQEP6K5IHJx8stvB7oS0Ywlgp4xlJk1p8MhQGJQm3aNCTIWlP/+ZYj99GIu9StYGcFKWDFIaMxqVAFIgTl2xXgVQPT0/i8nPpwWBxqRqzFN/8M45uFRVpC+Y8OfeGFd09v1Lvqir3l+4S5gqyzJzrztyJRN/5a/+EiMTYxI0hgjRWtu2nolyVWjYhODZ0Ecf3Z/N5iKUp7aExEDI7WxuEQNI2W8YiKiZnZPr7p7rgsy2YxBk1S+SqAz1fuvbEILhLDmXEEPmu3WjoYGarNulg4MV3E7w/Q/9yoQsH3z2/8yrJu/QuW+HLWt+yA0esn8sGbeU8g+fFe3zj6Z7HCLORvNJMX12cro/cgejkrwQQNqsRpNq7T0AOgLDVoGKwiAAgSKgANVtW6/WYibfezIRIQTT6Jgh9iYokrfNztAWKcs5iShPo/Mz0/l7q8YYAKSzODCcF+QAV2YYYur4z3wCDCxgcnyLN8Y5BKiccZgICETGRfX86cnt2y+ORmNbOGcNxPbJsxMtxk8v4Ne/O02T/evT9Ke/CD/x8rNbxen375/9/vnLMeqOmTpUVZHVNymmjEjHGEmpCKnydaAYogobl1PNiNiZoipH49HYFZyAq+ogeDtYSKqoJFVpUbhdGcMWgVDJGlvXdW6Ms4ATwBguSzfKCFM+iGKKWRwWU8xp05IEkVrvMyU6f9FaWxRFHnmqqkjqAjVVAbY2u92J+bEoVxjo0SmKIasClAcoogNGzD0psR8lQc8EQSZ2hkMbLKqz7Xf55X/3Xv1hE/3Vyd394jPHL2pjVhdXdw7Kwpn7F+t3P3p6OJ+NLYY2aI5gjyqKQnbdeh8whvba/uiiFlfNMElSqtATfiykIzfzCooKjNTrLnrvTFFrrUoHGeYC1lnXRZAKECBDR3yKKcakDUwKMjPwSDO2dlxy6VAIwemkNBdXq8nR7bY5De1lwXh+cRZZrr/0hX/77ek///CGlHtGlptFeHV2NRU9XzYXtVnEPoeLsjBCgm826wVC57GTISf6ZPUAeYFuXjhl5hBjflCm83lC9ZK8CJBURgyLl7idrhAkiEnMyfNLH9LQ3yHjer32wSto0zSZCxpj7CyTuwQMGsxeO7t9ScYYFckR7d57aywxt20bQsyFvLGmc43vpIRdDzWQcLDPOtwqpIchFO2QZvLm10lE4YcmRcMyZea2bVSlY0YQ37uEtx+vxkyVq/bme74Nm7rNTh93bl6fTcchhBBDVVUi4r1HJGOsqo7H48nUVKXZ4PS9c1PXNQ4xHP3sfEDsOrsK6S6zJNm6ThJ2Dni9PuxjBP+ebpl/TadTdeU/+c0Plk3h6tUaXfKJgAiIFIwgic5HFSYvMnDVcUk3/rfflYfwmpESUaMS8N6jZ42oQDEL4xdZdmf5MB6PvfcZCaqqymbUDYl+/rPPvnjznph2MaqYTRbYGGOa0AKRK11I4fj4sKIwKXhT1133lR90UhGDWJDlIck4S1i7UqBvC5G2o7pc0nSnJOFAdciLrPe8EwWNMRg2Ofw3x432ZMutdKK3wYXdsMwhGmgoTXYCNYn6pIwBBts6pkKXT1ZVVbagzc1vjIlAymriaXLn2r4XCptQr1tblOysYTCMx0cHKbTW2LZtRaQsyzyyXK1WKaWmaQyX98/tHz4uiCmDdjtJorqNRhgA0m5r1ZSSJIkx5t5j2LOHJzOzy7LA2DlnrCmKom3bxsdl9cIfPyjaTWpCcGQpIQuNXFWyKS2XDKXFHLLivXfOPHwwvtq8EsoPOVkBMeiNLm4cGEb54/ce/vEjz5LV61gUzhheLVfDcVE3tUh24FOybvaVW+6u1uNQZzKnJAkxrTYbIBQAZL66vCgMGIb9/b08IRIVQPG+BWFQzuq8fJOuLq+qquqpzN0n7/nHne9etvyz1ubtPd/ZPCrpMkVAUxLn3HqzHiRAxDntiAZ6xU7oKuxGO+3y5n7of3B3GqmwW+bnpZZh3iSimpXNOVWQmICTDxHAN/fuPzl7fsZIoJiAELU0xretSACAoihyYEIewhRF0TTN5cWmXqerZrTh223bAmQaSCfeySujMz6QrqzMjPBsBI+ExprUozwKyn3ulYImSZlUk69qWZRJUooJJdWJ7/ujycEdxti2wfsISjEIJFUfASJjstZm7ft8Prv5gh/p/XJzyAhRFaV+5Sbr6n2DUIz3l2nEgohkmH3rY0yiUriiq1YVYow53JmkxpdH+t/82Ml4UwsiFmzBihVWwKQWmUTb4J63kxqnKaayKpeLZdM0MQqRSRoBlYiDJmRMoQ3Nauj2FRQoCniBIOo7amefbRRiyBt7ijGnamcEa7D0a5s2b62IOOwfWRCWvz4cdrmw7UZ/qAqSNGbvXc1ZUvkbCLqosx0G/G5AS37i67peLK46D/c8JjLMxqzUfbKAdrGo3HgyGX/w4Vs3b82dSSNnSqMGoY3QppgIIujlavX89MywqXH2W++2v/HR4a88fe237rlp2nR7LXdFUn7Kc+R4HxkJaAiZkDlqIurmg/lB7aorVSSnaGJCBSMICcQ6R8xN28YQ84ubFL69mSq5zXKCgYwQpcT51YoyJWEC8ooJAiSTLrlZiK4T2Kg14UJk+uTBk32u6naR9m+6uI9FUNWs5sp5bet6k+HrlBqCpOJRo0klN8HMXfjZL+q/+/7Fgw1qatQRobG56CHOLuQxxow3lmUZUxxc3RVzqiAw0WbTTmfTKKmztBt2EVUBzfkn1AWsUq/1EzYMCklS4YqmbfLPdiA4daKibkyGwEwxCkIPGO5UVwK5A+2Mpnbz6/opLxJiTNEam/fdrGtgwwAQQ8z5CcQ0GU/ytaOePh9SIjZVwTw+mtD00YN3P/PG6z6qb1sEUVbnnKhe1nG/mDSpWS3XV4vNWxd7f/yoldGXrkKVrhqxjWptPeWcywwcDAPN7uDu0+0FcryFySDWlp6EXXnafXM30wdE8sE752wfwhCScPKmKC/PrmB1qWNKqNmDUjSFJojCxdn50eHN+48fH9y6c0l3vv9UkrWUUnaBiRIvoG7Gt9fnF9/81pMGDryqyykd2SymC8ojSUJ9OQQApl4vk63GJDfdR68cv/DBiZYlGa0ENcTgrDNMq5XPfNa29YwqItbY7H2VP1hMEbWbUDFxUsl2SN77fEWyRCIDtXkSzJQ9g3uSMXXpMVkNG0PsSPQq3dYigABErNLd7O407JlUeUY0IKCayfUKGbDd+gCESJRTmbVtfS7gUpuyk2weIrVNmx1W84wl96dIpH49s9XDs6vnq+eWvTHesI2xC2APMSJSUVWnV4vJeLxu6oObL33jO/aqeqVpweFzo8SRU6AAbceGwRwhKqqaNeO9fRwgYuGKEMO2Htdtad/Z5ipgv8enlJAwF1ibeiMiyCQgpF4Qy+NXVqe/07IbjSwK50AGBDbsZuPZpvarzcot4//x7ZMNHid0EtoIiQhQpjV/4pd/PTxOUOOxaOtio2oUshVGx+AZgkRERZMiIk1V2da+5Vk1mpsFs40SUDk/DUlSDDF/pmzLJklG41F2u+9hccxTPya+uLwc4NMQwzAo3c3w7ZIEVFJKuWjooHLRTb3JxxwbHixfcctEAJHuR35ItjqUTZJP+BQH7WEvKYbcmdpuZAkI6JwdEFEmJiYRCTG6osjwaY6SH9pJbi+PC5nO922sX33l1isvHDr0E+uqUcXMhMhMl6enqWmWFxdVWT54ehKgQt+69jkpkEpKaZB7K2zN/nIBKklEJKaY5ep1Uw9WzUPCRdbu9Wf39r1ls0VEXFwtoLOvziQIX0f8rbefq5laLNo6+kY0ASjFJKpUluVkb28+329beK4vep2xiiSfhDUalGZNi6di1L1kHVqz5jgZDIW7ApSJmW1OorLWWQcANC2KfVvwxKx8nJXWxNaS83DF3bjDKHYChxBizq/Kh4V1tps9iCgoqfq2ZhSV0Dd6AF2AR4f7oUD+F0TzRAiyYkQhJenGiimtVuuUkm5jCnocoV+DWR2l/eimFxnngAgiZARSyWsil/vc9Y/Z+ZO2lGVjTLa5ymd93qg6GEKFmCSlHFoGSfbmB0fjcPr8NMZLpMXl1WpcTmZTZzA4ZxkRQv3S7eOb+0fz0cQxXS15pabFDSvHqDGqoEQMhg1Tt5ET0v7+vsn5U2SQHJFTMNl1bEidzTWWsUZ6ck23VXTPvLPWOlf41scUQ4wd+qAQoRhp+LX3Fh+WL3ObyuASQ+ulqc9jaKxFMvT4wcOC3TM8AjUooa9DsvWlFIBkVOsrowmxEGOpW945XgkQwGRyCrOq+uBVlaJhREqxLqzzaJAB1RhbACiz6XKbiIyxKUXofNutYdNFMKgy82QyMdbGGMuyCCnlWzU46EMnKg+7+pm+NO7T4Th7N3T+USJZWyB9JlJ/MXclXz3XWXvG3pDdOtg67DxaPVSjvemOwpDMk/lavXpMh4wxSbI7aqzGo+Xi4vT0ZDorJLWlKyVFwoSq3vuyLEdlFZu6qZ+eXZ09OInPNgfKc009cUcFkYw1CuAKN5mMs9byanFlrUEY+D64C/YOQYfMHEJE2HK1oY/mC8HnEXtO/WAekkTyhZTG7v/Kdx+uHaJtYlyotAYOWCfi3eosXpzdf9Tir/8BEl9R//ERUFEBsMAyJjHWxpAk9mkJhERUlmVGkjMVyrd+IA0QFG7ThKtVg270nQ9OwdrQBhTrg9fehs/aroqPMW3qOrdyec6WVRlN3Rjmtm0BgYlCDJ3JEwzTwZ12rxMtSl9Qa+zkGH2Z32W4gWHOT7b2MM/HclnhY77wW3VjtlPfweJ/CAHdBm32P751qOoRifw9SdJOLhMhoHV4dv70+o3Ds9Nn1sLe3qSpV9mBrWkbZ1xpnCsFxgeP/c0Lunt6VkP0qpGZsjV527Td+AEgpxYQdZAe9L7UQ44h7hiY5GGU/ifMbFCoqmq5XMYUY86B6rllualKKW20WJU3lnt3zzcrDQ4Ctj5BCDG051fnUNz49XfdsphQmCDSx64wQAbkhocwJUHqDEuIyFk7mUw6D1/C4b6TphoLXnh9+97ZeTtvgpJNPVGsm+DmvdEYzh2Hiko/8kPoshha356fn28N0aQrmzqMIIfgaId2pJhyZFd/oklKCUBTTH18t8aUYkohxiEiK+uk2XA2E+wySIkyTtGNb6kDoEU0xrgLLmg/pe7eBnSufxlHyjoTVcmy8WyNOUCsIiKaRON6sySOs5m5c+fGenWBkPZmk/Ozc2stZ7IboJqbTzc3Plgen6zCyBGDV8UYU0opp6d670MIbdM2bdM0TZ41W2OZOUcnZ2vuoYrohmCh54bgtnlUUGNtDJGZl8tlWZWEBKp5PJtEVVV8oxhbLf/vX38nmmKzsk/PrhZXz56e3Xu6Pl9Nxn90cvPUv7rRR9hWiKCi1OnRIRuTMLEkkSTWWGctAhauyCVdElmulk3b7OTMKgBQacWy2UR+uoRH56pkIYW2XebyKO/PuxoMVxTWuUyHci6nxAgTr9fr2WxGRCFGRKxG1e4y3yXx7bpV9kFEmtvj/F57HXBHOoCepAv9S1ljm7axzuZauyNBwDBU7s6+zEjqCYA992oLinYjgYH7sTVsVs32KRnk7DhSAmxoPCpv3LquEAFT6ZxET6S3bt2smxoJN/WKCr64nLz1IV7SAXPLsqIUo6L0Jka5JIwxhRiCDwhojCGmJClJlgd3jLQ86YdOwkS6pQWBAmS7wLKsMqRsjGE2/UE+RCJhFEBpsV5p9LNbNxfts4vVSTTNeLw/mV5v6eg/vrX83nLiRYs4L8YXiOiD340A72FCygBshjmSpNyH1nWdG7tdnToCmtYSaVo25jc+GpduDBDAjFE1aTdENWAikaTofejKSaRp6WK7XuDYQtP6OgGE1pdlpaKIgiRt2xpjVFSVcQjwIsiT49xdK2h2aeDceiuCaq4EuyErfWyClsk2KUZjDeSl0OUcgWKXqBhDMNYkUZBt9lu2dOhs1gnzCs+HezfVHoxVZevAnpJoElZAiwhauuJHXq3BT83svMDSk8wrh2A1UYHp+tH89751fuONV13Y/NrD8BynuloRSEygUAC2g2yyl2N3ThMikiMfRdTuxGmLpCH3yRrrQ2DiECMzDSzcoizW63U/HkVmSjFpR+QSBdUkzOwVUZXb5sGFvDf79IrSw2eT+LipwT5fpYSfsmoINs4USVFSTElyMZ2b03zdFKJAIoOI4Nu6KqsQQ4pallNACDEhMKLpWOAAJgT77e/ev7+43viRNdnevqvK27Y1bHzwxpVELoYAgCmxsbGR5194/e6fvHV5lRyacZWaZYxdqauiIjnRqSNOoeb2YVcnOEgdOr8kxWxW1vXVvbH7TsSXgkJKIc8NMI9TJBljsiWkkqroaDyWlHzwTCaXn5qyfA0H8uAOD25ngI2Yq2NVGRwWeihSAMPh3N6aijwKn7z7ySadoSuCtFNGMLTUWNrVl772yX/0r3kzqiJcj35TQV2n7vbs5sEO8+PBQS4En50EBk7YQPczxiSRkHlyooYZEbV3vdxsNplenf2Seg/ODgLSHXajqEKStb/2W/cbZquxaOvTVdMijwRUSACh9W0/i5TesTE/qxGwy2jJHddoNEJETFjXtTHVYByUy+huhP+jf/ZHxzffeOvh5jzNGba2MR29BNQYS8wpxbw5C6QohN6llb82bhYhamL0qayqwVwa+v2DiFTRWdcbrWBvHZHXNXY0FdgGM3XfswMl5LIp7/zDzda+5B8U+rkPzQinsSa3NB0FIDeLO6FOhCSq+ZTPCzzvHNkApjPw7XwiVJFQ/PWZ/ujLuHl2uX52MT1WIKvQFs6m0E55VLaTSCfffpYu22s+iG/WkqJI14d+XNudU4Koz7HdZv5+zOcSEZFshj8QQDv1er7f+fRn4hiCdA7TuuOUSTu0idyDA2EEPV8TBG3rzdkqQDmqCkeoHpE76jZTxtK6aCDArJTJdyLlA9cQqrZt22WkC+zMNnrmvSrxra/9xg/q57UDI73xyfYzA0DsWzwiYkYsgKhk3o9x9PWf+NRnDi5uznUdsJvfEWabZCLKF8I5t6k3uVLbycDJcTE01Ke6zUrdKfmhgygHhnU+MyTPpLsDK3XhFz0xq1uFoCJJt7WCZvlarsNyDHPGHTpWNBtm6qv7TBYABU2dLFlGRXz+7PL5+oGsNu1ajKoGFCwjjAPXF/rRlX9pefpiERawukAF31kGb/HQoZ/Ju/qWSw0gKmzMltjTG/eGGGN2Y9sh8eXNNS8vNkb6vPfcEGMfcDdw1zpzQzXSTN16nC6cNCWhl7hW8IUzmVmfX19EMGt9syaPshqbEcCwcc4ZtilFIkoxdZkSfeKtwpYnab7xPTzb3EphJaYADYqaH9zt/JVNjCElscaCIohVbO24nU3C+x/8YNbee7aOwdwFaI1hEROCzw5Yqd9RiqLoAaFMMKVcb/VgDCqkbfWzE668o+QcpsWokCFs1X55DcDUQJLpOCTEsjONQ8Ck2XlRhy5ycEMYTLby+qZsrtSd1uSscRYfPVtePyqvufl0NMO4SWwWa7n/pLm0L37zXb6ow+nswoW5hwuOLWWKXn+YDw45WUaIW4ijc8uRlHapsB03mjthAeb2thcjdTwZRJGUSZED/bU/NLbKcpFEhBEllrFKF2ow8qgM5aiYRVEfI0LbEX0B+9Du7iLkvz2fNq4oYgyq2nrPbJhNFoHtCDux99tD40ezKaTLwPnd9t5r3ZBYREIM1hLHUGhVKxmRCtMz78qLev/Toyv/M++uFseoDUAIUVRdUSWJSEigMcU2eADIob25j1XUHmjo0E8lFO3vAyIgKkDKqmYk7Xu3zuuR8Ifwpyzg0axPTpBQuhWTuwSiJJI/c2eHJJKjN3bs47WD1wGSJEOm50IhUyRVqlwM56fL+2/e/HQ1Kpu42SO8MuNjbX/z6dGH7QThU1jCXojiN6Aa5IdMnaEfqG0bz63cqPcrzD/QUdlyRZiEGPIOQUhJUxcCRRjbLoIgD0O3w6tu+SETKwijCqox3DZtacukU1XhiFSaqF4R2EgIXe0rPXsgY55M7JzzIUhKCBRDTFEAgE2ZgQZAA5i0XzZ9lpYSEr15tKo3FwnQSeq0yD/srSi+9cKuEQaUyGZdjD83fjTXs6ebG7/1R+9hNMqRiTNDkIjyrj7E9lEv+B92lx1/Dt016RvgTlXpxcwKmdcwaBR3SBPa9wddLEoPJ/ZHDPZpU4MqAURSlmx0HE3dallTSsxsrevJOV0MFwBaa2/euCM0bZtw9vy5tGnV4O+9t/q95wcf1HuoSgAMEKOs1uvtjKFbQEQDORFwl/P5Q/zVfvAAP+TWZIzNW1R3AHVKYMqu9jnBL9NAut6Zunom467GZM4q9lAiEGK2JBq8nCVJEvHeq3SramArIfYYaZ/uZs2WszTohHeqJwQAulWuQL0AMEq22Ntx3QBRFUkIkASCRtUkSLf0o0/bjx7X9KvfWrTlQWVKMQmYgImsVUZrTFVWrnBFUWQQUhUGfRz2fin9VEd3No8O4qJO+JBXSScblyFMZ6v00p12Y5CnDv/AzmwEhko5M1F7q8uUaXZI6KxDQKZupJpRMCbDxMz00YOHRTUPUWbVuF0t/dXFaO+V71/NPe/nMWUMsa031DNRd7xMtIfrdmYEeYPdgbm7L2pHmdutMlWFmAcanYqEGDI1Mn/G0WiUh6hZgsvMRIhE48k4+01mGmA3vMqMfsO+9a33nQ5CJMVojc1lTBYZAEDIOYMxdj+bDRNy19/7jfefAocyS1XN2x813hdVVcZ23fPZuzuRg1WZDSH4pEVaFZyuOX9j9fa6mjaTVws1troyscJRipE7Y7OkErwPPr+hXhsIAOCcDQFE1CALRNjxF4XUm1YppF6hpZIdHzETp3q+g+oOTY8GoB80a52pc0rqSIUdqjAAHb1IeCB+dTUfgoBQv+vJVnGRG1gTY9w0V3Q4v1rVruSS6wT2/vPGgGdCiTH5ICEpdut/VxM7UIb61qk7GVNGPru6a5DppTzlzGTAXqQkeSaRH5U+/qm7CIurRS65tItHJBVBhM1mQ31f208mOipYXdd9hne25EPqLbgyOOxbz8aklIqi7Mg5Xc/OgINxV/e2M/SVn3RmRCDzvYsjaxlUAkDvf9UxFbGnPQURQ+jS5pUZvYBP3a3Xf+2Rm2u8DAi2ce2oxQRRjHUIKiCbepN18YjEvV0YIjZN65xFkOB9LgtyXdGbjg5C+6HZzzdAdvefzo1z2PaydVt/yOboOSTMOp6untQtoyk/XjHFwhW5ad+VJHRkumGQkvspJhFhhrED5qgGI1e1NT94stjYa04Eo0oSSQk6tkc2UlMCGqgZSIOCDTJ1UUR63cDwzOBuezW0iHlNZI+CHq7sghSKosj0JEiQcS8mBsS2adKABPRPr6gSISh3Uy/oDE4HWnkGNfJrjsajlJK1RkQAiZlSShl23S1eM2zENBgWd1D2/z8Abjip7wkJjk8AAAAASUVORK5CYII=' width='200' height='133' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=2647a386f5a04917b74cc4f40a48f57f' target='_blank'><b>Model Builder for Mussel Farm Detection</b>\n",
+       "                        </a>\n",
+       "                        <br/>Model Builder for Mussel Farm Detection<img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">Geoprocessing Sample by api_data_owner\n",
+       "                        <br/>Last Modified: December 16, 2021\n",
+       "                        <br/>0 comments, 0 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"Model Builder for Mussel Farm Detection\" type:Geoprocessing Sample owner:api_data_owner>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=ff6a48b3391c4a24b807af0eb08bb6c1' target='_blank'>\n",
+       "                        <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAACFCAYAAAAenrcsAACAAElEQVR4Xsy9Z3icx53lu89zP+7de3fHO2PP3HFUYM45igkkQeTU6EbnnHNGdwONBho5J+YoiZI8nvHYY3s8O06y5aBIi5kUcwIBgjmIkmyfe6pAz+5zP9+V9aGebgAd3n67fv9zTlW9hf/03m3gL9Xe/fP9yT/h2O1PMXH/IS5du4jew60IDfkQGPLD2mOHK+9FtCUGV2MI+qQDnhY/siNZZIYa4GzxwZRzoHGkEU2jjUj2RtC5px1Dh/rR0J9EpCMIb4sXjowDpeYqVDir+DoOhDtCsKRMMMTUUAWq4Gw0w5uzos5fBn2kFqnBGGJ9fsR7Qhjc34Ydrw6gc3cO+ZEUAu1eVIcVMMcN0MXVWKsvwFrjVkQ7Exg6MIgdr4xg+EA/Ona2w5FzI9ZTj7ZdbcjvyMLX6YUqZUR5SIUt1kpsMpRhi7YMxW4VLDkXgv0hODocsLS7YG51QNdghqLehNKUFpu8lRjY1YtXvnsY5qgZtf5axLpSsKd82KQuwnrVZr5eMbbZKqHya6D0quFu8iLDc1VW78NijwULXCbMc+ix0KnDErcR3zLV4RvGOnzVoMLfG5T4W30t/o7tq1oF/l5Xja/rq/CisQrLXEq4u4KIDdYjOBiHu8+LwEgItg43KmwVKNeVQmWrRrWpEjVsloAGxXVbsa5mPSwxE5xJC1xJK/R+LUKdQST3JOAb8cPW5eLnMKBQUwVj2AhLwowaTw2/ExU0ASXs9RZY0zYY6m0wN8VQFgniO++fwpmJ+zhz7hyuX7+Gickx3LhxBRMTY7g1eZNtAnfu3ObPE7JNTk7i0aMHuPdwHJN3r+P+w0k+76p8zP379/DgwT08ffoYT55MtXv37+Dhw7u4/+Au/tP/t9N+3u39yanbI3f+iIknhOTOTXQebkHXwSYMvpxH1/4mZEbrkexKIJyLs4O2onEgy5Mchq3ZCWuzC65WDwJdAST6osgMJNF/oA/Dr4gO3YzG4RRihCFEqLbpy1DtqpGAJHoiiHUH4Gu2wVqvhiGigjmjgzZaQ2iUiHb7kRgIoW1nE7a/3MvWg5GDHejfk4ev1YsVugIUmYoR6QxAk2bntZeg0FEJbdzMTulGnvD6cwGUOGqgiVj5PmH48wH4OwLY5leggJ1og6YMa0yl2GitQrAziVa+trcvSEDc0DTaUJkwoDSsxRbCo2NHr42a0DbcgVx/CzslXzdsYIdysUMqoHUqofDUYr2mEJv1JXxPPbTscOGeGN8zhi1hOwExY75dj7k2DWaZVZhmUuI5k4pNjefMGnydoAhIvmaoxTcEJATka7pKPGeoxBxRXPh6Ln5eW7+XANvh6fSgxquE0qXCxspNKKjahJK6bdDyZw87tJ3HW24ug5P3vVkXLHEjatwKKJI61DUYoE3qYWlzoManR6VVDXVAx7/XospRzUKlhCnCn121qODvKvi3Ip8Ttel6fP/ISZy/eAlXrlzGrdsE4s4Yxm5eZbuCSd6/d38Cd+/dxt27dwnBHdy+PSl/fvQx79+7wefcwNWrlyQgjx/fx8NHd/H0k4f4+OPH+OSTj/H4yQM8enyPz5n4ywPy53bq/h/x4JOnuHnnBtIH02jem0THviyadqaQHE7IjuXOepHqTqFpKIdIVwz2ZjciPVHEe2NwsNP6CEqsO4TWHTn07WvD8KFOtO9ohC/rhrfJRziUsLJCRdqDUmm8hEMfqYM2Ug1zUgMvvyx33soObkGaldLf40NqJCHh2PlKH0YPdmHnoR6+RwQvGbehxFeF+r4ErG02bPCUYYV+MzZaSrHFUgZTwoRIawQqfvkFVIgtzkroGk0wsuOXhVUotFez1aDUp8IGVxWqYnqEqB7x7UmUZtXQNjlRw98V++qwmUpRw9cL5WNItqVhjFigDbDzN8dQ69aj1l6LUL0dNU52LHYqW8YOa4ODyhUjwHGoUy6sC9iwxGXEAgGIVYMZhGOaUYHpBGS6WU1YNBKUb1BJvm5U8laJr+sUBKQKzxuqscKphrnBTVUPQdtuwVZHKRQ+JSoIejWVo5yfsZpKo3fVIdTggS/j4u9reHwKgmJEvDXEguEj1Hp2dMLdZIQ1a4e+wYpiHoslaoc5YUWZtRqVfJ4+qIM75eB3RqU1lGOTTY2VRi22+j34l9++iwsXL1ApxvDgMUGgMly/fh43xi7iwSPRsYUy3GG7TfWYwO27t3Dn3jjuPRjH46e3qRh3+NgrVJLbePL0Htt9PP30MUGZuv/4CZ/78Bbu3h//4gBy+t4fcffxI1ybuIrWV5qR251AciQCN6tUigrSuKOBticJV1bYJVawtEtarYbBBkQJiJ+KYGeniHdF0La9Ga2jGbRuT6OxP45YexTe3jAC7Nhmyr09ZYOjwcaTX4FCdmqFtxSOrAGxXh+VyQ1f3omuA10IDUZhbrNiYF8H1aMb3TuzGNjbCl+bDwUEorK+jkC5URZSYJ5yLVbW0eIYy7BeW4xyZy3sSdqkqBVFtFKbveWwEyR1vQ7VETUtlQLrLfziqR5LtFsxV7UBq50ltDF+aLJm2gkXVIR5k6MKL7nLsIHWz9jiRjifhC3lgbfBT0WNocKuRJVdAV+KQLmVUAf1tJ5pnrM0rVUj0iwmipQXy9wmLHYaqCA6zLbUSUCmIBG3dQRFjRctWjxPJXmOSvJNCUiNtFizrVSwTBhRAhejNQoMRGBMWXjeVKijjfPR9hrcWigsNaixVMPDn91JO3RhdvIGJ62TFg19KaT70/C0+qFOmxAcDvE7zcBASGwEuL47zr95URcz8DPopN0y0UZWUxlLqF4FFjXWWI0oDvnxgzd/QQW4zI4/jkdPJ9npJ2mxzuHqtbN48jGt1L27VJHbePj4loTi1p3rBGQMd9jhn372iIoyIeF6+EQ85h4+/vQBf38fD57w8Y8I0sMJ/v4uf3//iwPIqbt/xK37D3Dx2gU0HyQge9Jo2dmA5uEM6gfiMPFEK3wGVHkptWYFytkpFDENTLRZQXb8cHcUriZaLdqYhsEMcqMNaBhKIdWTRLApjCqfBlZ2MCeziKiwpZYSbKhdhyJmBy0zR5CdN9btISAuePOsvr0BZh9+8WmjzDKZvjCyfRF0U51ihFGZ0qCGgOipCvYmO7ZRBdZrt2FFzSYsV9B+WSoJshvqGPMGFWOzuxKGjBGqqBq1CWElVHzvciyoXo/Z5WsxX7kBG5wVqEsaoW+iTaMlMVNFtvlqsdJSiDXuIjgIpshcuqCRFdoHhVODl2q3sOrWwhgl8A4F9CE9UkP16H69HW2H8lTfRhSErFjk0FI9tIRDLe3VTCrHDLYpQHjfPAXINLYXCYnIJl/XK/BNfTUWmZVIdmTQMNCA5JD4PtKoH07D2SqKlRNavxrGkAkuQqr1aqFi1dfx1pVwoJ72LtkVR/NQE/Lb8/BQvT19tMM769H/SpeETYCSJtBBnl877WkdIdeEeK74ujUERO2nklL91trMWO+y4Z9/8m+4fPkyO/0tPPmEVf/TO7g5cRHXrp/B449FdriDByJDUAVE7rhzn9nk9hjzx5hUjMtXLkhb9eTpHQmIsF5PqCy3bl/ja97E+K0xvt4NCckXBpBjzCBXx+/g2NnjaNidRXZHkqE7Q8/fhiwrT4Qn2pZ0YzOtyVYGbQOrq5Ph3Nhih7PNA1e7UJNGuJhJ3C0eWe0y/DnAHGChVBviVlY0I+wxKxz0xEqfAhtr12NlxXLYM2bkaG0ytA8Ng6IRhqEITFkTrLREXr5PiHC1DqaZgRqRpG3x1ftRQ5+sbNTw2AIw8ngKzOXYQv9fYxUhU0tL4kR8oB76vA0bXeVYZy7GFlMFQ3QNqyItlqMCyw2FWKIqwDbmhzDzk4+2TpnTM4yqCH6IMJmwLVgLD5WlMsSOyKDbsacb9dsbsJVqtVaxGVW0NeW2WhncLTELAUmh7eUWtBxohqHZj5UehnKHBvNoU2YTjtnmKSimGWsxnYDMlApSN6UeVJLn2V4gSM8Zp0Cq9jvgiPoQFmos1Gk4x4yWRKW3FtakyHAWRJoDaB/N82c7tjCHlGhKmENcyHQxW40IRc8jPZBBbIBKsiuD6PY4wjt4HgfCyOxII9AZ5bl2w8ZzVksgjPUOWi4zswgLkUuDdVYtltFibfLZ8eNf/ZwKcpUZY0IGbqEityavYpyQCNW4ffcGO/wDBu37Mkc8fHRHBviJyWuE4TauXL+IK9cu4er1y1SdywTrCp97DSdOHCd4l3Di5AmcPnOaf7vyxQHkvdt/wntjT/DO6TPoe7ULydEQBl5uR8euVobsOKtQCg5aC03aCk3SQB+vRE1KS//vgoGWyNBkg7s9gGhXFCFWqcRAArmdzUh0JuDtCDITWKXd2aotxbLitSjUbUOxfisqLduQ6PAz1ySkxWramUDDMAN1uxP6jB6KEAMnK3kPlWNoX7vMH+Z6YS+YDVylUDXqEO0MwZS2oCZYRwi1iDR4kWgLw1LPY00Z+f4+5iM/PMxM2pCweC4U0ocvo7VaWLOR1mwLPHk/MrSEhrwdtQ20GIQq1B+FKmZGrD/FEB/FZhYGPTtO9/5+JIbrUUmo1PT0dR4tqmm1yoyVMpj3vNyBztc60MLQr0wLe6XFQmcdFUSDubRXc6gWs54pyAyjsFt1hKWOcGgIiVYC8qL4HcP6coISbk6jaaAdqV1ZxEaSaD/UgTizYJ1fy+BtgpJWyxw2o2u0DfaEHZW0RHpmL2/Gg4aeNKKtYRaYMNI7WPgIrmOYsGf1KE0wqGeDiPRnCUg9bZsbGn5H2riFBS4BPbOLKW6GJmLm9+3A1ogPJVE33nznLXbkiwzSk9I63X3AoH77KibZ7lItHgnr9Ii54ulTPHnyhJbrDv82zr/dZGaZwONPJnkrcgkV5t4kLdctCcaRI0cY/K/w9gP588OH975IgIj2JxydeITDP3oZ4aEgq1UYQXZ4R0sQ7Tv5BXUmYSQg1gYTg6cGVRnRWKnbfQh2RGBpsNMKiJGuJiRYufxNorJTLcIGrFNuxdqqAlajOobcqVGVULMHzayKgwfz6NzVyEDrQrJPKEickLnhydlovQIM6IMYPtCN3r15NLKCuts9KAxVoiqhRONwHD27ckgOxOBkXhJDuMZGK+rFMHFviMHcCHeHC+17qDy0aaqQjp3aiFqCtJnBfYVuK9tmuHIeZIZj8HQzezTTnvR7kNvLDsmO0jbagiSPUwyzNg7msPu1XUj1NUBNu2llh4x0JKGipVlXvRGVDP5J+v0D3z+Eg9/7NkFLMZxrsYgheyEt2VxrHWYze8wU6sGcMY2hfLqhjkCoqBpaabPmOHi+wrQ62XqehxzPUxTRhijzTCNStL2Z3Rk07m1CgMcjMl2RrljaKi8LQ62HFtLBbOJWwxG3w0pFM6Ws8LJoudjsPR5UpjUsLjUoZ0Zb57WgMOxBaczPwB5CsJ3FkI4h3lsPe2MAlRE7lvOY17hMBMSLrUEnfvLWT3Ht2nU8ZmadoHUav3WDlugyFeIq7lBVnnz8iNnjNj799CnbpzKw375zQ8Ij8sVd5pIHj27LYVwxcvWI4fwBVWZ84joV5xZf5zpV6Cbt2hcOEFqt25/gX9/8IcwMvxp20ARPlq8tghB9v5MVWJc0sYoaoIgoqSY6Po7AtDgp+XxMi5eduBPNI1l6cjvKTAoUW6thpLpsNZSiQLUNOr8BdlZhW8qMKMFqG0lhzxt96D/QwlCfoWI1IcXKHWnzskr6kR9txP7XRtC7px39ezvQvqMFXkJTlagjUF7kWFF3MMC3726Cqc2Ojf4KqBpoEXhc/l4qHgHZ7KmAv5MWpZNfuE8NPW2egTZCFdSgwF2BiqAKIQI+dKgdPfty0LfwOdEqNPLY2ghf62gTtu/rwfC+Xgzt6MfQ3n5awmZaPapeVwyORg/KHTWosFTwM4XQureNrzOK3O5RbAzZaa/qGNCnAJkj8odBgWnMFi/yVkAiQRFDvWIkizZLqMdKhxnB3i7sPHwQ4aYYoh31VLgsUlSBGPNDaHc9Ar0RdnofzCkb6gh+sC8Kb08QtpwTLmYTa9zGzOeUf6/yKqXFrfCpsMlewVaDgrAdq0MOLPXasNhmxMYAv5eWOJp2tCJM5SmNubA55sDmOG+Dbmzye7CRj/23X/4UY2NUjrt3cOvWTdwcv8ZccYagXJbh/N69e3Ie4/ETMXT7hI+bJEDMF1SQO/dpyx6Jka1xOcIl5kFEZrl7f5Lw3JTDwA+eTPBxN+Tjv2CAUEHG7+P1f3kVkZ4wlBkLbG0hpPsb0Uib0dybRLjVBwOrdGVACVVcD6sYkWq0w51zoZFhPjecQojPqWVFlY1fnL3LC1WEwc+vkz5dDB+Kod8AgWqmVdlzuBcD+/OUdS9atqeQ6Y/QNvnomePo3pXHgdeG0UaL1bG9BT07OxjMbaisVxKeFKLD7JC7G9G6qwH6rBmFAQXcrP6VDXVY62HmsFdik7kCtTEDgTYTblrBRq88rhJW0coQg37CQqUMo3NfE5Umi2CPH4YGGxpZRTvEiBxVY+duQjzYg76hfippBqnBLJqGm6icYfgY3G1pG2y0dLasg5U9iqq4E+u9RiywqagatYRDjbk2Zg19LV7UVeEFtukSkFo8r60hLEpaqylAZtLvr/Ww+rc0YuTVXYhQhZp25hGnBRQKkmCoju5kqO6Ny9E2L8O1l+csuTMLb2cY3q4QEoMJOJs8cOR98rMWMJsVMjNtEyN3/NybYnYsY+efFzBjUdCGZREXFlFNVvstKE77UZT0Ym3UgXVUoXW8XWrWYbGuDiVBC3713u9Y9R/JOY6bYzeZL8YxPn6dqjFB23WXgNymtRKAPMInnzyVWeT2nQkCMInJO+PSkk3cvjE1N0IrJoZ75d/uXscttnuPbsqs8ujJ5BcLkPcJyKmxSWx/fQRde5gfaCuszV4YGzxsZnaIBDuDCHI2rLeVMbiVocpTBzU7vy/vQWNfAmHaMR096zb68WIG4QqHQgbZdaqtKDayutOvu9NO+Bsc8NBmtVA19r8xiO4djVBGKun3/QQyRtVyy7mQzh1t2PFyL7p259FHFckONWBbuEYO1wYIkaXLQW9NG0TbYSY4Rc5a1FLZSpldCvzVWEX7UWCoxFZbNQpcVaiM0RY1ulAR06COXjvQHqalSyPJDuWgIlUw02wLKmHiY3JDTRjd04dXD+3Cnv070TvSg9GD2xGnpXLR36f4vDRBEcBZaGMSfUlYmkUV9mBbwITFBGOOsYq5Q0EVUTNrCFulIBxUD7ZpegVeZHtOS2DEfZlDpkazFjrNKEkEEOprgofqkdrRjD4qadvBdsR3sgiN8LvJuVHpr0NdxgzvCBW8r5750IJyZiMDrbCrxc/8FWVm43kxVaDQXIbNjiqsoAVbxEyxuN6NBbSIi+MOLE+4sSruwVICslg0jwXLfBasCdmwhqoxT1OLVfoqaBMOHD19VE7myZnycQHHGNVgXIJx584tKgI792N2+geTcl5E2Kj7D6gUD8Wo1dTo1n1arAcER9i0ew/Ez89Gu+5cfzb8e5d27QumIGI2/dzNmxg43IOu/S0YZths294Ia9bDL/oluDvdaOhPIE7LtdVVjYWGrVijL8UWZzWsGTvDZAiGsBVb6kqwumYTtuiKUMjKtbBwFZaVrcWa6g2oYQdWEypjQM0c4kTH3mbsfLUXgwy0le4S5gMFfLQI0Z4QPF1uVsQAmrfnpG3LjWagb7Kiol6DsPDTOQcUDVqk2FkaRxJQxg0odqlpJzSoYT4otCuwoq4IRcZqlDNEb3XS8gnFEBN57MT+3gTtUA77vjOI+tE0NrPSlqe8KAu5YW/2441v78G+w0N45Tt7WTB60Lu9jUrWAmfaJVucBSQ6kJSBNtEbQ+crHYgOsaMORKBKstMRkJm6MkzXlTOUT4ExzSCgqJ6ChGryglAQ3n+Bv3+e959jJvmmtFsEyqrGAifzCzPMSlpCbVucx9mCEDNaYkcKjjYPytyEmYXGPRCCl5bL3x1FsZgEtVbIwmWl/bNRrau9dSikDVzL15ntM2NewoUFtE7zmAfnM2esSvuwKRfB8qiTSmLDXFq8ZVSx5Q4Tlhi1WMFjrQwwtGe8ePvob2mNJuVMuGjj41dxa/IGAbnFwD0ulUGE70nmDjFsK8K2COxPPxGTgWIScJL54r60VnfkJOLE1Ay7WIYiVEioCoESf/tCAXL07h9xnb5w7z8OoWVPCq37Uujc3yjXJy11b4Gt1YUEs4arwQVrkxNu2q1yvxqrDSWoYeeyUWlUfiOKzFUotrFqG4uxrrYAczevxNyCpdioLEAFq1g5lcQcMiHaGkQ3w2ZuiAowkoYto4PCV466QDW9fFBOUqpaTdC10cbxvUO0feomMyu0GxnaC3+HH4WRavh63Qj1BlHkrUUpQ2qVS4Nymxoqtx5bzJUoZUcVcxVbeVxFVActs1XTaB5te9uR39+E4dd74KRV0uTS0KYihCOOzj29+OGP/xmDLw9hkAA3Mxu1jjSibagF2rAJ/vYAmvY2ooW2rOVgM3pf6cbQtwfQ/0YHbVA9w24CW9xazNNXYLqmDC9qS6kUZXiBaiHyxzS9sFUKCYZQj+cMNXiOv3uO4V2szfqGUY1v0Xa9yJ+nEa7pZgVmsi2yKamgJkJCi8VcWMjPV+WuQ6AvjCBVJM5MpmVwr/QpUe1RyREpe4MbStrINR6dVI5FtE8zmY1mUx2epw2c6bfSbvmwwOfg+4gMxON2MJdYjVikUzHDmeDMJ5nTGhDpTuHEueO0TAKEceaPK7h86ayc+BMdXgRyoQhiJEvkjLv3pzq8GM367LNP8elnTyQ0AhKhJLduX5fzH0I5RHvwSEwuTlmx6zeufnEAeZ/t7P0/Udoe4Af/42W0HmxAz8Ecdrzageb9WVZOduS+DCrDavpadta+kMwpYmi1jl9YIRVlrZZ2pq4cFaxqWy1l2KjdhpdUm7C2eiOWFq7EBsVGGAL8MunXk3kqw3ADWkbrEaO1aWQwD7W4oPbTPgWqoAxVQ9doQGVWg9LGOtg6PHB1EchkHbRpk7R6dipNIW2Uvd2JimgdNtHy6dgRhHpU2OuYgTTYKGbWWcHLaSs2W6qwSL8FL9Ee1tEq1CZFRwti7+E+WrRWOHpyiI+2wTvUiGr6d3XOh8Y93Tj849ex//sHMHiwDz3DHQy7ZkRoA3MHG3luGhDoDqBxdxpNVLquPV0sIil480GUMRCv4HsvZpuvLsI05Ta8WF1IWCplDnleV4nnhZoY/icg3yIQYqnJ18RsuklYLqVcavIiVXAam4Bkvq0W2xJWKJl5yhy1qAvqqCwpeHoDzCYJlPK7EOunzHk/FKz4puYIljBHPOc14WsOPZ6zmzDDZ8NzvP+C04DpXisW+J2YRbWYplXSLWiwxKnn+VSiPKjl8z3Y+71X8b2f/gi9ewdx8uwJAiBmy8dw6fJJOYMuwvnjxw/lMhIRtgUkt2m3xPKRqZGqh3K499FjBnL+7fHTu/JxYuhXLEMRk4g3J67KrCLatWtXcOb0qS8OIEfuAGNP/ihHE9744T4MHmZFfKUTB749hM4DbWjf2QJPxgdj1IISXw0sGRtiHREowjq4KPHCYi0lCKtK1zF/lDMMlqGEHbacnndN1SasLF2LKoZlHwO9j3km3OhEkmG+cTCG/I56qkgMwRYnNEEFdKFa5hMbDCk9w7WGYbccZQmC0WDFVl816pgjAm1eBvkASp1VKPMqsJnvVeZSwBK3odpZB03UjCqq2zZajRJXrVxPtI6ddLl6C1ZrtqHab6Da1KGCEEU6k+g9MIDIUB6bEjasDuuxnM9d5qZFc9egMG5GaJRW7PsH8b0ffxuDB/qQo+WLbI8jxHCsb2CVZtFw8PzoIibEO1PIU6Hc/Ix+BngzP7M950JtVA9FSodZOqEmbLRfL+hF/qiWoHyL0DxHWL5BSL4mlpoYVfiWWNBoFFaMfyNQ/xMSFUpiNnhaw+ja141kTxL6mJHnxoQqsbAwZMR8tw7PeYz4hlAJBvIXAhZ8lUB802XCi1SNmREqRsCO590WzPLZsZIqsikVxJZ6L2qYwewdASRpsV29YQy8MYqXf/Q6OgnIe0ffZ06YxNj4JSrIJdnBH7GwiuFdMTF4+94YAblLWMS6qgf4+KlYfHhXLmocn7yKCdqxydtjuPOAt/euyceL0a1bd25inIH/2tWrEpCrVy5+cQD58O6fcPfpH3D95jVaigFaqzzBaMb+fxjEyCu9tDAxJPvSiObDMvQVE5IqqkElmyVth5mh+yXVNmxmExYs0kkrlnVAHVThJUUBKh3MKVEDPHysg1lB5VFA4VEi2cXqOxiWSuJi2HSymaMaQmSDm6+pC+pZhQux3FyI1cYiLFBsYEfTIs7ntQym4KJiVBGAcsJRxveoctWg2FoOR5MLvm6xXMUr52fERKAipKb9K5dDzsGOOOLdSeadCAK5OCvjMOq392B9xIyl9OtLeGyLma0W2MqxREDuU6CmyYbWQ73Y991DGNg/KIebowNxaOpNqA4IJdXBmKJ1ZAZp3puVCzLjnSE07E2h5VAjEl0pZMVgBJVrnrGUUJSy41fQalWxUUGYRYSSCBX5hlEAopSwvGCpo4pU4VvCnvHvs80M/xYeH1VyS9AkJ/v0WT/sLSFs8+vwkkeD5bRTX3do8WUC8VVmjhdidnydgPw9w/c3gg5MYyCfzmA+P+XDEj5/dS6MAp6HbZkQCsI2whGENu9A854WWslm7PrODnQfYD9oS+LtI2/j+thFXL7ykRy+nbwrVEAsc78pO74EhFbr8WMBBsEhJCKj3GRWuX7jEsG6xuwyKUeyJu9ek8tRxJITsbjx6pXLuH7tKsZory6cP/vFAeTM/T+wKjzBxWuXEKXXNjMghwbC6NjThN2v9qFfzGJ3xWCpdyJLCxFsCcBM1dCxQxgzJgQ6fNAnjHJmOcoQ30nFSfDx1QyMG5VbUWGthLfBCUe9hbc2GCMG1NA71/fEkGbAbKKCRBk667uCSHSE4EiZYSJIYlXpRgb9NfpizC1diWU165hTalHfHWZozsMWZ8V0V9Nv10IV0tJuaKHic/R8vjFnhSKghlsMJ7+SQ2x7hPaN+cRaxZDtQSgfQX1HCr0jXWjfPYiKhgBWBLRYwNdb6KrCAkcF5tlLMc9aggVUqKWOShTG1AjvSGPv919FD6FqEuub8iE5USpgaX01h47XmtHznVY078vQivoRGQ0gdziFeuaG9v2tzChx6Lus2BhRUQkUzBhT4f0FWqznBSBCRcSSd7mqt5ZWS4T3KYURaiMC/1yzkselIiRqLLHVYTWBKAiLnKHFKreGmVGLv3fo8WWqxdcCVjwfd+PLXjP+xmPG3wVor/jzdCrFvIwfy5rCWJEJYl0yACPVz9Dmg42ZztkXQGg4RvuYQ9/hfgT5fSoJ5Fvv/JJwnMMlAnJj/LJc4i5m0gUAYuRJhHOx9koM8z6i7RLBXCxQFNAI+ySyi4BBjHiJjCLmSaRiXL6ISxfPs32EixfO4vSpo395QMRFUx9M/gFX73+Mx/SJ569dhKu/HsURdrakBc4WD7a/1oeD/zCK9pEcvKxUwWYGVFbfpt56duogTKygSSpMbm8O6eE0hg/1Yc/hYQSa/Sin7y81MkgSlHCrH4G8G8FW5gfmEA2DfWYog8xwHEl2eG/Wzse4qUBWmGK0VyEqFBVBrHlaWbsZ67UFKHeWQRWgv47rEWBOqBXXQ9DrG+NG1Po1hNQMd7sfasK1iRloVfl6mFI2VvEM4tujUslKTcw4Pi2PJYjmwRyDdwcBb8SaMEOpl52WcMxzlmOOowxzbMWs2EWYYyagpiIs4m1BWInBHxzGP/38R+ja24P4oBiGzSC3qxkt+1vQ8Worul7Lo34kCv+AD8HBANL7WACY2VoZ9vu/34aW72YQGQmjMuXge4i1WGJlby2eNyokIN96Bsg32b4lfictmMgsVZhJQOYQmnlUlgVWNRZaqXhUkxUONZY76rDKpcEypwZ/z7D9N3Yjvhq04e8YyL/ss+DLHiu+QhX5VsSJmSmGdQb2WVEXlsS9zHsxZHbm0bivCY6+IFIEPHswC08PVbYvDi/V0Jh24c3f/VwqglhbNT7Jjn3jPAO5uHDq6jM4bhCEsakZ8odTo1bSetFC3bo1JkenxPISsepXTDZO3prA6ZNHcfL4EZwhFKdOfMjbYzh+7IMvACCE4zfnbuDM+Y9kkLoydhmuzjgKebLN9NBilWfX/jbZsqNZpHpT2GyugoLe3dvogTcnfLce4c4wIoQkwvA+8nI/BumL1fTxW9SF2FizEbXs6J2jzciyM/kISSDvkdeFZAcb0L2/E4Ov9GPg5T7mkWb4m72EywdrSlzdpsBaVQFmbV6CddotKHKUEpoqWip2cn8dM04ljGEDj8UtgUwwPHtprdR+LUoJZ6G2hJlEQUUxMi/EoI1ZUc6qbWTIFVdEdu3uRW5HNzTNMSyjesxnuJ3N15xjJxxUj9mWInbIbZhl3IbZ+q2YrduCxeZStHznIL7761+i9+Agon0ROXLVQL/etD+H1pfzCDIfqYJK2h6x2jmMOGGJDUfR/kozGvbE0fF6IzK76lGVcsrl7DPY2aeZVXhRhHJhq0zMH8wg3+R9kUGEgjynr5SZZYaRNuuZisyn1VrE5y8lZMupJisIyGoCspyAfJVB/2+dOvy1W4//zoD+FQEI84YA5GtBO74ZtmN6xIVphGYtbVewP4ueg920h80EJID8wRb0v0Zb1ZeARlyeEDKg2mfEW++9JTODXIN15zouXDqDGzeZR25dkbPfYrnI1EVTU0oxtdTkpgTjxg1askkR4G9TNa7RRp3DuY9O4iRhOH3i9zjB21O8FXAcY9b5iwPy3vhT/OqD30tiBc0XKJ1dBzvgYAh20Tb1HepG5/YWjB7qQWYgheaRFhQ5ldhoKkc1VaaYvl5Ju2TO2QlNLfSs7PFudpjeJMoslVhfU4D1ik3MG3XID2WRpeoExRWIrQIQ5ojhJgwc6MbI4QHs+vZObD88KifoGvqSSHWxwrKKLy5biUXFK7FZUyRX6xYYS1DIbFDJar+ZnVZBBXHQvuV25eiXc7Ax52h9OpSZa7C8bIPMHt5OP1xUPlPCLi/eCrRG0ba3i8Ugjc1xBlRmnQXMHXOZZeYw+M+0lWKWtZiBeBs75FbMMBRiJt9rhqYA843F6PneG/jBu79G78tDEg5nq4u3aTSy4jYfoJ1jDlHT8tkzLgbbNrTta6W6ZtC4MwND0kC74mF2MWKZjXmCmWKWVQBSJ8F4Xl5lKEaweEsIXqBaiAwi1GMaQZnBNouQCEDmEJ6FFhWWUUGEevwHIGzftGvwNwTvv7L9NcP6f2f7G6cRX3aY8bcE5atuE5732AmfCVtou/RZD8L9SbQwd6T2ZNF1qJPq3gBrzoOttiqsrNmKAkL6i9/9jDmDnf+xmOCbYJZgtiAg47euE5pJOdwrRrXEKJaYJxErdi9eOouJW9dkTrl//76cib/Aonz0w/dwjO3U8d/jww/exnFCcYL3T1BNjh39CyvIu7f/hA/HHjBo3cLDhw/kBM/ZC6fQ/Uo7A1kOieEkg6ifVkuHPobO7v3N6N7TJkdJNjFTFLkV2GivQBltTrkIyOJa7Dg7RbsL1kY7CjXFKGEgVniqWbGNyPSk2enjDONW2GnLNAEVYh20HVSNjj2t6KGSdO/ukPMj9fS7uYE0dLRZ65QbsFG1GYagQS4Q3GapYCDWwlVvR5GlHJ5WH9wM4437s/T7CQSoTGLoc3HhaiwpXsP8U0PrFiPAWlTYa9HMfNS1bxDGtnqsDZuxjMF2qU8j1WMe1WY2s8cMSzFmmAmEecszQLZiOgGZRkBm6wvR88+v4Z9+/TNkdzYj1BtALT9LOUO9u92HDp6/tteYNUZTSAhr0u2FstGI0qgGupxDXqYsVKWKNnCxVSED9yx28llWrYREACLU43k2AcyLBORFQiHU40UxksUwP5NZZQ7VRqztElZrKdVDKIi0WE71lMXi3/5vnQL/ja/93wjLX9l1+Curfiqo+2z4qpV5RGvAc1oTtnltsOUC8nqTHK10bkcrGmgHNTEzSnnOVhOO5RWb8JKqGP/+1v+Qo1EyjNM+iQuhxIJFsfjwyceP8fHHH09dkz4+jps3rzOYM3jTmYyJBY20X+P8vVCSC+fP4NTJD3H29HF8dOY4jh55hz8fZfY4hpNUkZO0Wn8RQMSch8geR27/Eaev3eSHmprEESHq1PnjyAwSBvrpzr0taBpJIzMaRmjEA3ufHRZW/hJW7DW6EhTZlahg0DZEzShjp1Kyg62rKkAJQamjkiiZCfwNbuRpozKDCcSpCGpfHYq0hSgxFtHqlPK5GrgJk7gSsYHZJ9oaolXywtPgQKonziBND8+sYUs4CBThizkZ/EU2UcrHFhiK4enkY3pDcil4w/aMvCZCRYjLaLG2Um28LUH6/yRVxsvXbEDPvn4Y2+uxOiRGrLRYIpoEhMHXWYOZ1lJ2SgJh2oLpBgJCMF6ktZqm24y5PO7V9hrkDvah6+UBWssIP4MexeZy5q1yBNrC6D/Yj97Xumg34ygTK5n5mVeymKx01WKtpxbbQhp5vfsGv4oZgkASgJnmKUDEOiyxcFEsWBTXiEyX167XTs2+i1GsZ8tUpuuEiigY2JUSkCUCDkKxnNZ4tUtLQHT4ik6J/6JV4L8Suv+iV1JJNPiK04CvO2m16vT461odvqTQ4utV1Shj8Yl1J+BqIuxeA1VZgwBtcx0LyGZNGV6qKcTy8o3YqC7GT976d1wbuygtlWhCQcTk3i1mCTkh+OlnuHTpglSImzdFNrkxteqXt7fvTvBv53CCqnH0w3dxhnCIUC6yx3EqhoBCAHLuo1O4fOmjvwwgQjneHf8EF+8/xeNPxOzmU3zy6SN54fxVfqBIVxqWjBPqjBm6vJUV0ouSUBXUDXqs9zN0s1oqPVqoeCItcSfCuSB07AjRfAg6vx6lVJfaQB0cYkFi1of2wSaE2wIIs7rG2aEcKQsq7eUoMmyTFqrUVCwX+gWYZ1zMPVZaD1+TUwISpg0LERjxHrHmqFzwuEaxEWuVBbDRvlRSveJiqcmBJhjqLYTJD33EjFqPBtqQhXYqhEibuNakHq1UqC7mIy8LwCoBh0/PpsVi5qmFbjXmEo7Z9kqqRwkr9lZ2yALZBBxCPVYym1hZZbsPDbPK5glvgsfglsPeFYTGFLdQZbv4swPlXuajqBHr+LpLmBEW2QiDRUFLpcRLtKhbAiJI12KuhUrACi+uNJxt005BYlZjOvODuJjqz9euy9W/OqEgU7PwM9hmG6fgmsvnL3bw9WRI1zCkTwHyZZUS/7m6Gv9nTQ3+L50KX6J6fMXGLELF+FK1lvnGTHtmQhG/x0B/Qg7p2uudzG0VqOJxV7hV2KgtxXplIRZtW4U5m5bKnWneeudXVIRruHbjEjv+FSrJTYbxe4ThhrzI6eb4DZw69XucZbYYHxeB/ZYM6kJ1zp07TSv1O7z/zlvSTl04f5qQHMPR379LOD7A2TNHcfHiGVy+fP4vNw/yzs2P8ZtjZ3Dl+jVprcRWK59+9piQPJTXpDvzcRSzAq9ylGCdsxQVkTpUiapHMDZRKSzsvOIqQX9LBC0DLegZzksQfM1BWb3F6t74jjiyuxqR6IzCGbNByYpviRkRafEgSVBCYuLMXo0KWxmKzEUw829BsegvYaLy1KIuUENQ9LRaUapZG5r7sgizs4vrpA18rJvQiCX46qiJ4bdeqoeCna7CocQ2WpEqdpRwvp45h1WxwQMXO7a9qx4laQ9WBMVolQ4LCflCgrSIKjifxzebPnsGlWA6Q/iLhPd5KsYL+s3skIXsiMXQU8k69uflKoO2va1UiyCK9BWo4HN1cSPKqQa5oRy26kuxzlCONbKiaxmgNVhiU2Mxg7RYwLicuWMVj3OhsFfmKRUQF1DNZoUXbYZZXEBF5dBPLW6cwZwhcsc0kUEIyvRngAgFmRrNIoDMMEsJyAqnGOYl+A4qhKIG/7m8Ev+5rBLfIBhfc9nwV1SOLykM+BuVESv9bqgIc4LntokWV2Q4R1oodC0V28rzyO+/ajNWla3Fkq3LsICtluC8/cFbcnHi+PhNefWg6Pxixa6A4SLV4QI7+MlTH8hh4IlbYk5kUl4nMnHnGk7QQh2hlTry/m9prY5KCM6dPUkwjlM5PsRFWnyhMJcvX6CCXPj8ARErdo+PP8LFq5flhxQjDA8ePJDLAT5+Kn5/Du5cXC7Wq00ZUJRQ0itroGTHLY0rURCuRHGkFgZC4GIHidLHD2zvQFt/Ezu0gxZKy8yhgr3VidiOBCHJwsNKL/Zjcsdt8Ge8SOTDMFLSSw1lUNNm6Bj2axwKGNnBFe4qKpOCoBiYWeIYPTSA/a/vRAchbOrJINIcQrYvLffeSo9koY6Y4O+IIDmYhjZqkZe+VjhUKOWtn7atfiiNRH8KOirLWqrGYqrGIo8YrVJjgVvDYK4mJGrMZ1WfQUs2zVTGJma5t+J57RYG4y0SkHm0Vjp+5sa9aTQdyCC/j4qVNNNWKVDLMK6n2m4jFLqIEVu0RVhrqGRw1jAb0L5ZmQlsosKLnwmKVSmzxwILqz87+CzZ2XlLMESbLuCQ14kIMBSyTZdgEBKdsFlVEhLxHBHURVtoE4BosMLFwuY2SEC+RPX4P4or8JVaFZb6bZgb8eJvbTb8PyYbptltWO01I9gZR8t2hvLhNHz5AGpcKtjiZp77GDZUb8SiTcuxsmQNlhetwqKtK7BVV4Y3f/vTZ8O1U7PmYihXbO1z4eJZqRqi+p+iZbp2/ZK0WGLy8O49sTfWfakg77/3W/zqzX+ngrxHQAQI56WSfHT2hLRVlwnItauXZPt8AZkkHLc/xZ0nn5D6B3LtzJ836xIXtoiAdZEHnGhnZhjIIjaUhKuftqfDwxNJa9TmkoGzIq1FsCeIvt2t6KTVaB2aumYino/BxwptChnlzhjOVjdy27Oo703CzM4bzYXRMtgGZ8KNFaXrsKxkFQp1hVDRl1fbKghJBawEUYAhlraPHBzA9kNDaO5vpM0KMJe4pELFuhLoPtBN/0+QxbJzQpDbnZXLX1T0zkrCZyGUsRFxkVEDvH1JbOT7L6ZqLBaqQTDmuwiIi4AQlPmuOsy1ixwgRonK8KKY5eZxCUhe4O1SRzUKCZA5ZUXzcBM69uWZeQLMHla40j55NaHIICpakloWhxIxekdLtcKhIxTa/2hLJTAaOSy7kJAsYDifLzo4lUCAMtv0DBCCMV2vwMxnbUoxpnLHdAGHBIRBXSrIVAb5MyDLaK+WCwVh1vhKZQW+VF6Bb9VUYi2V66WgDXMIydJIEMpcCOaOgLy2PTuQobUVG9ApUG2uRpO4EIwFZWXRaizYsAgry1ZhXc06bFRsYgE04Lfv/VoucRedXqrHo3tynyuhGufY0c+fO4MTx47IzeGE3RJzJpOTN+VzPjpzEu++/Rbe/s2bMncIQERYP8/McZG3ApYrly9i/OYYxsZufD6AyB0UJz7DBzfu48rkHZL8mHBMQSFGHMRS5Kn7j3Ce9Hvp9b0tATSMNLBSZulNG+T+VI3DGXTtzEHbYEJ6KIGRQ+0YYEdu7s1iZO8AGlnZU+1RZHtS9LJ2OHnSs0ONtGK0IuYKbFGXQunQY13FZswrWIalpauwjJWpzFCKKlotZ9oiL8wS1SvWGkCsLYRwCzNFWE3LpZKh38mgnRltQHwggfZ9beh9uRudB6aGIxP00d68H26+X7AzhnYeXysh1hKuJcwZC1xCKf6Xxp/nOWmvqDjz7GIDhQoqRgleEJAYhM0Sk4MVqIzb4cn6kcxHMLC3R9o+d9pNOKiGnfU8bi9qqAgqvoZCbCDnVWOb38IsYMAqp562R081YdYRE3q2PzehJCqqC+/TIom20Epw2dlnEZCZz2zUTAGCuE8oBCQzRAZ5piJiJGuuScyFCIslZtX5WrR1i2mzlrn0WKAqxUsmBdZoy7HVOhXES9M8n020pF20iTs60TbCc9SfhS1mRTGtYR3PRa4zjQpax9Vla7Bww3xsrl2PamsJtH4l3A1uHDnO7HDhDFVknO7jrrRJJ08cwamT4vdnZdD+8PdvSwW5fuMKb8/hxthlqR6//c1P8ObP/hW/fvOnUkE+Onscv//gtzh29B3Cc4Lh/DRt1jlpsz46+3ktVqRyHL1+B5du3JCZQ1zmKFdWEhQBhxiTFgvLxGzn6XMnEWKobRpMYfSVTtSPRuDqZUffUY+OPXn4GcS1TVa07M6g/+U29B/owtDebvRubycILgRzzBE82ZWOGnkddGpnhtnEK+1HgaoIK0pewvyC5Zi3ZSUWMvitqliHWnp4Pa1WjpW+sSdBq2aGNqhmZa6FntnHnDDKSUEjX9ffEpLb/tibXGhgxknz9fMHWlFPsMJ9USSG6tG0oxnZ7U2EOAtHgx9bfOKaCg1hIBAOqgXbHLb57EzyZwbnOezgLxKM57QM6HoR0kvYMUuxyWOBLhOCvymGlpFm5A+3yPOQ7k0j3kcgW31y6x2xK2EVg/o2XQn0BKoi6pJwrGQlX/kfgKhlHhFBeoVoVJOV/P1K2i7RlouMIlSFajJHwCGGc8VolYBB3BeACJsls4gARIF5JqFEKjmTvoQZZJFoVBEBYCGBrWABqKRiVtPiCpupJOj6eq/cjrX39V507WVxaU/B4DfBSIV1RczQia1+nCpUWoqxqW4DdK4aVJm3ocpaCg9D/O/efpN54feyw4vZ77d/83O889s32dHfZpY4id8zY3xw5Ne4clXslXWeWeQk2ykc/fBt/Oyn/4yf/eRf2H6Ao8fexolT7+Po0bdx/MR7OEJQjhKsk8c/wIdHGOTf/tXnAMikWKn7J9x8/Nkz1ZgK5E+ePCQcH8thOQGIuGxyYuI6FeQ02ll1W3Y2o5NWovcAvT9tSqAjJL1qsj0DLa2Gp8cnoREXVYldFJu3NyJFz6/0qWFKWGBJO+BpCyDE3+nFJglesccSwz6zwfqaLZhHbztn3RJKd4HMH1aG3NbBBtiFr3eUMUdUoM5XyyrtkHvLinkND/NHh5jRZ65Jj2TQyvDeeqAFA6/1IdPPfELVaOIxilGr7HAzVYWVkVV/bcAo4ZjPzjPPLiChmrAtdIjNFDRyZexsi5hrKMdzmmJ8U11Ea1Usr+WYq61k51Uh3t2EpqEW5F7Nofs73ci/0YKm17KI9EcQaY8RaAPzUy2UITUUCRvWEgxhsVY49M+aDit5K6BZJe7bGKYJyGoBiW0KlBVSTZgnCMh8MUKlJRSaKgnINHXlf9grqSRCWagg80zP1EPAxeMU174v4edaaapBmYNq5tdBxeynyPlR2uSFoU2MDCbQuqcNPYf70b4/j1hnFK6MG464Ay4eu85Xx/yxAWXMXQo3c6JbgXJzMb+7UljCevz7T3+I99/9NU6ePEIofsc88WP85lc/ZQd/hwpwlgH8d/jo/Ie4cu2cnGG/PvYRTp/5PZ/zG7zz9s/x29/+BO++80tasVMyowiIzp8/gfMXCRIzyLFj7/DvvyB0P//fD4iwV+9TQc4/+Ax374vc8Qh/+OOn+MMfPpP2SjSxh+rNmzflcNyFq2eR7M0g2Z9Ez55muZNIfjSLhu56pPtSyNGvhvNRFPp50pIaBLtCcrl7gJ68Z1czDDkL9FkrrDkXorQ8YvtNbVQHQ0gPDW1OtDkMC6uUuF+sK8fy0rWodimQbI2gf2cH8sw+xpieClTJL6cGjrRNjm55GnwId8XQ9+0eJAbrkWCu6XujH52vdmHg9UF07u9E73523B1idCmO3EgrLG1hrA4aZdYQcMyXm7epJRhiaFQu1WDHElvxzHoGyIv6MmmzZpoqsTVgQ208yPfrwvDhfTwP3fyMtCUsHJ2vtCO3s4kth6bRJjhzzGk9LAj9YdQxF62RgOipFlMqslq2KTjE7Rpxy+NYRVBWEJAVVBfRlvJYFhGQhbRZ8zSVEtC5vJ3NNp2QTOPtDF2lhGYOVWWpVVi1OrnUZKkAhIoo1HJdgMDGrcyBUcIRxEZ2/i0JFwtWHsP7Rvm99qJndz86DrRRcac2Ine3iJUGJmjCdVB6lShQbsRW1QYomA8FNIaIXm5f+sN/+2d8QECEPTpGmySAEHMax1n5P6JFOnvuOMYnL2N8QuyVdVVu5iCWo5wRI1VnPsDJ0+8x0J+SG16LkS9hw65eu4Cxm5fl/llCTY4dp6oc/7yWmkz+AafGH+LBw0dSLYStEtuxfPbZZ3K1pdh5+/7Du/LSxwtXztBXpxHriCLH8BthJxPXcNd3x5gxkgi0BmkrQtgsJr7sJSihNbJkHbQb4roEZoORCFa6i7DJXwlXF337AP3ucAJBZooqWw22sjJvURWi3FQuJw0L9duwTVuMruE8DhzegZdf341Yc5DWSos6j5LKYoGTX6435ZNbZ/a83oW2/S3I9NWjbY+4TiWPDuaQCI8t0hZjSyI22ARPXwY1LV451zGfnnz+s43bBAzz6PXnsWPNZSCew/uzGI5nmsXVexXMH+WYxtsZpmp+Dlq7dAT1A10wtdRjc9iBxEArcju64OvPIbunGy3MYGJzOm9/EA2HMoiPJuBgdtoSsErFWOEwYK3bhHVsAhrRBCCrCcgqYa94HMvFKBc7+TKRS8zMIroaLGATt0uMtVhAO7VALDFRl2N6XbnMI7P481xarEXmqSFe8VyxWFHs4bvCy5DuNWBjzI6ilAcvRRxYTtjXxN2Ib+/B4e+9gVe//QoGdg8h2zuluJ6mANWmDqaoiQVQXPdjhIaFq8JSBGNQA1/KhXiefSHjwo9oj44zhF9iXhWrbsXcxblzop2UP19jZ791R+xiIhY0XsHYxBU55Hvu/EmCwXb5JFXlAiZuXZdb/dyauElYrsr9esXI1QmCJh4noPl8ALn9R5y9/QhPnj7BE9qshw8fPrNbH8u9VD/+5B4ef3Ibt++P4fzV0wh1p2DmiXUy8BrE1pZJKyt/CAmxKVw+CFejh75WjXXWCmzyKqBtdcDd7UbvKy0Ijvixyr0FJuYUYcusVJd6sUaJNk1NuS9mhV5atAYlxjJaqBoUGQtRx9fYe2gEr3/7AAZ3diHAIG4M6plLjDAELTDwC3en3GgUa7l25NAiVs2yerfvymP/68Pof7UPaVo8oSLZ0TZYGJy3pmx4iV+yGLVa8Gzbz/ms1mLj6DkEYq5JLW9nij1yxXCquLTVKP7VQAWmGVilxYpZdj4RdjW5BLYlPLQvemyNuLHWb8MyrwkbWZFtVNtARxLmBpdc7h4fTSJEddNkfFhj12ENIdvotWC9x4S1LiMtFVXEPmWxVvBYxMZwy3i7hOAuNgv1YDMwV+hrsZi3SwjBYmONBGSWpoKWq1JmEQmIXIdVJ4eRV1AZXyIcK9nW87yt9puxgrliZcCMJT4LFvAYFgRt2NgUhGWkBSP/dACv/tNh9O3oZzFMwCAutHIq4Gvxy72xxNWR/iYxPK9GtjOFA4e247XX9qKJgf4XDNrnL5yWIfzCBTFqdQzXr1/AFYb16/ydUA1xpeAkIbl5S6zTYkC/QPt0+Qw7/RmqyQnePyuXzIvXGBsTy1GuyN3hz9F2nTp1bEpdCM/nAMifaLE+w6U7DOSfCEv1RM573BP7ET28h4dP7sjNhx88Hpdr+k9dOo7IaAMqgiYp0doGJ/ysiCGqRrgrLK+t0PBkljHEFVM9NoQUSOxogK7ZJreasbaKndZLeJL9yA83IsrniD2pxCy3ilApmUO2qgtRaa9GkK/lpfpkOmJ4/R8O4NDre9CzoxPRXAh2qobaa0QVrY9YS+VmwGzd3w5fRwQJhuO+w13ofK0TPfxdx15mIAbzoVd2IbW9D+vDdqkci9xauenBYgfvs0MuZJsnZqxNwl4JBVFjppitltt/ilEssVeVAIQVWgRlOYSqkkqy1KnDfLGJgngddvCFfM0FLnb0kAWaPJVLbJRHdQ2KtVdUXVdHEEU+VnGfGRs9ZqwXCkI1WWHVMYxrZVtKIBYbqQACDNmoIDy+hTye+XoFFuoFHFQJwxQg8xnc5wg42OaIESyCs5jKt1Sqh5bvY8Aytw6L2Zb5TISYBYJtnseIOQR0nt8qdzBZQ8uqYbE5+KPv4MC398nti5QBDTQRHVLMdo1iqdHuTnS92oZa5iqFvQYxKszwri4qTga/fPunuEYFEKt5L1w4hdOnj8iRLJEnxDXmt++OyXaDYIiOL0awRB4RF1hdZgG+wiZmy0XIFxOCYgb+5vh1+biPPjrFPCKWqAh1+VyGef+EDyc/xY27U6oxFcinNuwSO9eJ64LFfkR37lIOSfu7R9+WGwJUxU0oZSerCBnk3kuuVq/c2HiLtxYbaJW20GKVRbRQNlrRc7ALYdqb3PYm+S8RKuM6+NrDcstSY8aCurgWG+oKYQtZEUkHYKSS1HnroKLFEntkCdXoEv93pCeNbHcag7t6sP3gCJxUMQFVia0aieEUM0cfsrtzyImVpq93opWANPI9Ow4RFnFdRn87KpIhVnu/7LwiiC+ilVnMjikAWSDVQyW3/pxrYS5hZ51tfmaxxKJAdroXdBUEpeo/5hjms801iQWBGmnJ/gzIArZ5DjHhSKtElbN2JlFPdYv2pmFkJ3Q0+6Csd6OAgGzwCDiYRageyywCDA0tEcGlii0y8jXF6xOKBXz9haIRmnmEYz5D+gJCscgo7lcRFgJLRZn7DI45bGLEawk/10LmmLlUyXksCPPEEK9bjyVUufmEZqZ7qs0SP4etWETrtY6hPXCgF9/98T8yj/TQFXhltmt9uR15sQZP7OI4EGN2rEMpw3qtt4Z21wQn3cPPf/cT2qZLePBoQs6ai4lBMeQr4BBXCIrrQcZE+KZdEv9gR3R8oRZiRa8A5PqN81QbcWGUmBAUE9YTclb+xtg1qSZiIaOYQ7l69XNYavL+5B9xZOwhro1PSEslABGLysTWkPcfiZWYU9cJ3xi/gGs3zuE37/8SjmwI5bQm5X49yiNGlLHDV9TroSAwK2mrqqNWKJMWlIbUckZ9z+Eh7Hp9BIOvdKNxVwMcHT448l5sI0zrLRUwETIxlFufi2PvwR2EoQ1G8Q9mQhq0DTSxZZGmirjr7XKm3ZMKoKGvCYGWkJy5rQ5oEepJoPVQB8HoQesBMZLViPRIGm2sdFm+RvfeIVQnAtgYdMCQb6TFsE6NUonhVXbMhVZ2ZtHJCYPo7KLNZmeUzST2yq1j/hDXhldKJZkpOqBYxiFWzNLqzDYQLFHZCddCmwBEj7kCEAbiJfT7hUkn6tqisLTXQ8e8ZM+zODTHCYgF62itBCDLLLopQPjeS/g6wk4t5OvOJxDiPeYKANjmioBOizWHgMwhGAKSeQzr8zRVUkXmCUDEal7j1DCvmD+ZR+Bmir1/xTERkoXPIJnFNp33pxOQGYRlvlhNELVhSdyOlzJubP/HfehlphIjdNnteTQwsKe3pxDuCaC7J4lkEz8Lc6A5YpGXSBexWP3rL/6VHf2CnEUXtujG9SvP/v/HhJxdn+rwYrPqMUzeviVX856n0ly8TPW4dlparUuXz0mABCBjBELejokJxan/TiVAuXTpcwDkPQLym7OXcJZyJlbsChV5yFD+8PEdeXGL2FVbrKg8f+EYATmP3594D8aEF8WU7jL6Wn3WDl2edidrwUtiGbhiE5abKrCB+UEsdRf/gGX41Q7seqUfI6/1sLpnYG9z0mI4UeCtwHJdEU+quMCqFvneHL77g29j3+u7YI6ZURtUo4OBum+0XU7CpenlPRmx8NEKb0uYFSwrr93I0g+LDd4i/XF0vNqO9r15eflvsCuIoV296B3tRu+eUViaG1AU8WBb1I/1Qae0VqLaL7ILFWHndBmoAOzcVmGXtP+hJKIJUKYTCnExkoBDrHMS8wwzdWxaMSchLBc7s0mARjWyCUDE3IqGMJpQELVjiUcvFWuZmBykpVrlNuMlFwM622phryx6CcZCvYqdnrCJrGEQ6lE3BSGhmMX3m6GuwgzCIIZ4ZzCUCzjkSBZhEdAIdZknFM4oAOYxCWWk/ZspBh7sYsROKxV0tkuL6TyemfzcMwjINIIzg7+bHzRjIdV8Lq1XfFcnehnW+/dvR6ovi1h7bGr3/JwXjc0RDO5og6fBzbCukHucGbI2vPXer2iJxuSu7CJci5W7omOLXdnFtqNiweKtSXHF4G15kZQowJeu0lKxj527eAwfnT8m1URkFnGZ7XU+XsBx8+YYobki1UNcgiv+xcL/dkDev/Upzl6/SSrH8fFTMZJ1n6F8Kpg/eDwpd90+f/4kzpw9QkBO48jxt2FM+lET0svtcywM2Y3bMzCI/8HhrsNSfRFWm0uxwlaKJbrNUNRrMHC4E699fy/+4QcH0HUoj6GD7Qgxg1TFtKhNmbHFWIKXqtZhs2oLq5FdLjnR+w3YrC+d+tcBdgU2GUphSbrQupOwvbEf//bWr/C9n/4b0r3tULLqxRiAEwNJOJrEVYMptO5tRxetXf+rveja3omD3zkMe1cjlrMDLBYTZewgi8X/AXToqSACEmGNhM0SOUTc6uStCO0SEFbzGWL5uFlsLK2UcMyWdoYdV8fKbhKZRSiQRr7GKobexXyPhXyvpazQIqcIOBY5xDIPI5aLESsqx3pCIgBZ6zAREMLD11hsFDaqjmpAOAjeXCqIUKiZBnEBlJKQ1GJa3RQgs3UM4zqRP6bmRWZpqCo6kUXE8pSpSUJx2a0YoZsjbJYYzhabZEs4NJjJczCLgEwnHC/YVZjmqJO/WyT2wvLbEN/dg8PfPYzh/aPo2tuFXvFv9w42o21XE3p2taNllEpOa+2jzc6yH8T6o3jju2/g9ddfx89+9jO5E/uvf/0Wc8hp/PCHP2QmucDf/xRvvvkLWnYxinVdjmCdv8BwflHkD5FFzsrMMUZLdeXSeblJg5hmEO3aNWGtxHCv2NL0//d/wfYnvCv+5+CkCOZ/kj9/8P8y997dUV/p1uC3mDVzux3JBoxNFiAhcg7KOZRKlXNJKqlKFZVzzhIgMjbOobsdutt2O0ecwESRJBCIZGxsd9/pPfs5Je59J615+16vWf7jrF+pkqSqs8/e+5wnXL6JS+PjKu7qp5/uqrKOP/1DuvdIrvA4//hTOPHdJ/ju1CfqxPOLbz+ifnYixS/+IxtpHg0MnOwa0rGkXCaVZGOTK4NfeAJXwg3IDGjoQSoxeKSN1zpYWlwobilBGUf9nhoUBEyIT1+vCsitydyIRJr77YWJNN7JWJ+9GUsSVmFx4mrE0aOkEzROypRnXn8ZX5w4gT9//BF6jxyE3mOGKWxFFb885Tf2tuEP7/8Zg8/sIWNVoL6rlitdO9xtYSy1yyEgV2cDpYeBxlciaQUglCCy0soWr7CHAESBZZJJRGaJWVedn6QvB2XOHCWpOJHzCY58SjGZ0NocxJi0yK7wECQFUY9jiAJR4p+WyC6VAIIgWUGWWWEgUAyUWLwu58+LtVEPslhASpDMyxdZxd+fLztr2ZhFBpmRlYyZMggGYZI5BMSsbDlRT+HfIPFZEupO9tAKe2RN7s4RIAaJEpDwmRzMJovMIpvIdTYBMYugEYBM53NmEjyxJRYYGiLY/9ozePY1+pC+Dgw9M4S2o/SDh+sR7vGjRs5HunyoJoN37G9Dy1PN8HSV4sizRzA4OIhPP/0Ux48fJ0DeUwD54x//hC+/OobX33gdL7/8ogLHtRuXo36DLHP+wukoQOhZhDEuUabJtrCwRlReXVfXixfPq9uSefirAUQOBKNda6PAkPHFtZ8xck2AcIeSSsYt/PjLTdz7+wTHDdVf7vLoBbLHMZw+c0wZqG9Pf46aPdUIDJTD1GxFWiWlUEia3pBJQi4UcQUvCJmwypSEWP1W5E7GZVUMhRDZFYSu2oqUYml+mU3DbkeKKw+xyesQl7QW8SnrsT5nGxIMSUi3SsRtkmp4uaUgURW61hRJsQYD2oe78dxrr2Dg8F44KrzQUb6kmrJUo56GQ43ofKoXr73/Joae2qV2YBo76iizmlXNpkT+bYttnMjGtChI9JKLIT5EQJL7n7tQevEleQokAhZhBwUQCS2/v7OlEdnDVZoTd4GWr6W8mk+ZtESvwVqHkcyRT59zHyAcOvEXWWTXKDCWC9Pwd8pYRvaINZJZeF08ac6FQR7Pm2SPPGGtdEwjMKYTDNMp62ZKUWsCZCaZY0aOxGFJbFY0eFEYbq6AV7yVfvJcRwBBWfyYgEBPQBMs8SVm5BIIuQ0VWOo2UmZlK2aZRz+yo9wFX1cLBg/tQ/eeAew5SgWwuwEVBESgRUJ2QujZz8eP9KDnSCd6n+lGNRfDj7/8gIxwRq34kh0oPT1knD17ZpIZJOz9bLSow/WLk3LqLK/H+bpv1Am6gOQCASOguc8YUsRhbGxUHR4KQOTnXwUgn92MZgd+NfF3fDPxCz4b/xlfUFqdvnILE7eiOcK3bktJyGu494uAY0IVC74iNY0mxklxsoctiffncOLsVxh+aQAVe4KwtNuRHNIgoSwfBr8JHo8FzpAdPn54xhonCqr00NXokBLMh77BAt8gJVC1AztowGP0O7HZnoUcTyGWJazBoo2xWLx5JeZvXoEUa6YqG+SX8qFBqzpZd5VbURR2I4lAkLyKokgJfNU+6Dx6GEtNyKK+lwNJOVMJkzUad7eojrPV3XUIN4cVi3QPdxHYVUivsWC5O4tMkkYgcILrxVhnKx+ygF5gvkG2fXMnAUKg6POV3Ipu+UYBIrdnc+IKa4jvEIAs1BIcOskjL4jWrDXJ9i9/livfU1hBwtqj4KDs4u+Qc49lnMTL9PJzvmIPtXMljEFQzOX7z+ZQzJGTimkCitzJwdtTCZBpHAIQifCdyfvltjCcbFPLtrUMkYpz+H/O0GViemE6r/wfyBhb+bkefeMFHHz1ZaRXh+hL8hWbLCD75dKz1e8awPDTh1Dfws+zvp5e0IvqAS6QPeWo5UJZO1iFI68cwe5ndqOWJt7X7sOXJ48przExIU06J9SOqOxCXR6TxpzX8eO9O/Qe0Wrtstt1/MQXOHXqG46v1ZAT9YsXZM5x0KhfuChh8WNqA0nC5sWky/VXk1hf3vgHRm78iCs372L81ve4NME/+M49/HDvR9wiKFQy/a2oYbojlbTvXqP3GFUnlaITx8Yu4MrV8/QnEzh9/jvsVQDxQ9dmQkqIssqfDwtNm6HcoCoH2iValibZ2mzDjkAmltl2YnVxKjKrCxGiZtURJDH6bYgr3Ib1uduxbPsqxG5fjeU7VmPBxmXYoUtCpLkcLZ0VcAes8IZdaGjwI0BQpBAg0i46k+AKSuBhfxDlpHl/Z0CVFCrvLoenowzeTmnHVoNQWwTF9aWqp6CH8qx+sJYSrBZ5tTasLdFguZUruoUMoqJcJ7d8DfdBkqdM+3zdJEAKpOPTffbgxBXzrLZh+VoCZAmfF2MoVGOZSUefQV/BsYxDwLFYnXGQLZScip55rDBEGUTk1VKdgCxbbeOKvFKyjWM2gTKL4JieTUBw8k8VBuGYpoYAJJGgiIJEGGW6gCVXEq3IQATHXHooyUScxet0ehIByEwBiC4N8S4d+o4egra+GiuKbYj32JBWE8KKIjPyK/0YpnfrH96L2uZm+CvKlT+sG6pGw74aBHv9vF2DV95+DYdffRGWkBU6epEPvvhIMYas9iKPxFzLbUmW+p4AuXR5hBP/Ahflq7g0ehpff/Mpvvn2c5w5/Q0uXRTmoO8YjZpxaR99/z3kfC6arz6qzkK++eZXqIsl+eVnbv2MOz/e4x93V8VV/XjvHn75+8/45d/vqpZXshUnf4wEJMrj0kRRWvbKfvSFC6f4j33Hn8+ptMmzFwmQZ/sol/hh9btR2GyiB7Eh3OFHupdAiVA2lWqQFdFjXVkqlpg3Y40tGZud2cggm9Ttb4K9oRjL8zZjReo6BYqYLbEESDxvEygJq7FTmwCr1wQL2UXPEagqQW2NF+UBN3KtZKz8BFXgzVBpQkGwEH7Kvc6j7Wg4WA9PdxnKBwIIDYRQNVipOuzKKXBuSS5MfiPMAbuKtPXTj1gbi1Sb57UEiFQalDBwYQ4BhrCGXBWT8Co7U8qcaySLj0CRbV1KoScoiRYQGIv5fGGQpWSPZUYdVpj0iCGLLOFrYwiIKED4/nyNbOWKzIqyBl/Dn5eK/CJAFtGDzJf3pe+YO+lrBCAzxZgLY2QlcSQrqRWVW0lqzBCgZCXyMQ4CRkCidtk00Qagkss+kwCZUUh5RRaZLWE1EiFsyUfn4UNwtbUgwV9K2UzWPbAXq0odGHrhCA49dxRNrW2orKtDRUMl6tprUdNZje4jffA0lKHjQA/2vniEXpByt85NxWDGwecP4+OPP1bjlVdexfvvf4CPPvoIb731V5r0s/jwww/w4osvqNg+kVEnvvtKhY6MjZ3H2OjopAGX8JLLqjKjisfi/bJrJTJNehW+++67+OyzT/77APnixr/jwvVbavtWonPF2KgMQdmxuidde8ZVqRVpuniFNCZlIG/ekioUBM0VObA5TR8iPa4lROAyvjzxOVoONqPxQDVaD9ag41C9Wk1a9tSjqq9C1a2S7kq+jiA2+HKxnSPLq0VGkYa6tUxF23bs7YA+YMOSnWsQn7AOa5PWIZZGfJNmG/RlhdDS7BeW6FRilTvkRKShHFaPDtmWDGicGmzL3KoSd0qbSlRTTG1Aj8gAv7z99QjSPNYOVaF6sBqVgxGCpAo1uyvJNl446xxwV7tR0x0hu1TCGrGgQAo8k5U22DmxCT45E1lgEOaYBImckQiT6KIMMlMjBRIkYUlO28k8YqxFGtF3LOWIMRZiuYkMwusiPrZQ/E2hhJdz8usle1BOyQU0Epio+Y/DwSWTAFEMQkYScAgwZufKEImVHmWQzCRMyUjEoxkJvCbg0czomE5gTON1qgy5rQo4pGCatFAooKwiSGbx90jLhFkEyBxDtHXCKrcejvow+vYO4Mi+YTz34ovoPXoUeVWV/C5b0bunB7UN/FwjFejs70FzZwsaOloxRBBVdVRj4OgQqnbVoqq3RhV1kNpih549hM8//5wT+DO88MILeP3113n7c7z55p8JlA/x17/+FYcOHVRsIExw6vR3aktXAHH+/Hlcv37fjF9QC/fY2JgCh1xlF0u2jkVyySHjfxsgcs7x9dhtXJ24ibs/RE/Lb9y4gV9+uad2rO79fAs//HRbFaWWA0Ip7SPxLyKvpFTkxMQVlTd8584tVSLyOGnQ2xWm/qxE79Nt6HuqGYNcvXc91QNHswO6egtyyR7bizKxqSQDeREjstxaaP1WMocbg4fbEOkJYYM+GUuS16hAxNWp65FmToO1TA9vpRsOsofWpUGePRfFFW40tFfwMSOZJREGeg4TPYk9ZOH7uZBiSMM2TRJyirTwtpehcR8Bu7ue4KC8GggjSCMp/QmbCOBwdxCelmJUdofQtrsRLr5e+hUmW7Kxw6HFCurvxWLWZSdLK4eFZA+RW5zcwhSyeyWprvfZY6Gs+Lr7ABG2kEGgGLRYYij4D4As5ljC913C95HbAg4JUlzO944R0FAGye7VfDH5GppqAmR2vnSbIiAJjMdypI8IgUnGEGA8mLodD6TswAOpO/Bvqdvw+/QdeCRtJ6Zm7MQ0Pj49M1FJrym5UnExDY/Qm0yTFgmUVzO09FCUVnJGs8JO9u1o5kLj5+fpQL6bPzdVoH33IDw1YRj4PdS11KCppQn7Dx/AwDNDaivdEXHAXkPp21WMMKWtBIXWDzeg53Afanvq8MmxT1SmoOQUyYQWsBz78nPFBFL6R/zIV19/hVNn5JR9RJ1pXL0imYXRxVrAcO6cxGGJgR+hL5GdrChQhEFUC4Xb0TTe/z5Abshp+b/j5PUfcPO2JEPdoYy6rVhEOvr8499/UtVKfrx3SwV/ya7VeRqkS9KGlwZJttQEzSK9JDvsO6K9fk8jeg9xFTnSjLo9IZT2elDW7YG+1ozcWgOyK3TYWpyOLY5UpAULkOjJQypZpL6/GnuP9qkgx2WZm7AhdwcSChJgIDDKq0tQTu9SHLIhWEeZVOOB2auHrdyMkrATzd21yow7vRI1SiZoc6HQr4O+RMvXm2CkV7GE7ajdVcUVsAuth5rQeLAONbsqEZKtyF0h1ZtDclc81UWUWcIoLpUm66D5z/bZVXStAER2neQkXUAhXkQYRLZvBRiz5ERbzjoKZceKYBIWUSChGddFARJj1JIdCgkK2daN+g4ZcltklrDFUjHpBFgMby8SY14QZQ7ZCZuTR3DkkDEIjGlZqWQFAoPM8TCZ4+F0AcgO/D5lO36XvA3/lkKAcDxIwDzC+x9J2YlH+JyHBEiUYw9Rlk3Jl0BLAlsrcisNTxqzsNptQFqgCM27ulHZWYNAU0CFiRgr7PA2BFBMv6d1aTG4dzcO0aMcePkpLjKtZGJ6vVavasbqaSniZz2EXU/vQ9PuJqUOamjgP//6M2XC5dRcFlmJqbo8dk4Vkfvp71JfbYIy/qzKBRFvOzYqQ1obXOU8u84FWfqKXFY7XrI4C6AEIAIUAUl0A2BC9UH8VQCi4q2u/4yx6zdV3zgBx/2ARAlOvEPWmJDm7FelJMuFaPzL9asYVRXvzqigMKmVKqefZ0fOoJngEPnSTfZoocQq7SzjpLer0/Tkslzoak3Y5ElV3VKzacxTPfkoailFI2VQy94mZJbRwKZvxOqMzUg3pqkkHK+U3+EX5OIkr+gIw0d9KzIrx5avonYrmytQQENpLNIREIUEZZmq9eugbBJzmGqQUGyD2oJs2luPisEQGvfXovPpJrQerqH8CqP+AKXXQATe5hL4mothKzPARYby1JYhqcyCpeY8tR0bPf8gaxgmT9Y5HicgxJTPke1X3l5AcCwUgMi2LBlEAYOssYLsEUuDvtKsI0gKlP8Q5lAAmWQT8SOynSumXMJLFhUKOLKi5x25UXBMyyYwCI4pBMfD6QRGWiIeSkvglSN5O36fsAUPJG3l4DVxq2KQB1KizPL71J34HccDZJKHxdTLzpbIwoJ0Fba/ymUg+1ahbU8/ug4ORU/K97WhaVcDymqkpnIt6jqbUEXmPvDUXgy/sB9DT++nbJXQfYKjnf6z2kNPZ0HDQAPZuBN9Rwa4KLVQ6gbw3qd/w7g6+R5VDXREkVy/OYYff7qposOFGU6fOaFC2i+NnVFSfmxsRHlhMeXj9B9S5X10VCTWBXUecplz8eTJE9Ei1upcRBrr/Iot2L4c/xFXrsmWW7SsowxB4W0yg3QivXxpRMXMyN70hbETuHDla5y59AVOXfwU5y5/hfOXTnEV4B95/iR8/TS4lEsR6f60K8wPtxG1/RXIJBDED7gbncirKCBwPLA3u5FQlIU8av2CICckV5+MUk6g7K3Ykr8DBdK/MGCGnn7DXG6Alz6lcbAJxVXFKvPQVmtDoc9IuaWBprgAhWVa5EjsFX9HeCAIf6dffVF2vxO+evEfdajm31JO0FaSNVp2iycqozTg39tPObC/Gi2UeZ0He9C5m8a+rwHepiAy/GQ1s0Zt9SpJpZcQ+MndLGERAYxijShjKHYgMJYRGOIlRC7JNZbssZIAiTeLUS+ISikBCq8SoatAIn5DfMnkEN8hpvyxnAzKKJFSMiiLsug5MpLIDDujzCBXssa0VPqO5K14OIWD10cpuaYSIL9P2KyY5CHefjBNWIRSS85GpMgDr1I+aG5hGjZ7pPdjC9oGOujHmmm6JZyEaqCvEQ29TZRYnWjtbUfPng7sOzKM+i7K0/YqBLoDCPcFVa+RsupiWPmZlVR6EKTkbtrfgaFn96Dn6XZ89vXHqrCCLLqyK6pyOm6MUaJLTd4JFXd18swxXCYwBCBj187iyvg51UlK5t/VaxJndUpVMJFweWGg8+fPkkEkkPGyAthFzlcphv2rAEQKwX1x+RbRHN2lEhaRq+wjC0ik5PyFS6cxcvk4zo59htPj7+PMxN9wavxvODn6Hk5cfB+nLn+Es1c+xbEzH6L2YDVq9kRIqZUqQ65uqAK1ZJTi2mK09lWhqS8MS50Fvm4v7C1OmCqt2GrOwLLC7djiysR2RybWa3bCSCaxh80ob/BQUhWhKGhFeVM5Goca4JL0zxKa9EY3rLUuPs+BYhpsd0sJdEEjzDTYkd4Q2g80o+NAC3Yd6Uf3nk70HuxE+74WdB1qQ/fTrainD4l0yravB8UNRQROCAayU0rQDl2dl6MchdU+JJa7EGvXq3MLCQdZQD+yyKBRYzEn/hKj3JYMQNnKzadfkfgpDcHAwWucUXI5ZPtWTsm5ANCoy+PL1POFXaJMIuBYSMZQQ8JKRFoJM5E5ZmSnKdaYTtYQYEwlc0wlGKakiLdIxhRO/EcJkKmUUtMpo6bTc0xNIzh4+1F6kYfIJlPktpJh2yjJdqqtYDlVlxwRCW1ZR6+VFXKhmp9xoDEEf0MYZbV+VHRHUNNXg4qeCkrhOoJD4q+aEG4NEQxeVLZTqnb7Ud5VhpKGYqQWJCJFk4xCdz5sVXb4eyJUB10YeLoDJ858w8VWAgzlmCC6VStSSVofqGODq+dw7uI3BMdJjI2fxej4aXVb+qNLeoX0VB8ZOYXTJ7/GyRPHVFWT08qvSJGHUWUBhFkuj/6KwYonr9Oc3xRjc0MBQ3ScgETOP8aun8HZqx/jzPi7OHv9bzhLcJy9yds33sXpqx/g5OUP1fXs9ffxydnXUH2gElW7w6oYs/TerqbUCQ6FsP+Zfuw63IFQbzm2BNKQFMhGWasHhiornkxfjyW5W7HWmIwEexZSHdkqMzDc5IXFb0R1ix8eGsUADWPD/jqEB4PQesk6ZCRhoQgneuVABcraOKnD9BwEXXlXAB37mzFAcDQPd8JPNggONaF8VxOCe5pRe6ANYcq1Eso7X28EJW0B6CIurHZywpuzECONZOw0zGSnpTau8latOtxbZKLpJgCWCgjMlEyWQsRZdAoUsZNDggzj5GoSQEi4urCHgETAUoB4k1add4ghl12r6C6VHCjKqbtE6mapk/K5NOFzKKlmERzTBSCZ9AwExSPJZIKk7bzujIKEEutR3jeF4HiUUkrGjAxhFsqrVA5hFAJE2GRKOoGUvh0PESRi3KfnJPB3JGCztQD5HjtNeQDVfbWq0ktVZ4RACSLURyB0eFBJ9u1/qh89BzrQPNSIUE+QviNM004WbvMhsjukipSn6pKxkd/p1qxN2K7dofqf9B0dxvBLT+Hb0ydUWZ5LF86oZKmREcnfGFNKRc5ALo2ewplzX+HiKBmBYLl4+ZQCjRxU37ojFd4vqnKjZ09/y/cZVVu8Erkri/kEjbl0mooC7VcKVvzq5j8xducnUpxUJ/lebaPdZ5KrEyM4N/Exzt16HyM338c5gmLk5nsYuc3bt95TwDhzhSAZJUh4/ejsH5BRbkQipZGmwgxvrx/Ve2nODjTg+VcO4M3Xj8LX58WaQDLSawoQJCVLX4yY7C2Ym7ga2fQbu3d1oKWrhmxTj/7hNtS2B1HXGkBDd5XK+WjaV4f6I7UEhg2+YS+CR4NofrYGvh4vSjvK4O4oQUGVUQUltg03o31PDxK5Kq6hp1jF91/F62pe13gNyKS3yeJYVVKIlQ4pipCJhTLMmVhq5aS1SWFqAsROQFgJHEu+OvmWSNs4AmOVje9jN2K1zUhAiL/QKIAIOyiAmAvV/QISxSLG6DWOABFgiOcQj6FC2JWpz56MscrA7JxUPEav8RgllQBgamYqHk2jGScoHhaAkDke4lVuP5gkoCBYOPkfIWs8miaTfxuvZI2UzSqbcHqamPStvH87wcb3IHCmEygzs7ZjmS6di0UD6rsbydLSLzGM6j0V6B3uRXMfF5VWH3ytpQh3h9RBYDXNeGV3BY24B566Mui9Vmj9Znh6ytS2uSPiRKImUZ1frdixko/rUberHn2H+/DNyW+VXJfT8KtX5ST8jNrNEhaR845vvv2QcukLXLwo/kOYQMy6RPiO8Xa0DpbEYN2YEIN+RQFEslxl7or5l463Fwm003zefwMg/1SHhJJOe2LiJ4xPSB+GO1HfcfuWMt2StCI+4+zEewoMI//DOH9HGOMDnCIwzox/QBBx3HgPH537E/JDdhSWm+GjX3DzQ82sMmGbNwdhalGJzdnhzca64hS4at3o4ATe+1w/iurdWFGwnXKnEk8d2YWh3ZRAg9S87RF09NSimv6hKOziB21E65EmVXKm5Xnq4yMVqDzIL+1gBJ7OYgQHA8pohykJ6skUvfv7+DdUYX2JCbFuTuBiHWJp7uM44j2UOkW8j2M5/ctym5jkNMqnDCwieywhOJbYyBYCCsqPpRZhEU5wmxar7QIMg4qpWmMzKKCskLyNSYDETgJopWKXQt4vLFKgfIiwyDId31Mnkip6+LeQQ07c5+VlcjKnYRb9xQzKqBnpSZiWnswhfoPswZ+FNR4WcJAtHk6V2wSIAgllE0EwNZNASBfm2EymIEDSeE3dREBtJqCi44HkTQo883J3YhP/53WFycim97NVOFFW56GUCqF+uAq13bUqpVZa4vm54AgAvFQA0rioVCpOuvJgCxZTRhXD0ezi588FkUwu6QSZ7hxVVWZd1kak2TNULbLW3c04ToBIBqF0hpJuthKVIYfPKt5q5Ft8eUyCFz/jfZL/cVpFi0uoyfHjx3BCisudPq7ORaJh7dHt3Rs3JGZQdmFvqvO4sSuy6/VfaAP9ycQ/8cnN+wGJwLHrf8f5a8IWN4jA2yr55OZN8R4SBnAO5+k7zhEIZybexsnxv+Db0TdweuIdyqv3CByRVgIQ+o/rHxJEn+K9kRMoa4nA4behuMYNE/VnQcCADbKl682HucWO5Eot8qtNaBqsw8CBTvTta1UFHjabUuk3gjh8aBAtnVWoaiO7NBIYNHumYiMKHBrkFGkQ2RfBrj8Oou2pVtVbo/25ZjQ9XYvQbpryAR8c9XYE2sg0A/U4cHgv7LURrHYZsKKoUI3Y4ugQkKwoKlBjmYvsYOdqLsWirVlkjFwsc+SrsHcJKhSArCBAVtl1WCvAICDW2qJXAUe8TUf2kUJvmigghE0m2SNWDLlZtnajO1kxch5CgMjWreRzPKmZPBnPzVDbuLPoMaZz0k+lkRY59XCSSCca6gwBDb1GilQ7TIhu197fnUraqsDxENnjYTLH1CwyRSbBkLaRxpwjeQOfs57A2MjrJoJpI2IN6TDRF1Zwsrurbao+crA5hCAnfmQgiPaDDfBK9yt+rq6WYlgq6RcrHKjb0wgvGaWQC0sapVQeP1MHH7c3OBGh9JUWFLW7quHr9CHLJRX1CzgfLCip4wLWFcGxE1+pbVsJV5dzDVWCVJ2an1MNcL787D0c/+YTnPrua1V/VxhD6u+e+OYLVT3xzOmTZJ/zyg6I0hm/dp2GflxFgNz5/o4KNZGoj59/vvevAuSfODbxd3x342ecvnkP39F3nL5KcJA5RE7J1tjly3KucVH1mB65eBEj/GVfXzyOD0+9j49Ov4WPT/8BH518DsfOv4pzlFpn6DvOXhOQfIyTN07ibyPjqO1vgd1n5TDDJPV2/QXYVJaJFc6dWO9Pg6HDgfBQBJ17W1UnqdZdtWjcXY2yZi+qO6rxzNH96OhtoMatRyt1ridcBF2JEWmmbFUXq7y1DH3PdaoGLeYKCzyUVJX0OPUHueLtrUCIX1L1QBUaemvRvbcH2ZFSrHTrsdxdqKqyx/Eay7HCVRBllSIpUJCvJNUyAmMpmWQJby+V6h7WfMUasfQf8bZCrHUasJ4AWWOT3HkdVlkJDo6VHMvM0SSnWN6/QkBCXxIFB383jXmMQUspRQ+jJTg00gNd8jnSacIljzxL3Z5D5pglrEGGmEJWmCq7U0niMxJpulPUmEaZpXwIGeQheoqHkrcTBNvwIOWSjMfzkrCRQE8uJUANaZRr9BwEykOJazjW4cGEDZiTuQ3Z9G/CBuIjIgMhlfIcoYx1cGEray1WJX0khq2Y0tVc50SWtI8ImFQ5VjN9Y36xpNAayRYlqjtWoJ+eZV816g/R6+0NwsDHpMWdy29CWcRBcPhQy/f8/PgX6mBZTsajpULPKXCIF/nuu+P0FidVlcQRKUMqOeYc0pDz3JlTyogrvyLh7JRUyjff/h7jt6WfoSTz3VXnIirc/V+N5pUDwdPjt2l2oiV8bt4iY1yV7qKS4ijx9SNqO/f8hRGcuDyOL6/cxRfXflFdpD668iM+vHwDH54/gw/PvI0vL/4JJ6/9lYP+Y/wYAfIpTlw/jncvXEfL3m64g3bYpaJJoEA1f9nozcIGTzq2+zJR3F5C01yvPtBgrw/uFhd2P92Dwaf70bGvE2++/Tre/+R9/OWjt3HwxUPw1wVUmU6php5Jn5DtzIeNq1VphxeFfj2M9WbU7Kmk6a5Bw+FaNPDq6+Aq2FGBwsoyrC4yYrlLjyWTlTri3CKtuPIXk1WcnES8vdwh8omsQVO+lNIqhtJqGb3HCprzlfZCSiodfYYuKq0EHMIaluiIGnQCgABZRoAsJVvEkD1ieN8yk4DDgBijnuAoIDAk7D0fT+RPAmQyZP1xSaoiOOakJ2K2bL+SFaZy4gtIphMcM1MptwQgZBe1EyXyKlmYYxt+l7BFAeTRzJ2I5d+fHbDBIuc30q8jbFH5OallOqw3JWOHOw9bbRqkuAvUjp+PDOymHAp0BFXjmwJ6BY20kqh3oKKvAu6KEthqHCrIVFuihSVghbVCDgxN0EdMKGqiB2yvVFvhUoky2BdB5f5KlPWWwVRjUslSNv5uT71Lhb8HBiP44sSX6hhBNoLkLE0AcOZUFASnTp7AyZMnCYbT6qxNFm3pEyIhJyOSg84F/JrUypKi1hPjfM4ELo2N4/a9X1SN6GjAohwoSpfcH/91gJyZuIt7P/+sCr/JG0TN+A21MyAIPn1+BN+M3sDnlF4ShvJ/eg9Jorr+D3w0dgMfnP0cH515A5+NfkuZdgPHb5Aer53BB5euo/NQP0qr3NAFDdgZyMNGgiLOmoQMnwZbitI5aU2o3VODov5S6BvNMDba0LCrDkNP96GejPH86y/hs2++watv/QUtuztho8Eu4ZdZ81QVrPVOGIJmrnA+hOk1Slq9KCKjhMR37AqjtKcU3h4pUheAs64c69xGVXR5mVNHwx2t1LHCpVOMEk/gyO3lBMlygmGZgMIhwIiCI9aupaSaBAeHyCslp8gQwhrxVgM9Br0HARJjKsQi+oxFBMlCGvBFEk4iEbsERozJiKUGPeZrNXicAJmbS3+jycb8/Ew8lpOOmfQcMwUclE+zOfkFJLM4+WcQBLN4+3GacwHIdD4+Xc495FScYwol2INyKJi8jVJqhypgHerhItFfjxqybwXNdDlX/0BfueqB4qiRIuJOFDcVc7FxwtvMz7CrAq66ImW4Q20hbNemIL0ol88heNp8CHWEYAybsFOXgIIS6cFSRB+og65cpzI5C8qMyOFnqC+3cVCi8T08jcUwBY1wtznpM+2weA2oHAij9UCzCmI8feGMAsj9jSDxu5IVeOHiBRWZMUZQfPPt1zhDxpDdqUsqY1AMukRvSNyfHFafU5G9VyX3/IJ0oBpToJH20FIGV3y0gOVfAogMqc5++4ef8Y9//BKtbXXvJ7LJ9+r08eTZs2SGq/jkxn8CI5pE9Z8Auf/zx9d+xoej1/Hx1Rv0NT/js5u/EIC/4O0L11Az2AJH0IbcskJsJMWu0O3Agtxoqm1CUTbsTR5q1Qj8u2j2KIc81KqWOjfZJAhHUykGnxrGH995C8++8RI8tV742v2o31eDphfqUPtcFQJD5aobrCRm1fbVqfwDkVmqBCZXLE9LKVe1MHaWWZWx3lBsJVPoFUAWW6WvhQCCEsghQDEglgCRiubL+dgKAkOBhSOe9692RAGiwGEXrxGVU3FWAQYHrzG8LiFjLKT/eJJjrl6DeboCzDfosFBvIFiMWGCQ8PZCMoV010pHbNpWxEiIR1Y6zXeq8hhTk7ZjFif6jJSteIzSaQ6Z5DGCYCb9xgzlQcSsJ9F/RMNGpmcm0XjvUId/D/J1U3ITUdFexRFS8rOOJrt6WBaOcrjanajiZ+3vK6OfcKimPf4GP0FSzsluJhjkM5MWEAVYr9muSrUW1bng7fIjr7QAGTTZ+UUmbDNkINGahhTppUL/IXXK4nauQrIhBfFJa+kR86H161RBv7XZW7AmazNKCcTOIx1kpGq0HejCyXPfqZK14iGkEaeEKonZHhmR6ogSznQRn33xKb4jm6gCDtekhI8EKp4lMC5SVhEEKqj2Dq5dv04rwPfgdVxOz6+PR19DFrlOH/IvA+RzssLZCalSMk7Xf1e1T7tz+ya9xhUco6QShrhv4P+/xz8JkB/wPhH86dVxfM4/6EP+A82722EP2ZHND2udNRlLC7ZjccE2bLakIthars4ntBVmFfoe5pfpbfBhvT4dWQEjkvkF1fW14IU/vYyGgTY4qopQPViFrufb0PVcO8LDQX7gHtTtphHkBy5FG0prPSilnPA3eOEMOlViTqS7GolldppuDUFRoMCxSHajrMIOlEKUW8vJKssJgBUccXYZlF8Exko+FufUYo0USiOwVjsIDAGHw8DHKcvIHMs4YgQkdskMJBAoqzaXkyXrNmMOzfhjNOJz9Fo8XlioxhNkkp0lFqzJTuCEMyLTrcEanWzlpqndqamc+CKnHk3YjJlp2zi2k012kjl2cAhAhEHkcDCBfkTON6IBiLKTJezxUMYOlQFZ3d+ACKVOiPK1Ypcf1buCqNxLHyFtmbs8CFPSVg9WorzeBw/lk4fGuaiuhJ+fF3lkV2nosyVvGxcaA1xNdjj7SuCqL1IF/6S/4/bCnfzZQWlVAj2ZPNOSge18/oqElapRzsbczcgkeLZpdmJdzmYVgR0kyBr2NcLXHUJpewCvv/Om2nmS/PNvqBROnz6lDvUktF16hJyjklEptmQPCWuX2lgy5LZ4C2EdKaIuxUOuXJPGOtL08w5u8SrJV3co3a4RIBf+q9u8IrUka/BbSqnTou34x5wcHVcFGmTb9//6/P+3ISfwH1+7h08l1Xb8b/j83Ms4fuV9HHxpN1wRJ/WqBWll+YgzJyKWLJJalofug23I83Di5ezAVmMmjAHqY2cBZqVswIzsDXhSUmjNuZRWbajrr1Vh6fVP1aHqcAVq9larXI6GvlYMHBxA//5OHDzaj93PDyJCaWENu2j42+hj2lHZV4MdJVZO3HxVxVAAIod9ywgEAUWcmHYCRO6T3PB43haArBTGIKso9lBXA1Y7TbyfcozgWGYz8PkmGnoDwWYi6IyYZ+T7OLIQ2r8E5q5VmKnPx3SdBrMIEBmP0Xss5HPWUE5tzt6BdHMmZYoBify/xXsIg0xNp7dIlXONzTTlm2jOt2BGupyIU2aROWZOsoecnsvzxH88JM+X0BE+54H0rQR9NoI9FWjaI+E0YQS6fSqqoXpvCP5BH3y9xQgMlKGKz5HzpBZ+RtJaO99byO/BgsJS/o1ZG7GBbG+LmCnPylBCti7nIraTzLFk+yo8sTYG2e4sejwPPF3FlLOl/J4LsSF7I+ZvWIxFG5dizqr5qnC4Maij/MqkP/FjO18fm75FLRBHnntW+Ywvv/ySAPlWGfMLl05ynFA55xKuLjFVEjoikbuqGMOYFIe7irNy/nGToKE/GRkdxSXK+9t3vleSTap+imyT4woJkbo58d+K5o32Gfzo4k18PHIVH5wiC4zdjT4mhRv+b8//fx4ixz6jxDp+YwRfX34TX577I9758GXU91SpVcpAJpH8c5FZSb58pPsLEKtPwJpC0jMnSm6JEZu1aXhk0wrq7bWIyduOTQXJiLRV4NArR7D3pT0YeKEH1ftrqWFbsO/5Ybz81h8w9NIhBHY3w9YZQXp1MZKDLmzipN9RZqNPiaCgJoBYlxGLJIdDiiPIIZ+NxplSSUAida9EdonUkk5JcWQNAUe8XQ4MCSACZiUfX0nWWEmAxDnNlGJmgsvE11sILDPf04gnzQYOToT6Ldj12kxUHlqIeZYszDDI77FhXYmTXsaIdYZ8pOqzkW7IRJIxTTGjJmCnSU+nVEpVO1Ozk5Owk++9kX/DfKnCnhE9DZ8xyRoKHCoYcZs683hEBSgSJHzO7zKlH0ki0vgZSK/3yoEgqujJKndFVNpr1VAQ9XurVC2wSoIi0hZAoa8QDppn8SBOXk1kcCnGtyF3Kyd0Ajz0LaX0Lzq/BUm6FCzYsASL1i/CFs1WFPB7LIhIofECbM3fBD1N/NLtsZi7eiFiKbl8fE9b2IJ0axYfT6QU24aFm2OxcEs8XvjDi6oPyInvvsGl0bMq8e7y2GmMXR1RUboS1i4BsHKqfm5Een2cU4wj27dXxi+qsKfvzp3HDbLFD/eitdrUIeHNW9HT9Ilo2q2wzH8ZIPertn8mjCFmXKTVNfER/7Py6n98r3/i2I17ODnxNT45+RL+9u6LGNjTirb+JhRTf652JWOFcSe2e7KwXCPbkBuxhPS7UZ+KBEceVpKOZ21ZhbmZ67HFmgGdz4y63loc+tMR7H5xCF2H+V5klIGju1C3vxsF9TTfHiOW0ExLLwsZUvxAFVeQ2CZO2CWWQt6vwXyOBRYtFtKLyFhi1XLiUl5NAkR8SBx/juc1XgGCg6wR5+Lgz3EuE59jJqBkiJex0tw7CRALgWHCk7yu8+UQGLHof/Ux1D31JBY70jBNT3AWlfBvrUI6pVoi/8Z0SqrEvCTV+yTcWQlblRfzCZAZErJOnzFnx04kmM2o7KxDWXMQqZRii2i8p0loSLKcjktISYKSWY/I+UiaJEPRk2QTXHmp2MzFJpO/y1ZjQ7jHh0BXKa9BVA9VoXlvDRoPECD9fnqRGuU9EnWplEkmlDSXINQZpMk2QBfUw1Fth7XSAmudDUUEW7I1E2afjhN9K2KT47BDL41TtyA+bQ0WbV2GdRkbYSzmZ5W6Bk9sXor1ZKF8pwY57lws3RKHmG3xWJWwHrGpG1SpplfffImq5YTq+XFx9AQZ4TKHBCxKlfZoxRLJPVIpFZelmsk55SmkcrtkEF6iHBu5cJE24Tpfd4t+JproFwWGHHJPKJBJ2Px/GSD/Of5HQPzr4Lg/BGhf0XR9efFdvPHnp9E11ISm3npFz8vsO6nl05ATtEAfdmOLPQfLuEqtIFiW5m/D0pxtWMuJkOs1w1FZBEeIPoITaOjZXeg82om6AclGbEFudRmBYUIMtbKcbi8w5VF353BEKxWucstjOmWUZQgwFtMnLOJYbNVxaDmxBSBR36HAoYawhk6BI56sE8exzCESzEgWMvP5JrKPVDuRYaaconSzWPA4J/MCSi5b73r0vfoEGo7Oh2/PYhQPrkBqzQ6sj+RjJRkkhe9XyMmba8lFkjYF9poS1PbUor69DtYKP1ZKbJaxEJt1WmykDAvxfw92VSAvaEOc1KNSABFjTnBItqBs8/L6CMExNTtFVVTRhoMIdjfBU+WHJ1KC6taIysn39ZWidl8F6neTNfbQpPf74O8oV8W7XXVO1ZyouMGlOgR7m+Q8oxxhso2/20ufUUyDH+EiVwJjuR5rM9arxqn6Io2qUbZg/RI8vnoB5q5ZhCfWLOFYRADFYxOBFJ+0Gtu1O7F02woCJJav3Ygk+hUr2eit915TJaIuXpYK7KdUhO7o2Ai9SLQgg5yJCFvI6brsXEnSlIST3Lx1Q4WWXOZjo/S852gLLly5pmIHb9yQiooCmOu4++MNVfdX3vdXAMivNz678Xd8PXYSb7/zEp55dggd/RIq7ke8LQmbynIR6m1Gy55uGIIOxImxIzjiRG5xJcsts6LAa4HFZ4e7shg+Gu6agTq0HWzH3qP7UTHcgw00uctkq5bgEMM935RPIOQrcMyTMHQBBg3yE1J5RLZcCYol9AqLySbCKPfBIcCIlStHPIGwikyxipN4pVO2hE1YwREjZpySatmkpFrCIZJqAX3HAqsZ8wiOOUYz1pdnov2FhRj84+Noff4JBPctQPuLT6DnlXnQ9WzFPL4+qdwDb50XrnIbMq05CNAD1Mlp80AHP48BOKvCsITLURwpV62n/b2c3P112FFuxmOa5ChjqNgrMeZy3a5O0acogKSSOfNhqCdDDPShoakOtY3VaGitQUVXWEVMRyi1qvaF0Xq0ATV7quhPKunRQgj1eFE5HFGGvqjWrXayqnZXoGo/AXWgBjXDkidTo1hH4yvA+pwtyDClIlWTiBXb4/D7J6fj9/Om4d/mTMH89YuxozAByeYUJFtSsTZ9HdZnb6Lh38SFIR2pphQugjtUa+jX3n4lWqH90rcqEFFKi6qUConAvSz5HbLdK4l5ktItZl0OEqXWVTQJ6uylK/QgtzhuKoCMnJfD7cv4QYBx5zru/BituiMtFH5TABGDf+za9/j6u8/w3juv4Olnd6OsoRSr9Dux0ZoGbYULGg5p0ZbmysN2WxaSS/JVeZ+VumSa83Qa2AylXSVXvOtAN3oO7sLLb76O3S+/iNSwV0kj2ZkS831fQkWBka+A8YQxenuBOpPQqrGYYwnZJIYAWW4XcAhbCHMQGPQYAo54p0gpo/IZKzipl8vPLitfI1JOwEHGMBnoL8yYazJjlo7eg+/n7F+LvW/OxZ7X5ih5Fdy3ED2vzkXfH+ai/pnF2FKRim3+YngawiimT9IW6VDWGUBRRwgpLdVIb6hGsKkBgcoIvDVBhNsr0TDUjPSAA4/Riz2SuVNt50rYicRbKXCkysk4/YiEnWRJfd1c/i9GFFRQVjXVYnDPEHoGu1WkcrArRA8SLSjdMtyMyq5KFWVQs7uKht6Hyv008/1SkT2AyqEKVOyrRN2BWoQGAgj0BVBHQIX3VMDb5UMWJdP6tHWqMecTq+i1OKbHzMHCjTHYTNbILM5CkpmLociv9NVYk7EW2fYM+Os8KKBHWUvFkEC59se/vEwzfhrj10dUuLsq0XN9nGxyYbIuFsdkGVE5A5GrmHXJUb88egVnLo5h4uZNMofEC0rxhov0JhJ7NYoff6ZJ/+EmJm5dVf1FfmMAAd6/9jM+u3IRx49/hDffeJY0H8S6okxqWwtqOiugr3LASRnlrnSrbd4dBMmCrC3YZMlBXqkeBUV50HsK1HZwhwQscoX9ywcfwtRah8SQh5PWoM4yFhMkcignIFnEya9AYogyyIL7wyRAkvpTNJB8znLKr1jxGHKmMWnABSDKiMsulW1yl4oAEfaI4VhCebXYTkllt+NJAYnVitkmC+bSf+g6tuDI2zMx9Me56HxxIXpfmYuW5x7H4bemY/BPj6HjxXkIHlyBeC/9TXER8socCLWEKG9qYW6htKqLYHnIi/zqIOraa9BDdm090Iq6ffXI8tsxM1t8hgBCYrF24gECROWap0R3sCSbcAoZRKrMZ5TZEJtFWWfJQy8Xlb3P7FEn6Pk+Pdr2dtKHVCDSHkFNd7XqbCWGvWFflWqu6qC0qhiiBKMMqzlYiyoyR1mHl3IrAHu9DaV8jr2xGNtMSUi3pGAr5bHGmYPqxjJsz9mIghJKRzKEFKfeqOF3qdmMNZnrkOfKgZHeRefRItmYhO26BOSXFuK9z95SrZ2vXZcdqos02XcVSKTGlexgKYDIwR99h0ir8cmyoiPnJE/kMsYm5BBQamfd5ONjSlZJjvvpM8dVdfgbtyUld4xS7P/vNtD/E+Ot8Z8wfOo7fHv+G7xDFilt8mGtNQVbbGkwB63QePWwVJoRaPcjw5eHZQWbsTh7C2Jp2ILW7l8AAIAASURBVDebk1FU7aQcKYbJZ4C7qgR9u/rw4uuvITVYhlzq6zVFZur//P9gEAUABQKtqle10CCVRyYHQbJISutI6IeVvsMuhnzyTIMAWVdkxWrKqniCI84eBUgMxyKLeBbDJDgsWOxyYj4BMs9mxRyzhQCxYlmRAcED8dj/59kEwpNqtL4wD50vEywvP04GmYPhNx5DywsLkNmciAVuG7Z4KWmGOiix6pBZW4FFZI3HQz4kkjnqKEfDzZQ3nRJCXgZnczHWOnMxRfI2UraSPbaqIgySVvs7AYnsZmWmYCZNfnrAjeqeGnXSvYGf4zZbHtI4KZOcmTBFLAi2B1Quh6/XS+MeUlvl4YEQJVS1WsDKd1NuUXa5G0tp2EsR6KTkoyfJKy+Ao9MJZ3sRDHUWZHhykWhJwobs9cgvyoInbEaBKx35nkyk2VOQbk/DGs0GLE6MxWoCRHa70qyp/LvykEJgJZnSoCnW4YPP36aJFhBIJZxRVQgkmkZ7WXkP2YGS8ww57xCAyA6WyCuRUqdGLlI63cHdOxLaHm39JzlLwi4iw66MX8aFS9E2CbLb9ZsDyJ+v/ITIsWN448IpvPPh69CH7FiSuwXbHTkori8hSCxoogYPtHmRUpqFeOsObHZnoMBvQIaRJq5Uh+IKhwqTDrUG0d7fjYPPPA0zpUgaV1vZgRIGWSi7U2LEOZSE4lCAMBQQHNEhp9uLjHy+hJnTqMeSQeSwT8x4HP1JnETiki0kuDCGHkUO/uJcNgLEQINvwEKa8oV2+g2yxhyLFXNlWO3qdk5TCp56ZxYO/GU2meMJZdJ7/vAkul5dgIbnFiB8IIYjHvnN27Dal83X2DHfWYxFxR6sCvixMFCOuWE/noj4EUvp6ODqXkFzXtddC19jtDfjSsoRCUmPhqdvw4Ny/kFp9Xua9QczkvCwpNxmp2Ej/x9dmQkb0jYjuSBFdQTewhU9pTgH9moXGvc1kj2C8HV5Ud3doPrCyxmHocYEe1MRnE0uhGnkq/fUIdAt9XTpSRqKuIDloKBaB0uzHaW7vfAOlsMYoacyJJApNqmWFFp3DtIcKYjPWouYzFWI06zHktRVWLBtGZYnrcJG+pZUSmgDwbSN3mUDJePbH/2FfoGTe0x6gFxQLQ6EQeQQUFhDTtglJ0l2sm7euMmrhMX/iDHed/b8Bfxw9y5u34oWZpBzD9XpjI/L62XH69z5E6oMleSO/OYA8ublH+B45120HPsEf/v6Q7Wd6awpQceeVvhbfbAGpOpICcFSDE1YmlzmIjeopQQzo4yM4SaAfLVi0svQ0FWH/sF+7N87jNreHiT4i8gWEmGrUewhY7FF6lVJqEihCuWQsdgosVAFWCxA0eWr+5Zb6DvswhYGAoJsYpWT82jISJwKGTESTDrKtEIafz1NuB4LCI4nbQIMYQ0LHuOYZbSQSUwwdG6FY2AD9J07kVhJ9gtkIrYkA7GeLCx0UfY48vGYVYsZRj0e1ekxTW/BTLMDT7pLML+kDItDISypCCEuXIZt5U5YGyQjz4+GvmZE6BE2FmXTY2wiODaRPbZM5n4k4KH0ZPyOIHk4IwWPZkuTHrJEdSnslXYk0iTn2HIoYR3IKdVyFMBZ4USkL4iawUp6Cp86JAzTdBe1O2GoMsLR4lTbvCW9HtQO18Pd4IGrwQ1PmwelveUo5MLlqHeirL0cni4/StvI5JTBq/PWIy5jFTSefNUwdZN2K2Jz1yCtJAvaAL0cPchG7Raa+0J1eu4m4LMduSjw6PG3j98hY1xRbQtGL8sWbzQXSXajBBjCHjLZr/L2NT526Sq9Blnj3Kg07LyinhON4ZKzjmg0iABEOi9fuzGKy1fO8LXn6HF+iwC5eBeml/6Eor/9Fa+dPIb2wx0oavWitk/CqB3oomEsbypDYdCIXH8hnNV25PgKkMsvtPNAZ7RoG7/EnuEO7Nu3C739Pehob8XA4BB01OzRHawoOCT2aSlZQthhmUUCA8kkHEslnZWTXs5DpAaVhJnLiKVsirNNDrscAIq0ImD4c6yZZpwAeUKnxVy9lmacXsflwEKHg7fpPcgas2jOpxlMmG404Qma91kGM2aTGWZScs0y29Rj04xmPFyox1SC6cFCAx7WmzFFZ8YMA1nI6sITzhI8UVyKJeUBxEeC2FZTDm2YEmmgHpWUOb66cjKlAY9mrMfvk9ZTXm0ie2xRu1aqKBxZ4wGyx6NS0SQnlZ5JQ2CFVWEKD72Ei+xr4mqd7s6DrcKGYLNftZiTs5AKAq99T7NKDdCGCpHqTEdwmAZ9TwjudjfKO4LIK9Iim4tWSU8JfYcT24wJSHdlwhA00YtIO28PFzMTUvjaTJekRqdjbd4m5T1W564nc+1EWnE+1uVtxnZTAoIDYXQ914ea/Y0obilVnbM+PPbRf8RK3c9e/c9zjGgYyVWyxsjYNZwnOM5cGsXotRsEi+R+XFOyS3az5LUCEjko/PGeRPFeVglW5y58hUtjJ3Dl2qnfHkDeOH8H2gPPovC117D/+DE8+5dn0LavGeUtHlj54URI7wMHW1X/jy2k5vyAFnleLYwhK/qe6kbz3iY0Dzaif6gde/b0UGK1o3egE52dbQh1NGJrqV2dgYjEkh0qkVEChuUCCDKFAESqF0rtW7lfcjFWcOJLkpLcL2AQI75CfAdN+EqnBavIFMsMOr5WTwbRYZ7sVhEwC8geC2w2mnO7Yo/pehMe5eSfxok/g+CYpjNiJhllJoExg2MKH3tIq8MDvD6iN+LBAt7O1+FRjQFTCwxkHxses7kwiyPGW46kygA0lcXQByWUvxiRnkpYQg6stWXgf9sZj/9152r8PplAIYtIMpTU2300IxkPSUlRjbSezsLaIh1CAw2o7KpGLc2/sdyIDFsmCsv18PIzD7cFos1J+yrQeqADjYMNZAEvDBEzjFUWuFrcvG2kN8iH2WfGppxt2GlLhrnJClOdFdn0DzllecinHynpKEOGOxebtduQTL8YRykVm74GK7PIJvQcWwu3YwcBksS/X1uhJ0sVo/X5NnS81IWGw82wVDlQVOfBMc6LaKHpG5OJencUQK5PEASUVGMTN3H+ynWMjV9Xu1XSC1PYQRL6hGUuXpK4rHHcmJDi11Irmqb9rmQmjqlavtH+IZd+e+cgMl4/dxv5u55C7suvUmZ9hDc+eh2Hj/aibbAC3cMN6OWX1DncBEstTSuliI1fUgVNY8+hDnQfbKd5l8JjPrjDThh9Jjgq3ajrqEZlWwXquurha6tXFf8EIIsl54LssVwmPa8ipZYQBDEEx3JJUrIIU5gIAIsCirCIRN8uIdssodyKITDWlhZDW12BeBvNP8HxpIDEYsJcgwGPm4zRw0CHSwFkGpljCuXSdAJEMYaObFJIkAhQePvhfC0e0hTigQIBih4PavT4fU4BHsotxEyCZAafM9vuwlxHEZb5/EiqDsPW4IWR8tIYtqhwc+ljssmeiX8jQP6XbfH4XeJaAmSDyhQUBhEPIt5jmrRZM2QR8LnY4beqA9mq7kr4GwMopdfzd0jIv4/eg2Z8Tw0qdkdQQyYJdoRUX3NJKhNw2LhQbdXshI7m2RFxYVPuNuSTXVzdRQoQ3k6vyrUJDQWQV6aJHgJmriZrbMCSncuxMmMNVmdvQExyPEGTrvJPvPQwFUdq0P5SOxqeaSJLheEZ8KK4o1SVADo58p1qJS6gkIo5N2/fwqUrV3H60hguXr9Dr3EDo1eiO1fSYlz60tz7icb8brQi/NmzcrI+jls3ZTfrNu7+IMwi9bKkXTSZY0xy2KNtoX9zAHmDADHsehrpL7ykfMg7X7yD557bg6oOP1pI8bsPd6OuvwqtNI7OJidMtWYEessIjg5US02lzlKUSS5CbRk0brKLORvmUgM6DrSrnZqW/b2qsNl9cx5Doy3gUAlKAgyCQjEK5dQKyqCVBIgkLcXy/uWSvGSV6Fs9FtFHLHHYEOcpgbOtDZuK3ASHDo9zzCWDzCZQ5tksUf9BGTVDGIRjKqXWVDPBIrfJIjPIIDMIEAHKIxodWcRIljHid7laPErWeIQgmcbrHIONz7VivqcUjxeVYIHXh5gy+d2VXPWt0FBiFnqp92UbnB5gKf3EAwlkkMQ19CAbVeagVFB8UOKvJHBRk656eMwy0vPY8znRy1A3UEMpW4sqSjVJlZURlGaaPQTKnjCC/SEEWqPZlnJYWNxWDGerS3mRoPiSJg9SjBmwV7lRtaeaXiVCL1IK/y4/vP3l2GbYgXgCYotuO7bot6uql45yOzLMmYhLWkPzngprtQNV++pVEfKO57pQ90wj/H0BVUijYjcXOv7ur09+pWSVSKqxq2M4c/48zo9ewanzFzHxfbSLsmztqmax399Uhl5AIE2cJM9DooBl5+ru3TtkFskk/F6BYeTCcRr045Re0eQ/CVX5zQHk9bM3kd97AOnPPo/2r2jUP38bR48OoIrSytdYBFOkECUtDhx+vg97nu5EuNsLf3sJKvkh+jqLUdpXrMpX1rfVQGfNhdGuUdq6flc1/L0BBLlKrncZVX2qxVJ4TTL5TFFZtZj+QaRVvMuG9SVurHRYaMKjwJCyn8qTWCQKl/LJQsZwOhQAFlNCPWHQq6jc+WSVJ8gmsymx5hBEc+xWrvr0GVYbFnJiryjzYabLRaDQsNsdmE6wTKX0eowgmkbWmE7QTNWaFDgezivEo1ojpvDxmTbKNDLREr5+RTCEJ7ylWB3yoaSzBlYCJNeRDT0NsZ3erGpvCLUHGpAbtGOpXtoXSPG3HZiSTnBIqm26FJ5OJ8vlYLlbDjI1yKDfKKl3wVplQ/lAOaq4aksqbXVXBM1DNXDWueHv96rCbvX7a1XVSUuzFTZ+F/WcuBH6kmBvGIawEaaQCWUt5XCTicp7wiiVfJImN3bqErGBXmMV5VSaOwOrUlZiS/5mrE1ehzUp68hCGgJVOnnVoutIH1qG21XX29q9jQhLkfDhevh3h/HlyS+5+k8oL3H28jjOX5JUb6nSPq5Y5b4fEQkmO1yyDSyAkJ0uAdbp02dUopQUaBDpJZmFEsMl0cBShfH7uzcxcV06Md/47QHktTM3oR88gtwXXsTu777Ep19/gJdeHEbTUAWKGu0w1pgRHvKh6UAEw8+24ciL/TjybB+ef2EIjbskqK4eEUqNqq5alEdKYXDpoA0YUN7qVyVMpVK4rbmKk10y9uTwz/gfkirWJmcZwhoWrKXBjrOaVC74ckv0vjinFUs56YUpFloJED7ncU70Jznmky1k12qeVQy4GXMIpBl8zxlWAsHhxFx3CdYGI/AO9iG9sQZzS1wEDgFGqfW43alYRoAwhYwixnyG0Ybp4jtozmdSmk3XkUX43AWuYsT6yrEhQpNe40caV3RLlVNVjwy3BTlRq2Dv96Gg04P0hiKsKy3EgoIUzM5OxGNSJjQjURWRW6TLxxyNtEjLpQzMxVqfAWmOfOQUaxEgCIqUfLLB21xG812mCnRLr0gpCVvUUowCvw62WgfcTUWoGhDG8aokKekhKKVXNfQeujIt8ulxane3KVbJofE3BS1ItWcg0ZSCbYU7kGJJRhY9z7aCHQShM5rENiyepwoBslRpB4HWUKJ2wSoosz2dJfj8+Gc03Lfx3cgILl+/gtt3hR2i7cUlVVYOAKW+lWQHRkFwR7HI/VxzqfAusVc//fQjpdePqgzp5dEzOH/hW3UdV0XVRaL9SpUVf83x+sht6A4+D80rL+MoV4pPyCC9h9uR22JEfqMZ7ZRWz784gOGjzejaW4NhGvNnXt6Ng0e74e8pRQ21sptmXushMNwFlFi5SNKnqtWxfMCH0gYfnC3VWCwHgdJ3Q9hDmtIYJWzdiFUEwRq3HZs8LjKIWe1cLTMbEE85tabYRf9ioX8xUGIREA47FlhpxPUGPGmSyNwoQOaReRYVuSirjAQIJ7jDgVmuIiwq9SG1shpZlVVkkjLMoyyLKymlVCrF3GI3FpaXYXNzLZnCiRkEyVxKqseNNszWRn3KfIcbKzw+eo9qTs4g9A1+uLjCu+pLUd7MVbrLi40VOszzZGC6MwWPGBPxaP5O1UJtauZOzNakYVpucrR7VHYapuSkk62yMKsgExs8ehRwElf0VKlDQHudDXleDQqDWlWxJNQSRFlbGSr6ySxdIVR2VvK5lfBw4krtMk1Ej7jkNdCVF8LdSBbqcqGytRzBpjIcevEwOnb1QCsV8pu98HX5kUojnkAZ6GpyQePRQOPTqkKBjUcb0fRUK3xkHmd9ETJtOdBROob4s0g+GyXYWx+9iws02bd/uI7v712PNoX9+YdoBO4tCSEZV3Whf6CkkjpX16+P4vq1UVVx5waZJSqxJvDL339S1eClyPU1accxeh4XL5ydjAI+rzIQf5MA0R98DsFXX8brX7yLp17aR9ZwYW15JsytToKiHkee6ycFN5ItpJp7P0c3dbcdpV1u1O+NUCYYoXNpEK7gyhN0q2rrVUNh1JFhAu2V2F7qwJNSR0q6Nsmu1eT5h5xlxHKCx5Ix4gmENZRacZz0y2QLlwZ8uU3irCxY7rRhqd2GRRwL6Ckep/GeoyvEPAJiHpllLlljPkEx22ZV0moGmWJWUTEeLy3DAgJCpNYSeok5BMJiMkIMgbGsyo+8AUqKV57Gk6Ul9Cgm5U0etzkp1Rxqt2ue1YHFfG1aOEi5GUaB1wQN2dHZUIwyGtsdFQRRSRZmOtPxsIl+Q7sTD2XtwNQsCUxMwDQpOSo9PXIJjqw0zMjPUr09pmozMduQjTiyh6amGG4yRLo7nfJnGyenDs6IQxn48iZ6kd4IfJyoFX0hFacV7IygergKG3K2Y+GmGKQVpSGnPJsyqwD9exvQsbcOXVzgJGe9wFMAW6VNhaD42/2w0dTXHqijxwjTYxRTGlah5UgTqg7UIDJMAHYHudjZUFhWqApuFASMyCoqwOsfvIurlEzf37tGkFyNBhhSDklraImvkm5REtouxeWuXJHGTVcVOOQqABEGkV2wn3+6R08iYSbnVTlSeY0MSbaS4EfJdf+NAeSfeOv8bbQ8+zIOv/IMnn1xL3xtfmxxS6mbHdhcwVWm10v26EYttals//bRnLcM1yArkoOaQxF0Pd+Iyt3laOmrxO6hFjjLLfwiLJQf5Rh4qgvBngbEW6V1gLQS0GKBNp9Akb4d0vevUAFitcOqzjVkKP+htnAlSNGCFU474sgOS21RcAhzzNJoFTgWc8I/QU8hwYjqYJDgeIzyaSbvn+UuoqzyYDavs+hZnnS6MYfXRTb6Cpcb60JcWff2o2zfLoKoGE8QVHMIsjlOyi9exZssIsgW8ufCigBXajvMYRtX+iLqfisstUXYEKQMc2ZimjkVD+mS8GB+Ah4kc8julYS1T5GyozmpmKXLxtS8DAWSaRoCRJeDKQTJLG06YqT1do0TJgIvj5KpggCoGZJeKH7l5Sr7qwkQvzLo2mAh8n0FqtjFyuS1HKtQUJqDnNJMZFtT0EBfWL83jIbhCkozCVcpJQPYaMQtNNyV6DjQjUg3jXyrj/+HCyWUafWHGxAYJvD4+yr3RBDga7Is6cgjy6TasuCqduPtT97H9dtSXYeMcUdyyKU6icRdXVLsILtX0cJwF5XMElYReRUNObmBEUqz+2WqpHabFJyTaidS2EH6gggDydax7HD9xgDyv+PjC6N49k/PYuhAp2q7ll1pxBZfLlL8GqRX61HYakdZnwfVeyoxfKQbuw/3cPUMwNFiQ9PTNWg+WoXqveVo3leFhv4qFDe6ySzUzzT5XQe6kOcvxZLCfMRz8q+jbJKDQDk1FyaRHazVlFgb6C3WcPWP5aQX+RVHVoij2V7ldmKZVSJ0bfQh/wdz7/0fdblvj/4b997X2duGENIrhCZFVKTX9GQmZdIm0zKZJJOZTHpvBAihhl5Ewd4LoCJNsWJFEekdRbHsc866az0j53zv97f7unef7Q/P6zMtA4RnfdZaz7uVIaqIckbHuVzyIeMrKxEvUJQQNDau8gqMUoxDDCLwiEW8BAgZIYbAieH7ifQYycUVmFNdy39fM2YEgyYdJbJIko0ehz8XSYMeRTAKIElkLWtTCFa/A4X+UrNh1NS7pKsK0+uLEVupccsESD4NuWWxCRCqk/uo7GXGnCu1ZLQBQx7uz8nAfXmZuI8sovVgUTYS7bnIpJ/RdKzSulI0DAVQRuOdHyqAl3Konr/r6sFa2BpLkOPjZ72ZlHiVmEJwzCufz83uRuMQJd/ySkoxmvRVVejYUI/mLQ1ooPF3dDlMi9fOnSrrbTejJqo6+Hl6Kf/qen6mmTfBegT6a+HorUC+JwdpBUswJ38B5hLw6RU5eG7/67jxs5q8yXgrek5JdVMBv3DLHhl0ZfBKPqnuPDyQUxNxLxpgKECoGYcaoqOakbvzCvUZASMcYVeXxb8YQE5c+R0nTn+GXc9tRAPvPgWtFchpLkcJzZtdx4nLnQjxl+0ZcqBm2EP26Mb2p9ZRbq2Ab6AKnTsoo/Y2EiTNGNzH/4ANTea8XtJqYOty+AY7MYWAiLdkI9VWaKY23U0pmUhDreNczf+bRMaYai+jL1HjNoKGUms6QTOZniO5RHETBxLJHJFFRQRJETcVPYf8CDdvTHk5IkroGcxpVDHuKbBhjJ0+opSmnh5CuVRxbg8iueFHU0LFl1Ugnn5jqkw8JdhEfy1Zhwa9RHUjLiRzxRJICQReikegKjPMNafei9xWL41tNWo6a2Btc2JSbQFiXPQUdm36pbg3d7E5uRpj5oGoeXUGIvhvH1OQjSibhXIrE/fTsN9fmGMAck9BBv8uWZhfno0F1sXIdVoQ6KlGMVlCfqHAV4gmeoHubV1wdTgx1zYflpDFSCPNaJxrnY2iqlxK2goE1ceq2wsXzXxZg4x/AA3bWlDUVm6i4/qZukFlRNjgH6D32LISdZRhzSOtxqSLtVSVuCR/PnI0LdeyENMyH8fcwjQ8e/AdXKVE+vHncKDwuoJ9P4aNuioCBQIBRFm66mCiNqJ3JdPd6LnS3wWscFKjWCZ87BuecnuD4LplRin8ZQCiMdLfXr2Nz7/7HJ0bulHYUmF+mSZBbnMTApuDsK9yw7eGentdFarWOA19r6eh6+EvtaSjDE3b69C9swEDuwiIJzrNBKih7YPYsXcjukdWctPbkJCfS9YgKGyUbVwCiaTVZALh7vRYXQUMAWYa5dY0yqrpXje9Bzcs2WIc2SOBviOiIB+RBZRXJaotp6zia5E07KOKizGGn7mvsIjSxWaSFMdTWsWaTF5KMDJKHKVSBKVYIsGi9yYSOJOqqxFD5oqyq6CqDJOqvJjMNY7gS1BzBzJciseJxEonUoMeTG10YhmNrI0Sy9buwiMhehCvhd8bBsgoa7iZwxjVrKs3Vm4mAZ2H0fnZuI+A+bui6pnL8LecNPybJR1/44osyiAT5CKjKA2zs2bDRtC5O+1w8/9DrUUDy+u4mbvpPcjulFN162vRsrUFwRX1KKspgdWdjVx3OgpdGQiEHKisK0FhIJ9MQsO+sSG81oXg6fGimqxXwZtgQF0VV2tSV7MJRrYRIJ0jPQj1UUr6iuCg15qbowh9OrJrC3HkkxO4xc2sklg1j1ODBeVUhedjhntaCTACgKlPvyxpdfnPDvCqHJSMCo/mUOsq+ZG7szX13JyC3SCgbv7/NmHq//v66MZ/4urtX/HNd99gz0v7sOmpEQTWKq1aQSYfHGtcKF/lhKdfp1E1qFlbSTapRe+mVviHfDR5bjTtDKB1Rwg9u5rRxrtU/7ZubHhiLXY/9yQyKa3GFVqQaNU4slwk56vxc36YNZRWQlCIOcyRL5ljqqPMmPSHuSEn6LhXcsyhKVG8g5eWIio/nxIl14BjjCWfep4bz1qAMQTFKIJEDDA6v4iAKTWgiCLjRHPFERTJlGIplVVkAzIS/ccEnw8TCI4kept4MpXiJ/FKX6nyYBKBGVdRghhKwPhy/t28Lsz0V2Jmmw+TuGFnNFRgqceK/EApZgdLyVD5NPZ5ZtLsAzTkyr0SSO5V9q6aWVvpObjuo+z6ezqfWyitCJh7LBn0LGQZWwZmEByz0h/HQssCpJUsRUlzCW9U1eaot7Ldi85h+r+dfajb4EcTpZPytLo2dCG/pghzVdRUpprzWShy55BRrCgnwFppxusH/aaOpH1nO5ppwnt39KKK3+vtrUU7zbwaw3Xt7kFgfZM5cs5xFSOt0op5xUsxp2Qxyjpp8DeE8PHXn+KPP34zjHE3tnGXOa5fl39QEPGKafujuhCxhAbMChxaipeEZdhZAyxl8/73uI5bhj2UtHjz9l+oYOoEDfr523/gm9On0NAf7tYXWh1C+7oWOPsrUbaqAv716pJRw/+YOrhXO1G3rpp3M1I1X3dTcrVuDVLrBtCzuw3rdw5h19M70b1pCEtqKgkGmnGCIslKBuGdf5JNowaKMYFXBQEnaREYYhTFPnSSJYZJKaIUUwTd7SBInPQqYbBMrfQglu9Fc40tLDByazSv91qtvHsX8LENsZRQUQRIIiVWioubn9dkeooU41UEPDce9QcwzuMhk7gICvoX+p1opa0QnOPJFBN5TRZzuEr5uAK5NOh1g62w9wQwj3fsx9xWlAQdCK5qxcy6Yn6PhUDMITgzcL/mB6qRNdljTG46xubnYGwB39PpFeXVg5o4pZFsfO0emvd7+TOjKbMWeGymBj7TkYu08mUobSFAhqoRWFMLd2sVWlcTILv6TTM+/R91beqGgwzzSMZjSHosGdMWT8HS/HlIL1yMxzMfMyUKSjQMdPvgIaBdLS44mxwmZUVmvX1DD1o3daB+qAEdmzrpGWtNgqOnhT5G1YjDQbj7vfDS03hXVOGjr8K5WDfJFDduXTENrG/eCo/+Cw9v0hDOcMfPcGLiBX5e2b6XTXxEPX1lxuVDtJS4+Msvd/7M79LAp8s4c/YUvj3z5V8HIB9c/Q98dfEGvvn2FGq761HcWGZ++Z1r20zXxJKVpPnVLoRI6Yry9tDkbX1mI3Y8vRH9vDt1be3A+j2rsOGpVVizcxDb921BC8Exv67SjDOLzstAgiUHCbnhlZQbZhH1up1EXzKpOOw9JhRr7EApplPqTFDrHT6eWFGKaTq5oowaR/aYUGHHBIJkrNWCSAJMQcL4cpXRFuFei9WsiCKlo7joI5yIIZuMo5RKotmOI4skuQgG+pjJYg6a9vEEiGIq8U4yjVJZvGQWZxmmVVci1U0ZVlHMny3GQz43TW4bPAE3yqrLzdzEmRmzUcjNHFjfhYdqyDKuPIwtyTYAGW2V58g0o9cUOY8gMCLIFmM1MJRSM5K/j4i8bNyfTXlFgNxjoSSzLEN6yIP21QO8+5fQFKfD0VdBH0cwrA3AT6kkGdS9uQN9/DMHtw5g1RMrkFOZCwvZIsudhaXF8/n3s6DEm8+/WxEqNa+xmf9/zQ6CuZSyrQRFlF5VvTWoHQqia1sfPWcrGtc0mdPJqtW1cA66Kcca0bK504zgbt7UQikWMMfLJ8kg8hFihtu/3DDDbu7WgYgFxAZ3vcbdDF8FDO+a9Z9+umZSUAQYgeNuRq9AZUp2L6vR3Hc4e/HUXwkg/8BnZy7gi2++grfdj1L+MuupTZvXN6KNv5Tq4RojrTo3hbD2ieXYvmcdXnh+D158YRf2UI5teXoddr24Hc+89TR2vvQE+nesQ2ZDDcEhFsgzHc9jaFLjcrORwo09kUAYX5iP1CIyhrwH17hCjU0mQCijJpcRGKVqxuA07XrGlZUgiSBKoQdJKeUqLzWZu9HFlFE2m/EeY7kEjFEWMkg+NyvlVBzlVVypHePJIGKKFHqPJIJlrL6DLDSOK8mpmhEyTaWDG5wAIjhSnKWmo8k4XpMdJUjl6zMorwqbGtGxup9ypQP5VaWYueQxLMxbAl+PH1mdVUgkQEYX0XzTfzxATzFa06U0Bz0/y8Q/xByKfwgsYyWvstJxX9Yy3MP37uHnR1FmZTaQJTZoEE6diWJ7l/swsLkP3es6ePPyIzgQMvMEW7ShN3Sgif9H8woXwNtdSabwoKQuHyGa+8ByjVOrNrMmg6v4XTTuyjpuIANWtalG3YKavlq0jbSjTd5jUztZKmTKGEo7KxDa1kQJ14LGtQ0Ibq43/qVtpAOffBHOxTJZvLdvGp+h0WmXueHDRv2aadqgqHk4cHjJzKpRfERGXQwhjyJACCCSWUp+vHXrOsEWblOq4TtafxmAfHL1N1y8eh3fnf4Wvo465Nba4O3zknKb0E/NqsDglt0rsfUpSqe9G7D3yU14+fkncOCt5/DSC7uxYd8IGmjEy/tasKDWhRlO9YTKQzw9h+RTdEYan1sJAhrzfAsmc7NPIDimlBQbyaWxAgKMDHoqV7Kec/M/TOYQQHR6laju6jZVHhYjWUFBAuRBgmo0fcd9eVZq+ULDFpEESVQhP0NJFUOPEkdzLgbRiqdhVywjniykYiqlw6fwGqsGcpRQqhNJVKMHpb3w+URT115Cxio3TSCmUn4VtDYjp7Ee6TUeLCuzIM9uQWNfA1o39mNmoJz+IxOj8mnMueE1zTaSoBCT3Eu5NYbX0VpilJxMPJBOj0IGMRLLIlmWhsddhXD3elHJzdy5rhfN69oJSN6shhrRONiI9rUdaB1RY+sgGSDATV1vupo0rVYqiiSgD1U9HtNkTpHvyi4qgEAJHzspeVdjx3PPo2toBeblzoe7wWlyuNo2kilGmlG7ug7WYDFVgwtl3Xa0bGlG8+pG/ttaCTL+OQTU0RPHoYE32vzhVqJKKbkZllmUUgLD2XM/mPclrXQcrH5YFwmi23/GN5TZq1p2MYw8iQkc0qf88otGIlwzhl7Hwn8ZgHxGgFy6chWnz5xG23A78vwlcHZ40Txcj7b1IYw8MUjG2ErG2I7nntmGfXs349UXd+HA/udx9OPjCG4cQmyhhlVmmHEAmp+h49xobo44boSY7CxMpAQywKBXGJdvRbKFRt1iQUpeHhmlyLCJgocpBIcAMoGgmEz5NN5ejlSdLBFI8QRRYiHZgd5DCYpR/L6xxcUERwFiS3S3p/QiYGJt3NQEgpo1JDtdZqW49NyFhAo1caC3IEjGUXZNkAdxhCsNY2nIE7mSNfqAoEhVKr4Bh52Sy216bD1aVYnHfZXICnFz9reiso3eoL8JdfQGrpWtBJ6FDCYGWWYm2Y6l/xijsc9ZKrHllSC4P0ejENIQkalZ6enmVOs+Aup+rom2HORXlxIgXpPy4emvhrPFjZruWoQ6g2hZ1YwO3smVZVvR5jb16KG1jaaBQ3BDDeq3KsjXYnK3lP4+I+0xzC9chPoBP3Y//xQOHD2KzqEBLCJA1IXGSQAp87eRSkF5XkUNJZhVsAD5gULUjdSZHLqm1Uq7b4G9w4NDxw+bE6wfKZVu0oPc+vG6ydT9iZv+xi2NE5fcuowbN8UU1/8M/oWPeU0yI0Gi4Ti///6b8S0y63c7Kip9Xp/Tka8++9cByPU/cPXmLRqj71C/nHdIatSSFg/8K3RHCqCVv7yR7QPY98QavP7ibrzywh4ChQzyzus4/PlJlPZ3U2dzQ2RSSuVqcKVGHqchKk8TmHIJEoInixIrKwuTucEn0kinCCAEyoQiyS0CozDMGsq9mlRRhgmUURN0alWsfrwVBEqpeTyTG3QKN3gCpZXqPtTjKoqsoXhIvCLrBUWUNAXm6Hc8QZLqriQYaPDJIBOrvIghoB6q8pkuJ3GUWoqpJKvTIoGQoGYPYg/KrccC1QREuCvjQ5VkDxr2GZUuTFXQ0u3AXLLbIp8TywIeTHcVk+1KMZcMEl2WTXAsxQO5ZIw8GnQz7nkx2WQZn6fjAfNYR8DLEJFBUGQuMzUif+f7AslEWy7SHerOXmkqAAtbHChsVLpJG3rWDKBv+yD6dqwwg3Cq+n1k7iZ0busxY7AbtgQR2h6iRGunBGvFMjtvUlMTkfLoJHgbqrH96X3Y+fxecwDw6NJHMd+6AM5WNxmoGh7+eWXtduTVWjEnby4WOhbDucplEieDPRpRQUCSmY5/chw//6Kj2AsGBLrji0GU0n7rthq/3TAZvNrsYoGLFy6YxtS/3lFqyS3zWSUq/uMf/zDy6m51ockCNqdgYhgdF/+LA4VqX6q2o0cv/Wp6+17gX/TLb7+Gr7cBjg7esfpVueYyZk4z7/p419qxewhvvPE0PvjwMD7+/COc/PZLHDj5GWw9nZQSGXhQgTHeKZWxGkOdrVSS6NwsxNOMxmQSONwQiTnZZhkWsZI9KJuSyCQaUDPZTnNMwzyR13EaWqMl/0E5lVpRbkYSjOMGj88XmxRS4+fQgxQhplSNGsoRKzahSR9bUIhxlFNJBE0qGWJabS0eqq2mB5Fxr8AkbyWlk5OyS8/LTWugRIIyWQcEXjcernITEGpVascUgmO6j8AgOPT6IwTGox4XJvHPTLBZEFespnfhLi2xBEdUaVaYQbKX8O+nqVJLTMBQw3I0zFPLtB5dtAD3LVqI+wiUewmYv6nSsCATmQEf/L2NKG9y43GyUXJRBrIbKuHvqUfTymaCodUEC9U3q74vhB7Ko76tvZRPbVixux8tI2SPNZRjI42o6HQilwY+qyILq9atwPZn9mIbJbGbrGH1F6Kiw2GKpBxkotqVdcivL8RixxIU8aoWQfZeh8kC9vcQiPQ9jnY3Pjh5wkgn1W38ePu66YSoflY3yRbf0zdcvnoWd379yRzXmtLca1fMiZd8i4y6pJXqQP744w8DCsVElC7/XzXqZpCOkh3/xQAJr//E8Ys/4+inJ3Hq1Ff47MuTaF/Xg8717ajlXcPe4kVBqAKda9oxsmslnnpmCz6jSfvi3Gl8evYMPqSpf+uTT1E22I/IHPWhXYKx2Rook26mu0Zl06DSiOqIN0EnVzToqWSK+CwyC2WXjnsTrbk07pJcVjKJ6kKKkEBWieJnE8kS48gkUWSbsVwxfD0iL5d34GxEWvMJhjxuSBvGEFxxKpISeMg6USVqWWr/syeWjnnJINzYKdzYCZRh4z1iFtWsOzCJj3Uqpq6LKsR6pMaHqfz8FAJnMj1HisqCySIP+zyYqToVfq/k4sP6WTWGKLbwZwmUCv5dCJAIG4055aaydh/IDHdVvE9j1rhGExxmTqHmhSzTkE96lcw0Y9rvyVnKm0wa0jzlWLV5AxpW9WBCcQ5vBmloWN2N5v4WFAfL4FvhNXKouoNeo9OH9s1NqN8SMFHwnu39CGwMmrHazevki5qxfHcfanmTW7VtHTY+sdOMpQiuC5msiPrhAEpD9CdNDtNzIN2VjgJ/Ho1/gBLbzvccyPcUYknRIqTZ08wIvffeP/ynv/gJ18ggP/96FXf+uE7/cZ0S6wJZ5BJu3yGz3NI454tkBY0lDxty5WmZ7u23VIb7y585WRf/TIGXHBPDhKPr8jJ/CYAcu/IHDn1+Ch9+fQqfnPoWbx7Zj6OffYh3PzyK1w8fwJpd6zG4iSZ9zyq8sf8lfPTVF/iQn3vviy/w7scf460PP0LJYC83tQXR9B0RBEQMGSOB7BBFWaWl0ysBIpXSarIkk1JN6D0mKc5B8668qynlqh6kvJGsIjAEkmTepeO5GQWWSBrxMWSMB/g9D/Iaz/d0ipWgz5g6dF1VgETfQQk0hVIslu/Lp6g+3bAHN/V4XqdUV2E8QZBqAOIycZZxbjJFtRczJOEEAk2WKi82FYzj7SWmWGsKP6OUe0nAKQKPXqdPiS8lQMpzaPZzEVmUTXBouA4lVRZZRMygJnFZGoGgyLr8B9cyvrZEswsJktywQc+pr+UGHuLdfAD5zUHkUBbN9ZUi2E+j3t8AV5eXzF5DYy2DXoua4RoaafqHrQ2mzWjf9uVYs2/EFFR5BymRh/xoJVg0Vap7I/8Pn9yFoW0bjGxuWN9guppU6fSL36v4iG95NerX1/E7CcDBGtMFpaypFKXBQhPVdzU78T4lltjAVAj+dBU//XIFPxEQ6oR448eLpm3o9VvncP7St+ZUSlIrfIyr496b+Jle5acfb5i5NmZOCFlD8ZJwq6BwyrwZ73bhXwwQSSwDkKv/wKHT1wyTHDt3C0c//xLHufmP8arHhz75CM+8/jSefWUPPvj0I3zw53sHPvoY73K9TYC4hlZQCtkop3IQTb8Ryzt8bAZ9R1oaYmlEJ+hIl5JKaxzv+imSVFypNOPjaL6nUh7N5MbVqLPxXMk29cRSgwYHYiinxuZZMNYq6WSl38hHFAEWSbOvwTbRelykjF7FPuymmEpltync9LrqxEoMIoAon2o8AaFyXfmOCZVOTPa6MJEbP4ksMYE+Qw2uxRzyGqlqQqdAoaZQ0ZukqgSY7wkg8iQJpWIudWnRDBEL/2460s0ku/FqOr8TELlKM0kzhj3CjINeQhbUbMMcAxId9ZouJ2SPBWQpS0M9JZv+/Vak1Xow11UAb5MfdW1+BHvrUTMQMMa5doUPAW7mzl0d6NzcYYbcBFc2YPkOAawOrk4XmacBbWtbTTxLqfFrdm3GpmeeoafswMCOXtgbKkw9iD6rU6ogP9+9qx1d25pNx3gVaMl7tO5oNM2zmzc24cTnJ0zkXMmIt24LDPQZV77Hles/mPwsPb90RSPZvjGJiEphD1ca3sTvf9zBDSU4XlFF4XUa9Tvm9EpMYo6Gr6uS8JYx7wLMvxQg/+s6buYZhmeOHPrsa7x59H288+GnOPiBQPAp3j7xPg5xffDFlzjx5Tc4evIrHDih9z7BO3zduWIA8QUWxFoV/MunnKIuz87FeG5qMYfWOL6XnJODFEqkCQTFlD+PeieVajSa3dyZx2tDc+PHFWrUQTmSeBePlt8gaGLpPyIJkAh+TwJll+RWHL9DMz5MLXoJ5VpFKeLpI2LpYcZXuskkTj4vN90VVaIrZpngcRoQJah8lx5jYqUkVwVNuiLmfF2dVAiYSS67AYQBBqWXjnxTnaVGVk0Qm/B9NZ5IKLYiUcs04c5FjC0b8fQlUQW8QVjDK1JzRCRBJa/IJAJIhMa3pS3F/WlqA5RuGCTKwpsLlzJ/1QV+VIZGuc1BtoKRrfVo6WsxR751K4NoVC3I+ja00Xv0bu5BD1fjADf4hi6yRqupNOzZ1o0BmvoOHQsP16FpTYsZzdDA99Y8swod/HnNu/cNVqNtsxhoBdp3d2HwqQG0rG1GB1/r3dmFjt2taNjWiIZNTfjs20+MMVdp7M0fL1FmXTBNFsLsofqOs+ES2h++NVm6SlqUHJOv+O3XX3GdnuQapdf1a5fIFNfIIGSjOz8aFlFk/fz5c2ac28mTJ/86ALm7jl36De+d/IYA+QD7j3+INw4fx1u8HiBQXn/vGA4e/wiHP/2C4PkMb/O1Ax98hAPvH0f9ujVIIEAi6TkSKJ1S6A8mFBSFj3HlHdLIItzo4ywCSA6SyDATCQ6lmiSTXSapKIobO1X5UgRHTL46vJdwk1kRV8TNL1+ijiX0GHotWp/hNUGvU0bFaCKUzUqTTCCVhwunJvkUIXeYx/IfE31eU3GYrLgKl452k3WUK5Aoeu5Ro7kSc5KlUQmpiodoVBsfq1hLPX/1mmSWOWkzsstmWqYmyqzbNOvESnDk/jdAyCZRFq0sjM0Jg0RNqxU8fCB9iZmhrlytv9OTqNvi3zUvRCdaNPH/Z9o8/C19DqLzFqGkpQY9y/vQ20+mWNmG1tU04UN16N3Wwc3fit5Nfehc14mm5U1YPtKDIRVJUWY1b1ICIk395jZ07Gw1WbwamVCzohZdO9qxdu8wmvjzKpBqWNuEnpFeBFaHDAB1QrZ69yr0PNllJFfVkA9FzQ68f/KoYYqfaM6vExwXLn2HK5d/wLUb53HjJzWuPmuAoZQS5V6JEQSQcIug8PXSRbUp/cF0g1cfXtOf99JFM7Xq0KFDePXVV/D666/9FQCimSL/PVfkGBnk7Y++MMxx5JMvCIJPsP8YAfL+RwYgrx46hreOncABvnaIIHnz6Am89M5h9Gzdikm8yydxY0elZyCRhjwll56EwIjl87iMdEzMl8yyYDwN+3gBgHIslRt9Ajd4irwEgZJQVBQGCBkmDAKyQilBoyNdMoZ5n99jYiIEmDxJLK+KqsdS4iVx844TQyj9nWyRQJkURzZJIEhSq9xI5F0/0Sk/4kAqpdU45VvxKgZJdJdRjlGmqfG1x04/4qE/qTAGfaK6rTjUeNtm2qGqRNgstSpSdxa7gEpms+UZoMQU5RiAxBVQahblGhaJK8wzkfVRlFOjyRhhgCzEvcsW4/6sNNzD1/8tQz17CZSMxfg/0ucRMPPohSzopITt7+lE20AL/IPqeFKLOm5Y/4gf7SMNJk6hLN/GoWaECJ62DW1mFEI7V58qC3f3h4FERmnd0IyWNc1kjBa0cNWtkx9RW6EuDO1cjfI6J+bmL0Z5u8Zza5BoM+zddiywL8M8WwaOfnIId36/RSMeBoik1dWrattzluA4A9WIKIAYTmQUQ4QzdSWj5C1kyL/++qs/5xh+bwqovvvuW3z55Rf47DOqloP78fzzz+LAwbf+NQDR0e7xa/9OMPxGxvgFx6/8juM3wiA5evE3vH78YwOANw+/T8P+AeXVJwYwb/HxAb4nwLx55ARNPFnk/Y/x4sHD6Nq8DYurazG1hBKHmzYmMxNJBEhCVg5XFhK5HpYJVzCw0EqG4Wai3DKnWjZNmC02wb9oPo8h6yQo2KdERGsBpYwnDBYlNur4lwwxTsmM5oSp1EivJNO0wW4k1GSa7KnVPkyu8ZlTKy2dVk2uqSIgXJhQ5SE43KbJQ7KkFIGTSqDEERxaCQ6yEH3FeI1QqHJius9tRiqkal6Jw2YkVqoye/k5zVRX5/mUMit9E/9NRcowJkgIEA3GieGKtYlNckwmr7q5qzZEIHmQRv3epYtxz9JFBE4m/m2ZWGQxAULAZC/Gv2XNN5ItrbEKgW7e/fua0DnSgdZVTajrqoGz34G6zQF07m6Hn/JJfavUZKFhdbNpEdS6vQUDe8gm+wYNQNq3tJscrsBwLdzLK+FZUYngxjp0byErbQhH0jso0+wBgiF3Lqp7KpHjyUFerQXT0x/BxIUPY2FZFt4+vt90d79x6zLOXviOIDlPsy6muIYb19SPV2xwweRanb8QLoQSMGTUJaHCoxAuGUMuNjGNHnhVuW64ZekP+PzLj/Dqay//awCicdCHz9/AOzTaR85eN7Lq7nt6vP/Dk3iNTPEGAbL/2EfmKsAc4GOt1949at7fTyY5SIC8/M4ROLp6kV5Xh4ncyNEGHLkERjalVRqSKKlSi6yYzI0cPsEKp5skUXolyrDbVJNeQllFI05/Ekt2SFSVIFe8UkXoM3QaFWfTRuRzAUkZvJRYsbyLx/PuHkP2iFVzOW5+s+g/Urj5U7jxk+kxEskEsfQnMZRGag00kWAZX+UyjJKsJg+GQdQyiOAgKyTQW8hv6IRKS/JKneMnyoOoBSpZZZLxI8VmLFxKhQb+EPwugpXXJHWPtGsYEI27LQdjC7PDqe6qLsxUd5PwUM/7CI4HMpQWn457KLH+LX0+/q9ls3FvzkKM4l18TM4CxBFU9b1taOlvRi3ZQ0e4nSPtCI2E4N9A476+Hs1rQ3B3exDke107uo2UatQg0FUaud2B3h1dJhLesaUNTeuDZkComsn5N9egfn0jgvxs6yb6jSf64VtVB29XFUpbSzEnbx7GP5qKlMcmInXBDDxWuNgARC1CxRY/nDuFK9fO4ha9yC+/3sCvv9/mhg/35w3XfxAcP6qjyWXDFPIZOrUSEGTCFQNRtq/S4yWxzPi2axdN1/ivTv2LPIgY5L3vzuPdU2dw/L/GRv83g7xy+ARePvieYYuDlFivvnMUb7x3HK9LXpFFJLX0/KDY5OiHeGH/eyhtbjcnVkmWXDykREB5DzJJIj1JaoECgrmYSg8xWflWBYqFcDNpvDI/pxOrSZr6xNcEhBT6kFgyiAASQ/8RW1Rsjnoj+N2x6r1LFpI/SaVUijctRstNF3fVbowngyTJPBMYUapedKq2o8xk6Mbxc6rzkAxL4WdT+JqSExP1mXIN11HSI30NJVQyARenFP0SDfgpMCZcHVhM6olTGcU2041eAJmooUAOfkZd6506KMhHijM8eDS2JMe0GB1rzTCVhUpQVIbBWGs6WSUTD/LxvTTpMuX3yphnL0RE4RKCPgORJUuQUpKO4oAPofYGtJNBGmjMFcOo2xgwZQeaVd+wrgGda/jeKr+JgTRSLg2QMRRIbF7eQFnVb4J8mjHSs60TvWISyi3PcjdqR2oJEAJlWPNEaP51fLxK3oZGf1sLJs+bhgmPpGLCnKmYkPYYFlRk4K33Xse589+YsWtX6TvMyLQflXJCM06QXL56xhzpKplRR8Ha+ALH3RhIuJjq6n/FRTQ64UcdF9P067GYRUNAv/n2i/95gBy/pqXTqt/M+t/fF4O8cfwTvEYAvEKmeOuojDpBcSgstyStBI433yO7HPmQTHIcz735Luzt3YjOyDARcp1QTeLmV925jneTacwn2goMgyhIqByseLJKHCVWTDY/X1yKhxxOwxwx+QWIojQLe49yrlJqe0XSw4ZdANJoA21oI7HkKWiix6nRQ40KoRyGFSbQoMuIx7uUQvLnc4JHkmo8H+t1gSVG7EMW0kz0KLJcdBGZTd6CryeR6RKLC8xJlXoIa6U6yR78MxQ81OCfSZ4yPOSlTPPoBMyGcW7KRa4UVxGBUoC4cvowmvZoSq4IMoikVnwZn9t0HJyB++lD7lmyyBj3UblLEFGwBLH2dHqhdCSXp+NRVx6yPaVoW9mOtsFmdK/vQ3BVCK5eN2wNxXD2OEy2dWiwBnV9lShrLYG7w4kAN3kzgdLIzd9BCRUgYwRWEgRklAClWGW/16SR1G+uh2fASwZqQYggU2zF3ekynVI0NXc8mSNxxjhMWvAwHrOqp28mXj3wgumhq6zbW7cvmhiIxqWp+fS1GxdxlqyieYOSTYqQa4V7ZoUzeM3wHCOpwoVTkls3bl7Cz3fUU+uKSWQUQC5c+le1HhVA/jdzfncJIAdOnCQIPjCbXxJLRv3Vd4/Rk4SB8srBI3iD1wMEj9bLB46gor0Hsdk0ojrS5cZPIFDGc0MLLEl52YZFBA6dWiXRf8SRDZReEkfPMc5GY0wQxBZQNpmAIAGSX8RVSMYgyxQpUGennleBlHKswkFBSagJNNhKMnyoRnUdDkTZixGtzouUTOPpLfQ4lnf8RJl3fjaZr8e47YilRIoulzQrNvETjUwYbcnmBqaPIFjUaSWpSKdTvMqUkzmSxSDqRO8qxVSvAo5iLwLHRVbhJk42ACnB+EqyW6WeEyQOfpdSUAiSSBp2ZfOadJSiDIzOC8ut+9IW4z56j9EFiykTycKuTDKQOr+nY2pZGqYULYazy4d2dTfkZjctRh2ZeMwyGwX+QhTXFiLXq+nCVmS4M2CpyoNTHRI3NhuppbT4gGrS1wXRQG9S3FKKgiYbyvorKNEInKEQGoeb0LZFY6b98HVXoosSbh7l1aR5kzEvfx7SyjKwhMDN8Vjw1tsvGxBcvEgvce0MTTrZ4er3OEdG0dDOC+fP4JpGsv2gWYXqbCKPEV7yIbfJFLfIOAKBmMSwxjV6lmtKdT9v/I3mHn5/9i+U7n53CSBvHf/UAORNSi2BQqwhsLz89hG8+NYhvPr2UbPe4nv7+ZlX+Lq9o8vkWyWQGVLoJZSxK4AoEDiVmy+RgFC9hwy8goiJViviFPxTRNywRh4fcxPl5SEmj3dyaz6iCRgVRUVZNSO9AkmKsOs4WMe0uvvLfxAA0Wru4CN7qOCJADGA4F0+oZIs4QmvOLcWwUEwjeHdP5KbPpLsEENWiyMrxRMUo8l0Ufw7xhZK9lFmFYenXGle4nidXtk1RJS+RJ3lfU7KOP593MUGBOM9xQYYyW5dyZzecr7G505N7bWaUy01iBudT+awpVNGyayr08liMsdSvpdGf5TB78tGEsGR5FiKKZ4MMmsaHiFoSjrsJjWkaXuTKYVWBm5ZawXyavJRyFUcyEdJqBAlDTbkVeXC4rOY/lfN68kMQ0pebCNAKM1Wy6C74SXbVKqHMtmobjCEJnoQ1bVbfPnI9lnhHfQhzb4M0xZPx+KKNFirC2ALlaCyoxLHPzxsAoAa0PnDua9w6cppMofGO3+HM99/CzVgkEwSOMITbMOFU3qsE61f7lzHj7evmJnqN25cMVnAV65p+u33NP2nudSGlAC8cuavB5CjF3/FG0c/MeB4mUzx3BvvGFCINcQe+49+xOtxA5DX3iarEEgvHzyM4uY2JObTdBMgWgLHeHmKnCxMpveIyso0p1XKs0rkho8lGEanU5MTLGrEEKsIOYEVT1BE6RSLxnycWIPPY3SiVUwD7nFhKoEwif4ihQAZyw2uOo6oMiUrFhqzHccNrHFpCZUViOJdfwzv+JH0GTF8LVb1HgRKJL3Jg/RBajaXbKcHKaHHUSylWAxlNXUaiQRInJrblVjCQ0U1p91JieURQ5RiSq0TqT51cCwlk4XBMbmWrFVN415FP1SlGhTKNBp4fYdOs8YWqNIwEw9Yl+J+i06qlphR0A9allKGpSOO+j6BK5nMkUommFaVjakVyzDPnYPS7nJ4V1ehdQeN+nAtqvpVt0EmqMtHZaOGGjnhCJWipM6GbGcWpqXNxBJKNGu1Ff6V1WgkEELLAyYgWL8hgL6NnVi9eQ0qG2ppyH3o3U5jv7YNS2xL8FjW4yioKURlqAJlngJzqlXcajenZBoGevLUZyZXStLo8uXz4SKo65dw5swpE/9Q+si33377/6golLTSaZZpEUT2kJS6SqbQY3V+V+nuuYthcGiAjsChUdB/OYAcufArnt1/DM+/eQhPv3rQrBcIkBfeeg/Pvv6OkVMCzisEx0s0568cPIoXeR3YthsPq9MhQaL6j3hKreR8Mgb9RhwBM2rxYuM5orOyyTR55vqgAJKdS5mRhWiL2CSXICFQyC7xNhVFaVqtm5tXNRrl5mRqWk2VybHSSGd5j0RKpUQySiyZI6qcconAiXWXI4pAGe2gbCJIRvNxBEEiFok1zFNsMnfjCTqB0wDEROUVcCRAC8RauYhTcwmNhpMJJxBSa3VUbMfMgBPzGryYEXRhflMlHuM11acKRd4AqgigKoKEDDLZq7SXsMRSxq+qCsdYMvCgmXy7APdrHAKl1SiCJY4SJsGRQXbMwjheJ7l5Y3HyeeEiTLQuwBTrQtjaylG9uhrlzeXIrS5Ejq8IriY3rJW5KKHMKvRx1ZViRvpjSHxkPB63zMXCokUoDObDzp/19PvgG6JXWR9EaHUQHSs60NbdjOpePzp3daF9ayfcbS7YQ8Xo3dSOymYXPA12NA3WU6IFaeqrUNHtNiW3SjTUaZS6kOhESo3iFPSTt1BsQzUe4ePb8CQpxUQEjvMXfzDSSmkqP5m5IDfx8y8/msDj5etnCRCxCBmEEu7yX3E+yJELd/D0m0ew96W3CY638eSLb+Gpl/bj6VcOGoC8uP+IAcZLZA2xx4HDH+LFN98xRTjPHHgRlrZmmm7e/XnnT6RsiiZQlNGra4xOoRT/ECvk5GFMeiblVN6fplz+Ix+jCKJImXVbmDXUckdFUKo5T1FnE7fYQ3UfillwI5JRYrXhZdjJEpECCkEQoSPbWg/GkklGV5Qgkq8l6OfkO8Ri6gavJEj6Gj3WAUG0fEe5qgeVpyV/oVHR/G4fGaHeg8yuEIqXt2BRexXKhlvQtGs1OretgW1lE9LafZgfcuDhWjum1jkwtcZB2ae/r6Lv/P5iC8YU5dLoWzHfno3J3PBjcpbiQfoQZf9KXiXYyR5cKZRUD3kIEDJJTM5cpNALxHHTzypdirn2pXiYoJlesAg2Mkj3+m6U+0tR015pJJXM90KygBhkxrKZyLVnorSlGMH1tWhc10iJFSQT+FCzphZN9CbB3hD8/YqFdKN/53I06OiY7zVub0EmfY4G+QQHA3C3exDUCLdBPz47dRK///47QXLHgETmW15CbKFBnKdOnTJxD4FHkXQd95p1+QJ+Us3ILaW13zQp8zoCVg9fReXDs9Ev4cJlSrPr5/j8yl8RIL8SIEex85k38NTLb2PfK28TIAfwzGvv4FkuMckrlFdaOsl6Wyde7xzFwWMncPzz99E4sgbTlRxIFojJoCHlhldRUJSkFCXXmExuBgJHKzIn1yw1Y0gqLTFdErVhlYQYQcmlTZ/slFRxmYlRMWWl4bu/XXXjalRdak6iwjKrGBFlNjxgp7+glIqkR4j0ViDCWUZDbqfscnKz25EoH6M2pYqwK7Wef9f4UnVo5M8VyUwTMGQixVaSyTqxdoKdcim9O8gNtApr96xB44YudGzowUqlYexaieZNfWhd1YXm4W6sfmIrLF1NmFtfTaZTur1yxcggpWTI0jxMrSpG2YAP83jHj7CkmQKqGJsaxlHWcTPHcHNH5S9AUvFiTLbTf5BZJlvmY1LOHIzPmIVxWXMwk6Y9u8qKqh4fOobb4O/0ok5d4IdpwjeGzPgEV7+HYFqE7Jo8WBoLUDNEk7+hhYbcD3evE+5BD0Ibm+DrVffFOpMJrBHSjVsImk30LNs6UdsXRFpFjunLWzMYNNWNLZu7cOLzj83JlFji7hJrKACoY1sBxaS0/3gL1ymlxAQXL/1ASXXeeA8B5NYtzQ6R1FKnk0sm6Hj52ll88+1XBiAm8EjA/OUAcuiHn7Hz+YMY2f0Ctj31CgHyDva+LKkloOynJ3k3LKsIFPkQnWaFJRdZZ//r/MX3YTq9g+RVdFYWIrMpqxT8oxkfpzQRSq5YS5hFogie0fxMisppKXHkNRT3iCwI13ZM9qoSMDyIcwzfVwJiNIGk7iXKqRrDzTyGoBhrwFGMUfQWD9CPjCEoogiQuCoHxpBRZMzFHgLWeMpApblHFyt1pcikoESXqoak1DSHi6WXUVwkmj+nE6/FDQF4VnSjiYDo39zDO3YH+rf2Ys3OlVi5RX2JB9G7uhsrVvdi5eoB7N77FLo2bUDlij48XKOUF0X51f2R5t+eh5nVNuTTM8zxkjWt6RhrJTBo0Ge5FGS0EJyZBO4i/p7m8yYyB5MLCI68uRhPXzAxdy5SueaWpSGXJtzV5kaoPwSrV80XqhEcaiB4W3mT4sZfUY2KLofxLiqaatBckXU07ASDf1UtvYgPLVvasHzvIH1Nq6k9rxuqQx1ZRrMMg8MhtG3p5GsB1Kz2G2nlW15rSns//PKj/+XYNjzu+a7XCKe1hydJhaPi50xk/NJVSq6fLobXratkEoLo9lUTZNRE2+s3dHL1Pb78+jPTE0sJkNdv/gU9yDtnfsLwjuexcsOTWLf9Wex4+g3seWG/YY99BMqTL7xJiXWYiwZekov+5PX3jptTrqaNI3iMPmESmSBVYCAwYriiuCIzMzEmSxms2aYa0FQFWqwmr0pRc23WeJl1yh1JIGXv6m6v52NLbKY8NpZAiuTzCNV4cDM/yOsYXkcTLKO5wSMJArHHWLdGHtgR5Qm38Ym1hyPo4STGcLOGCP4Zpo2ox4l4/rzejxKLlAp8/Dy9zaz6WgxsH8GTrzxDthhC7wiZY207Vu1agZVbl2Ng43Ks2LASwxtXYsVQLwZ4c1i9YgDrRtajf9s6sogXE+lddML1EP3JDHqGWT4rskL5WFJloV8jc9C4P+6wYk4lAeLJo3wko5amERQLMHbJTERnPoZU6zwkZjzG1+YZ9phbugwZVTmmXqOHwHW3u1E7VI0qZeRSKtWvaaDXkBknUFb5ULu6FnUETOPKAM26egy00pT3ok/N58g6XU90o31nJ0IEVuv2HjRv6ED1QK0ZmtO4vgXdO3pM/yxlDmtO+7GPj+KKSRNRfUe4dvxuMzjlXKn5mxkFfe0i2eB7cxQs0/3jz5fMuk2/obR31bRfFniu/EAmuWgi82fOf2PGKtz8szH2XxAgt7F+96sYXLcHK0eexKYnXsb2va8ZFnny+Tfx3Gvv0qiLQQ7TjxAoOu499pG5Nq7fhMervEhSlq1YgjIrkWwQIWAQIPcvSzPGPJaeI7mw2ORbKSCoRMSxFnkABd8IgkJJHY1xrjCdEGMrlAJCBqD/ULueKLsmQmneoA2jdeUGf6CsBNEEZyzXGHoIgeaBchse5IaP4IoiAKLtasqgo2DVjZcSPPxudTQpVbCwmK+VGLaJFeNUuZHd3YqtzzxBRt2N4Z3DWPPkSvTvIFs8MUCQDKB3C1llSx+Gtq7AwHAvgm0NqA3VoK2LLLNuFXK7Angk6MSM2nLMC9qxwFuAzLp8FHeXobDVzd9BLm8UFsz32jDdlUdJmW0AMqU4HZOX0GjPmYpkyqrxZJCUtEcxJXsOFpA95pBhsgkwjSdYtWOlqQps3aqeVm1hBlnTgnqNa1vXRBB5ea1H3Ro/mvha27pm9O3oMyW7iqmoS/yKvcvR++QA2p/op1kfRPPWNnRt0xCdNoTWN6N9TycCI/WoXuUnCGvx0RcnzEAcHeeqk4nWRZNWEp54a8azXb9iGEBscPXGWTMD5Odfr+Hn366ZyPudX38OVyRev2wSHn+8LZl1xRzv3rotdtF3/w8B5NjV/8Qh1Xlc+p2P/z0cJLz2Hzh+9T9w5Oo/+Pw//qse5F0DkNcwuH4vVm7chzVbnjEA2bHvNeymL3n+9UN42TDIYfqRd8PxkKMfYeOzL2N2pbqcdxIkHiQWih0sRl6NztJpVRZBko2xOsXKL0CSeuaSPcbQi4yhUY8gaCJVO3I376pcgTb5Bhp0zTp36pjWhUj1ziUAIrjJHyR4RvN5dFUl/YYHkQRQBEE1xk2z7qI5NzEPMgsZRPPOx5RpeKdGP2tEG2UUl+pFVM+uoOFYrkj6niT+/cf5PFjQGsKap3dh66v8PTy7k3KqzxQQreAmWrtvHXq39REk/Vi1bSVWbxxCU08rqptqUNVcR9nVD8fyZswKObGwyYOKDj/SyvOQ4chBcHUzyvoDJl1lEj1KesCORz30KeXZiLYtwxTrYszMnI3Myhw8lj8fyTTb49OmY6EzHUXNpSgIFKE4UIq6AT96N3XD1e5AcE0AXTu60MQ7vuRRJ4Hs7K3kn+VHw4YGgqHVlFH3bBYweNVnt4shmgiIDrQ91UOALKcK6IKru4p/Xy8swWJULK+Eg9+T6S9EVm0BCuvt+PK7L/DrHze5ia+ZuvHffv/Z9LpSyro5teL12k3JqUvGV5h6kctn8fOd6/jlV/mSi6YSUT8rP6I0E0mvn35WqslFehWCheyhk65/PkCu/Sfe/OFH7Pn0ezz52Q949bur2H/2Nvaf+wlv/HATz355Hocu/oq3z9/Ba2du4JUvL2FghJJi49MY4nXF+iexgZJr3bZnDEieI0BefDMcF3mVvuOtIyfw+qEPqFEHMJmbebrDyeXArMpKzHQ6MSYtnayh2vTc8CJIUugzEskckVk5lF95BiiRXMnKq+JdXo2jY3h3H8sNHVtRgZSqKozSxhY70N+MKafcoj9J9NdiLEEUQRM/ihv9QUqsaLd8Rxnu52YfTR8Rwe/Rc0mxCLJKlKSavl91J6YfloCieYZkFUqzSKWuiIkIxjmhIBzDK5BH6bRseScaN61AoJ8afqAOrRvb4GyvQnVvHQY20Y+MrMWKYUmv1ahf0Qpfdx0q+hrxeNCB3BYvajvqsbAoHVnufCyuK8NUZxFiC/MQb7NgQXUFHvfqEII3j5J0AmQBZpE1PJ0uZHlzMSPrUSx2ZcDRpxkeikUEkVdVgGB/E/+8FWjf2GJOnpq3taJppJGP/Wjc2ojmnU1o2dSMwNoAguuDZkx1y0grBgiGrp3taNqqdkFNqF0XQsuebv58GDzdW/voVVpQ3uJEuisTyyoyMLd8CRa40pHmtODTrz7GnT/UA+u6Acdvv982TKAOJpJbmip1489CqvNkjguXJbEElPMEApnlVlg+CRAy46ojuX7rgnn/yjWlmJwx7KNYyz8dIGKGF7+9YtbB8z9j24df46nPz+KFby7z8VfYcOxTvHzqCvZ9cRZrj3yMjYc+QtPKHWjr34bulbsIkqexfvvz2PzEi3jqxQP0IG8RIO/ircPv4+Cxj/H2+58YeZVR30hJRZmUrRY/ecgM1iMwtArT7NT7AkJOLq/ZiOVndKwbrc4jmVkYlan0DqWyq1VPvjmpkhmPJDhG8/FYbuSI0nJKqHIzeFMTajU1KoYAHEtgRLjdeJAgeUDs4f1TYhEU95M9IrjhR+t7CIAoh9JLHIjj58Qe8QSeJlGp2lCAjNOwTw9ZSjUjtT7E+avNSLaJDUFMpXSa2R5ETtCLWVkLkOsuMM31rN4iBAfr6QP60DM8SJk1iL713fD3aCRbPWoGuzDf74JnsAlVXVVYXJKB/GA5HnLkm9T5+DKd1uVSXvL3YsvFg/npmO4pQnqNDUs9mciuyYWl2gp3N79jlRduLjV201zCAt7NNQqhl56jdq3fNHnLDxXBQzNdvUqyKoCmzU3oownvfKIL3hWVaKTkCo00oHm7vEaT6XoSIoOou3tQsmwzGXCd2psG0TDcgnRnnmlYXTvkN53k55UtwZLSbBz98Cg39jXc0vzBX38iM0hSXTaN4fSaOrNfu65a9MuGSc5f+s4kNero9jJNu8YaKFCo9qNiIZl1HemqfFdNHr797iuyyAXznf98gFA27T/7E0FxBvs+/8EAZS/BsO/kOezl810fn8Krp69hz2ffY+T9z7Hh3Y/4n78Owfb1qO9Yj4E1ewyLbH3yVTLI69j30kHDIC/tP4T9Rz4gSOg/3jmG3FCzAUdsBpdAkp2HCYUlGF9E+UJAjLcVI9ZiQaxkFQEjaaUCqAezVS9BU6/ZG2QWdWc33RFtGmFAsAgIdnqK8goz+CahuiY8Jcrl5oZ2I9rnw9hKD8ZoLEENN3VttZk3OJYbfayXrEJmiFAKivyMGlR71KSajyvUZlSTpvhzCnAqIElpFVNdiVi/D4n1fizobkbeUA+WDLZiXmUJHs5YgLl5S1EWqEDTcDtayBRda3uR5VRDAzu9yBCGdq/AMFffhgFUDrVjSYsHjRv70D7UiWxnPiqaq7HA78Y4RyHiS8NBSWUTqGnDfVmLscCtYZ423qlzkO7OxtySxXD0OFC3icBYUwXfcA0qVxIoa2rQzDt/dV81qmnIS3rLYe9z8K5fjiJ/PpmgGf5NAW74IMFAP7ElXDXYs6uL8qsT3bu6TT/e0laX6X9WRYnmppmv1rTi4XpYa0vxmGUBHsmei1x/EZnMiqyKPGRXWHD8w2PhTU4pdbeHlTq6a9Pf+U29rS7hwsUzJunwjz9+Mce5l6/9YOTWZbUK+jE8cSqcpHgVt+9cxS/0Jj/9osm4V/GDqgxp3i9fPf/PB4ipM6fveI8e5D0VSPHxkSu/4/DlP3D4ChdfP8rX9PxdepTXvrqCxv7tqGlei1DHBpr1p7Byw1NYv+05guQV7Hz6VeM7Dhw5hoNH3zcp768c/gA5LW2I4GZ/MC0D8TTciZYCRGZkY5wSDTWCIDMHozMy6EvkTcgeZBAd60bk5SOBrJBCWaaJUWMJFo0sGF1MM05ARDnJCOXquk4wqHDKU4kYrmhNptXkKG7sSM1Ir6tFaqAOqcE6xNf4EOkjQKo1vJPMUKVRagQFGSaB4EnQyZXklfpiVfuQTIDFc8XVVCGGK4rsMaGxHqX9bWjZPAj78iYsLs5Ejj0HpTXlaFnVjv5N9B6bl8MVqsTD2fOwgN6hhbJEcZLV21bwbt2NHDJJbm8Nguva0T7MTbm6Aw3LW5DRUGV6aEUVWhCl/K88smh+DqY4NLTTicUVOSZS7uzwmD5UmnVePxLgHT6ImjXVqFlVA9/KKoSG6tE41EBf1AjPykqUEyB16zSa2ou6tfRCw9XwDtYgRJnVuKXNAKNzW4c5ttU455yaIiyx5xGE9DbtFchvroCbf19bqByTF87ApPnTMH7udERNS0XqohmYx8/l1drw4ecfmI6KpmPJdYHkR1M5KGOtqLgAoqYNNxQQNMFAnVadNa9dUrMGDce5pQg7vQpZJuxNtMJ9s27c0tzDS6bi8J8OkGPX/h0Hzt/GOxfv4AB9x6FLv+LQhV8Jkn/g7Qt3cITAOEqjfpTP36BX2X/qBoLdm+Go6TUyq3f1E+hbvYse5C5AXsE7x1UT8hb2vvYcDn/yKV4//iEKO7pNzCM2z2IkVjIBEqFIeY5S2wmIjEw8kJnJu2WuST5UCnsygZFUSt9QoqQ+l+mjG0XGiScw4sgQsbzeb9PxrceAQwM446vIEO5KjKv1kxEIFm8VTXoVEuhHkupqzN0/ssZrGCSylua9msCq9ZIZPEiorSLL+MyQzgRfJZLlY3xewzoCVYyf3x/wIzbox/Smem7MTnSRCdxtPiwqWAJXQwVKgxUor/fC11aD6u5aSo5MTFgwA7Nz58FOA7uS4Ohaz0041Iy0Vg+KVtQhRGPcs2k5NuxaC//yDvoP1bTkmV5YiYU5SBVY8vPwMF/PdRfhkZx5BIjNdLWspudw0gvUDvpQp/EHgx6UNZejst+NRs1AX+6nB2lA/cZ6VK71IbQ1RBkVoHQKmgYL/pVBBDRznYCQWZdHaSa7VK+qw5yCpfQXFjzCv/t8ewbS3FaylhWP8986cd40zFg6Aw9OSkDU9BRMS38Mi+1ZKGgsx/GTx82dX2Oa5Te02dXA+toNgeYS/cY50+XkotLfb142WbqqHTl3/rQx4XcbyKlIyswT+UU9tdTGVEVV3/K75EXCDRz+6QB5hwZ8O33Hvi/OYSuvklgv0HO8evo6dnz0DZ79+ryRWi9+fQnrj5/ESyfPw1W/EsWuNkqsdehcsYMSay927H0DT9B/7H3hdbx+8A0MbO3FyL4N+PTrL7D/w49R3N2LBKWnUzrFcSUrQ5f+IrmgCBMkmcQglFYRfG90jgqf1IihGDGl9Aqa4aHWoB6vGZU2VgM4yyrMgJsIjUAjCCbS00wM1COxuhbjauqwoKsXk+vqMc4fNCCJr6427JFAaRRTX4v4IDd7Qw1igtz4dVXc9HxcRyBwJRBISXXhzycRFIn0GgnBWsTx+bjmBkzrakMGTXWRvwKuJjV+Vl+oMgT7AijxO5BtL0Smi+a6cCkeyZxNXzIH+ZVWFNZoGqwXHevUF5cavtmF7G4fyleHUD4YRBEBtaiGUk6+g4B4MC8LqaVWTHIo5cWK6c4SLLRlYqkzy0y61cgB/0gtCjUmrb/WzEyvWxEw89GVOGgqAYdDyPdbYQkVoFjp6xvFNIqMt9KHhFBDf+Ja40MXZVbnlk7KrVb4KbtszXZMy5hLcD+MjGoL8uttmJExC6nzpmPc4w9hwuzpmEoWeSA1BomPTsAcy0JUtfvgHwzg/ZMnzBFveKqtEhCvmNoOnV4pWi5jLomkGpGrN9QS6Aec0ziDc98RQOEmDvoZdS+5eEnHwCqaOmviJufOnsGZM9/hwoWzZiT0Px0gAsKm978gSL4xAHnl9A08R4P+9JfnsP7YJ9h84nPz+pOfncbIB1/g5c8vorxuAIUVzahpHELX4E4sH96D7U+9jmdefQ/Pv3EIO/ftwPIN7XxtPdnkIA5+coIM0okUjUCjEZ/MTf4QN3gcQRGVQVbJVZp7PkanqwVOuEtJYomm01JiFdgwKl/Hug5M8JId7M4wOOwERoUmPlGOVFE+1QXNiuNnkqpqMNlfjxn1zWQVP5Kr/JjX3IaHQ0EkN1JitYSQxJVSX4PUlqABSoJeJ3jigwKPH0l8nFIfQHIogJTGICa2NGB2RwusK7tRs301yprccDe7UeSzwd3q5KLcaXCjoacFVS3VKOOdNNuRjZkZj2NOXrgJdFp5BpxtbrQON6Gd+l7TahfVl5FJ3PQibqQU5yHakoVIld7maQxbpqk/kQ950JJrKhctjW6aeh+ClFOhLUE0bdWULzIE7/ih5XUY3NaLHm72DnqI1p1q+dOOBTTPUzMfQVmXndIqQMaoI7iaDHhqNvjhpbfo3dmHFU+tQs+eXpR3ujBDkfpHJ2HKUgLEb6HvycbDix/FxMcnI2VmKhK5xs+ZgsipiZi2dCZvFkVkqjYyTy2OfXLMSCqxQHh67XmTYqLgoemJdfWM8ROKeeg4V7UeFy6dNhHzq1fVq/csLl4MdzxRia1GJ2g67g9nTuPbbz7HV1+dxNdffopjR97+5wJElYNvnrllTq9e/Z7A+PoiXjt90xz7ikmeICie5WsvfXfVAEmPn/30LAq8PWSQdlQGlqO5ewS9q3ZieNM+bNz5PJ4ii+zcu50AaUPHmhAGtvSgd/tyFLY003sUUE6pGVwxkqyFiFqWiUiCIoIriewyOi0To8kqiaoQJHPEFKqFTzGiizTKwI7YUgdiyRqj+Ty6TJNl6SOclEluMgtXTKUPcZRYKdV1mNfRg469zyKVAEl0eFHWN4DiznrYVnehYstq5A/1YkFrPQp6W7GwswGPdjXzZ1qMxIqnX0kmKASM1KYQZvd3oWrzMAIrW1Hd6UPrhlYzvdbXWm0A4qKRLae8mk9JYqsq5p20ElmOHFgr8zGRd9lZ2XOwhGyS584ji5Sgkwa+iwxS2VWFx115mEoZM6FMSZmZiLUqhT7PDPD8e2YaHqBB1xplpeQigB5vcKJhS4eRQTXDdWjYHEDHjjaCoRlDz/Rh6Ok+NG8PUU55abobTbBvfukSzClagFICRCPVjE9REwd6F+9QDawtJfDTeNevo3EfpLci4HO44R8iYzyWPxuTKaUmLZiO8bMmIXH6OIJkImZnzcIjWbPpQR7CxCXTUEKgq56koteFQx8eMqdMV/+c//HfteSXjbHWaZWOeH/5LRz3kCmXHFO/LCUtnvn+NM6e/d6A5AKXpJZOwL499SXe5w338y9O4KMTh3D40Ov/XICYdSNcPRgODur6H/hAj00Xk7uvhR/r+vKXl7HU3oiMwjq4/QNo7duC/uEnsGXPq2SO17lewsbd6xDkf4SPelj/CQFq4ZLWEKbZHZjKNbm4DHHZavmTg+iMXIxelmGOecdmS2JZKK+KjTm/nwwTSfYYk2Pla2UYQ7BEFKp1aCWm+kOId3kpr6rxIEET6fAgkcyRRHmV6K1Belcf1r30Eh6pa0BmZx/8q5bDzbt0flUeHs16HItLl2Jh4RIz0y+4vJGypwcta7uQ1RbEdHqOyfQYU9ubkLlmAKtf2YP1+4bRPBREXX81Ote2om1lCzrpJcob7Px9ZGKOdRFN6wx+91xkOnMwO3MOMkrTUEAznV9VgIpAGXIcuchzWdG3vhf969uNLHrMmcubxjLEZKebtqyRuVmILQqPYbs3IwN/T0/H37N447BZMbqU/s1pxRLKudzaIhRxU4Y2BNC2qxFNe+rRtbcZ3XtbULuhOtyRZKgOTWvVnKGZny1CTn0+pVM5KtoclF02lIdcmG1LQ9ycSaggK3Xv6kUDvdHC8jRkeKyYvPhhTM+cgYmLp1LaLcIS22LMz50LizMTFa3lcPV4zCClhy1zzL9Rg3xKOh049ukxegbVkGuu4A2Tpas0kUuXKaUuqsPiOXN0e+u2aj1+MintqhRUtaEi7uEOJ7dNjYhSUpSecunyZZwie5w8eRSffn4EJz58FydOvPc/AJD/l+ulL67wlxrAnEwPnLUDaOnZjAECZPWmp7F26z48+9pBDO0aQvUQ79o9DkorB69elLfXYp6vFlPoHyYVl2MCzXZSXgGSLNTX9B7R2Xn0Ibm4b2kGRmWp+bQF96Spx24+Ii02AkXdRioRT+YYT0aILXUipbLGsMiYcg3W5HvuarNiyt2YUFmLjJ7lmBNqha1vEF3rVsEZcsDiyuKdPA22pnxulFJ0qTvgygaU1RaiPFBCsFCCDLXyzjyI7idG0L91JQZGOtE90oS+3Z3o3aq2Oi1YVJiGhQXLMGnew5hATT59yaO8q86Fo7oEBe4CLCtaBovbgnJ/mflzy/wlBIkdNq8NwzuGyKzdKCS4ppVmYyKZIdVmofz8M6OA0mpUThbuITj+lp6Gv2Vm4D5NvlXnk+IcLArxeyjhpuc8jvKeCjJICwae7Ebbtia0bG/m79uOsl47QjTmzWSF5q0tZA0/QVKMQn8x8nwFyKMfKg05MYESKnHuRMyjr6miD6pZEeLNzIkp6bMxamoKZhcuwiJHBgqbSs1Sx/e8YAHZiExGSeVZwf/X0mVYRgm2xJONucVpOPLxe7jz+3Ujny6rA8m1cKRcLCFzrVMpsYYCfaZx9Z8jEc5f+AGnv//O5G3dLcGVzBJQxCJnTp/Cd6dP4rszJ41fOf39N389gLzw+WXMKKrD1MVlsHk60dA5glXrBY5nsWH7s9jz3GtYww1QvbwKngEfSqm5yxqd1LU+ZFDPT9bIgYJCTC1zYBKl0iRbOcbRZ8QQIONoxqOtBTTp1Nw5OupVt0QH5ZWDulyd2SmzbHYkEQBxZepnJb9Br+CjT6j0Y2JNPVK8fsqqAB4KNOKRpjZMIlBm+hu4kXrhba6Gt74cxfUW1Kx2wTfkQu+WVvTSNLtayuAlmP19lfDQoDb1+8mOQVTUlJrn9WTCIPV1/co61FAazc1dgJmLZ2HS41N5fQSzaGjnZ9Oo1jlQR+kV6qmDv6MK1S2VpuLO6rSQPcggvDP3bupFy7AaTfswx6XukTlIJgBUVamYR0Su+mNlEhwESJqaxaXj3pwM3GvNpCfLwFRuwgxvLmYXzafJrkUbQdG/p4s3JZ85xq0erkYlGaSS/weBFTq1akWAYCluKad8suPh7NmYy41fxN+FcrZyvBYsdmabAqtZ1sWYtGwO7p+YiHvGxWL8vJmw1hRTivmR31iCR/LnITVtJpIXTcdS/swCgmNWwULMcSwjk8zDPMrM9z5427QZVQRcUkrToy5duWgMuJrGqYxWp1zK7P3lzk/m+Pb3f9wxvuWbr7/G96dPU2adMjJLR7ky5Of4+FN62SOHD/B6zHRdPH/u7F8TIJMK/EiYbUVaYS28dcvRuXw71mx+Blv3vILdT7+K5195Ab0bNQ3Vj+CKBhQHnPB016Br6zDmUd/PcLqQSqk0kQCZRqCM4+YfSx8SSWCMzsmjtMrF/RkKFhYginIsmv4jsrAMiXYPJpAhxrl8SHLSnPNxSmUdkjz0DFV1mExQpFQHML4miHH0Iak06rNCbZhK4MyqDaGgzot83ulc1Nxtm0NoGVH/Jx83fTXqBivRNOxHTacbJVVW1DS5ENIJU20xSni3remuNBmvTvqNTBruhZRUjy6ZhVlps5FbnodHlszG4+lzkFmUBnewAqGuOgQ7KS87+N0dNXCH3FhGyZVZkYOBbYPo29COjuFm5NPoTy7NQ3IBWTQ3G2PzaNDJGveKOdI0Kz3z/27uzL+ivvL0/y9MYowaE5OorSEqghvEBZRF9q2K2qCKKrZaoCi2otgKin3f9x03EJVEYzQx6RjTnUUTd0VQUdyiPdOTpPPttJ10fnm+z/2QzA8zP8zMmTlz/OGeD1AFCue+7vM8d3vjZeW8kqxOjEOgLYkWTg9rhRU2Au0aLUXzZCNK+kukM+j5HUUo6CxEWrUVxjKzdOVoxXAtikZciM83IMIkgx8tZrJDlFzLhL0zH5k1wgo7EW3RwiPUFyu3e2LFW+uxhYF83c4t0mKglS7AWJYOb5kf3ti5ES9vcsOWqB3YIfdDGK1qEO2XAEQAJiZmxKLg9z+I/VZP5mesvhPbTOaL6Ijt7OKGkp9+/hv+9vSv0iEpsT4iDkc9enQP9+7dwp07U5ievoJbN6fxz396TBge4svPP8bJE4fw5RcfY2b6Km5MXXr2AHlv5l/glVwIt2A9QtQ2ZOQ1orF9HMNj72Pi2GkC8nt8dOYL7JscQNOeWnSOCYvSSo9fh7GTDPNHx5HVVA8fKoeXQdzNmwzPOOaNqFisiFVhlcghCQasUDKcqgiJXtzMbqHVElfvWOFF1fAkHGvSsvkUliof6zPsWC+gsRfAg69LLceOLfnF8CU0PgQk0lmBvKZKpLKT2Jsy0DFeh7b9NXA0Z0qFZcRdUDV9ThTU50CVqoCN1kjYr8ouJ0pb8lHO/FHRV4pMVxZfV0GbpkUEFSNME4EEix7q1HjCp2czILPEBluJFfYKdrzKbH7Ojlsn6gLaCWcWWve1oYd/l+r+aiiLM6gg8/XhxYLgSlFRSq7AshgFXo5VYqmKYZ1W040BPiA7hSG4FCWtFcioymLGKEbDGAP/ZD3yOcKn12dK5zhcVKfSzhK2UrSMtKBhqEmqNhVhkkvrFXq7GS17+1FAS5XbZOffRUwZV8NKxQtNlsF992as9duIEF0o3P03YbsiAJEWJfSijHWED9x2eWJD4GZsj/GBD9VEnZeAeFrUmEwNn0k4P3VBsk9/e/qtVAdErJCL8xx//+lH6bb2b8Wl1GK7ujgQ9cOfCcgP0mLh/Qd3CcYMw/gNzNw8L+WM27dvSJVt7929jVMnj+CDk5M4d+4MbkxfxtT1i88mIJsZ0FfsToBPjBnmrBpUMYe09x/B4IHjGJv8EO9/+DGOn9iH8Xf7pFvFa+lVuw92YfzYAXz02YfY995RxJdWYDMBWa/RYxOV4k2lBssJyGsyJX5H9VjJAL88Nh7LVSKPJOM1hQ5rkizMHpl402iDe1ouAcmHm5l2y5oLD0LjyUzinmXHWoZ30TyyhdLkIpCB3tTcgtY9XchwmaWgXtiSh84DrajpcaGLI/rIZA9qekuYE0zQMHQ7mwv5ejtbC0M5Pf6eBlqxBmRQDfUEIYP2RMMR10AgLIX05+y8RjZLPkMwATHza0ZHKvLKs6UcItZIagZqkdNQCGVhOhSFGQi3i0q9/P0N4gokHdbrqR5qJV6VybFMpsBSuRJL+HxZKWqDaKRa6h60YwF2I4JyDLBS4UR57frx2vkaIKKg5lAlagdrCXs1HHUOqSxb53gnSttKEWKIRGKBBf1HxtB1eBTOIReqh2vQdqgdWe0OaeYqiCrgGeqNdbs3YUv4Dqzx4zN6OzZH+cBXHYa1gVvhGeSNreHbERTnj52EJyxFhkT+3RJdRthbHZi+Oy1N74qL4kSxHLHfSuzB+umnv0uVo0RZ6If/fAuPvruFP/1wB395+idasn+lnbpLIKal2aqbty7j1q0rhGZWOss+df0S3n/vMD795H1cvnyWAF3B1LOpIH/GRgKybLcOW6NNMKSVSVtOOgffloL6yPgJTL77EY69N4nD7w5LJ+uaGXLfO30cR059gO5DbyO7rYeqkYw1YhaLAGyMM2BVRCyWhsawyfByqBxLg+V4JVyFJUEyLJdpsZQfr9Ik4424FLgZ0rBKZ6btssLdko03LVmSomxk3lifzeCeaafNompU1iOmog65fX3oGOWI3VrKPGGFVgRSjsC17LA1PWLHaxN6x9tR1uGEiZ3akK1H80AVBo50of1AA1xtYgHQyA5nR4aTgTuPQZxZIp6A6NIToDbGQW6IhYaBW1RbEiE9hX5erHskZBngqHGgsrNCqgsYnZmMHakJ2GEyYFOyFp6GOGzUKxGckYiIXBN/v1iqRwxeipLjpUi2aDZ5LJYo5Fgkj8RiZRRWJMbC3ahCdEHq/Cm+EarKkBM5XXkw8vdziB3FzQWQc9QXJaE73+lA81gr0soZrDtqafGGUNXfitJBF9onqGbvimPC1dI2kjjmkQ3hXlQKb1qo7fDc7YVNoYQikJ+H+2JdwFtw27ERmwmJnBnIT+6P3fEh8Kdt0zoSUdRfimuz1/BEXBf6F7Ez98n89vTvRTD/f9LWkm+/e4JHf76JJz8IQG7j0be38ODJrDSLNT0lbNUU4biMuTl+/cE9CZxrV87jD5+ekqZ5p25cxO07V3Ht+vlnD5ATBGRzihMvBzJUh6dAZy5FXkknalr3oqVnHAePniYYp3Hk2AcYmxihqrRj8sQ4PvzDWRT07UVoQQU2JpgJh55w6OGuSsCrQVFYsiuUYCixOFiJFwJisSBAgef8FXghkCNosBqvhsfhtch4vB6tk9oKubjlxIQ1iQz5mQVwS6Wq2PJoq0qwkTnEm8/YsjpkdvRi4NgEmsWt5g25KGrLk669yS3LoA83QmlSI94aj6zyDORVZkKfoUdetR21beXoHmlH93Ab6nurUVJfCBdHf6EKWlsiIvUyJPGZX5HDIJ4NU14qkuzJMDLQJlj1UJo1SHQkwVFfgArCMTjRg9yWEqoGlYeQWTm6+6UbpIKmG6gMQWYtZARvtToWL8dwcKDFWhpNUAjLqwoFlsijsEgRgZfiYvAKrd062ryYApNUCap+tF5agygbLoWFOUHcUWWrTIdKrLjz36mmxaoerUP9SDNcnVVSdWI9LVEe80rn0W60TLahY6ITBd0uBOoi4ea/EW60WD4qf2wJ24EATSC8Q7fBYzeVxd8Lbts2YJvcF0G6IKjSY5mtZAhNjIaSoT23LZ+AXJdWzoWFevrzD4RC7K36i3SJg7hqVOzJevztHOGYxePvbmP2/g3cuy9mqGYIx1XMErCbVIi7tFVikfHJ429w+9YNnP/6c8zMXOZrVzF98zIBufBsArKJgCwN4MgfmgS5NhfZhW0orRlkZzqKXob10YMnpeO3p//4Jd47cRynz5yWzq5HOyqwPsGCVTE6uMkJmNaIdTJ2eqrEIn8ZXtytxsKgeDwfpMPCEANeCNHj+WAdngvUYHFIPJaEarEoOE5qCwnSkjA1XiMoy6ksK/VmvGHKpMVyUEHysK3Ahf2ffI49J0+g/2A/GujLK9oKUdSajxijEgH04hH6aMRZ4qTcYCtKo7pkIjXPiMq2WkweP4SekR6MjA2gtZ82q6sWZW0uNA/Wo7C2ALtiQxCkCoWjNJMh3E5FSWQ+YWhuLkJVawniTXHIr8qFix9XDdTA2V/L31/M2mkRTaXIbRJbQvLgY9LBI16FHclxWKchHJGRbNH8vQQoMrwik2ENc9mLsnAsjA3HElWk1F6Lj0FMYRp6D1AdRAXb4TLp1GBRax4ikyJgYhZwUF1KussRT3D9OcpHJMfAVJ6OhgNNyG5iJhooQoU4HHW4Bc7ecpjKbAhn4PZR++EtuQ+2y3wQGBcIuTEKQfHB8KblEplkB8O53BQFVZpMuuHdUmpBHG1rMjNKRWclrjFciz1X4kzHz7/8KAVxEdD//ve/4sen4pz699L2kQePb+HeoxncY/Z4+PA+bs/ewK3bV9kuEZRrBERUoHosnV1/9OgBc4cAh++5NcXndb5v+tkERCjIK8wgXpFGaE0u5BS2o7C8F3WtB6giBwnK25LVmjj6Mcbf/pDtAwzx87CsEqxSJDJvJGGzzoJ1QgUiNHjJP4aKocJzBOP5UANbEhaEJeN5qSXiOcLyPGFZwNdEWxjKj4O1eCFIQ2j4/VSWZeokrKKKrCUc7lJwz0PRyBje/vwsjn58HC29VXAyd6QUJSMiRY6IJBlUBCUmUU4VUTEr5KGytRLV7dXYd/IoTl36GqcunsVHZz/B8MQg2kfaMHJokFbxHdR21UCWrEFYQgyVJBZ6WqqknBSk2FNR3JiPAdqZcoIittvUE4xM5g8Zc8i2ZDXzlhK+6XpECpvmykSQOBgl6sRrlXhdHo3FYaF4KSwMr4sKt1SNlyLDaLdCsTAqGItiI/AiIVmqjMDyuCgEmOOodCW0hgVUpHTp1GBxTwFkHNE1ebSRHBDEZsTQpCgEakMQbZYjvZE2a1TUUa9HI61lvag8dbAFNcO1KGBOictJRIA+BOGEYqcmgErhA72VVlFM4yr8sGa7B4L4dYUlEhn16WgmXOLihpy2HKTVZ0knCr+89Jm0fUTsvRIwiCau8RFrHaLClFgYFAuAYhr33r1Z3L839+uU7h1mDkLzkEF9bpqWa05agf/m8QPcuUt1obLMQ3SDz2nJej2zgAiLJQBRJRUjNaMWeaXdqGrai4b2A+gYOMLR9x10DU6ij7lkz8H30Tk8id1mB1bLE7FWnUI4DFgdpsHKEKoD4Xg+OEEC47mwFEKRigXhRkKSyo/F57+1eWgWCIBCE/ECYXkxRId/CuRoS9he15qwgpCsszmwKasAfnYnUlp7sP/UKckuFdTkwFhAW0VLpWXQ1mXokEblECvchpwkKoMTru42WPoGoe0ZQOqBMRQfOiKp0PiZj1B59Ai6P/09jp39lIrUDF0mwaDlyq3iaFxpR0p+CnNKDkaOdGL0EIE63IwaQhJbZIF/mqi7qMSmBCU2J8djq0kPv7REbEmJw9oEhm+Diuqixptq2qiwYKwiDO5x0bSShEUWilf4XKaKZmCPxAqqxxsJMvhbtcjvzkfpsBOO5hzmETscnWINxI609iyUD1SjZrASKcUpSKvNQDa/XrKvDEXitvZ+0ZjJWouQ4KQtpOVKLLYgwqJAcEoEQlOjsEO5C1tjfGihFJAnRyEsLhi75H4I1vpDl6uUzozUTzbB2pIDW3M2UmrSqUBK/PHcHxjKv/v1Urj5UgfiTMg/fvkJf6OKiOq0jx49lK4hnb09Q/s0I+3SnZubxUMxzftwlgBM8eP5Mm1352YYyi/j6vVzuHZNzG59hRtTlxnmbz/bgHiG0ItrKLHZDXBWD6O65QCqmvehqeugFNpbeg6hre8IBvefRGPvBPxSc7EyIh4rOeqvCFJiRWgcloVosWC3VursC8OT8SJzzX/WXhCQ/BsotGFUkhcJ2zJVMtyM2XjDkov1mfl4k5brLaqJtXcI3WN7mDuykUy7UdxcKO2dijEq0N7XhMG9PRzp25DV3oZYZxW2ZzuxxVYIr1wntuU4kVDVhPT2XvgWV2BbSSVS9+7HyKmTGJoYRe9YL3rGetCzR0xnN6KP6nH45BDG6e0PvNMm3YoewqAurJRXkrhNUtwFpsZ6A1VDL6r9EppkFXalaakoaVDaDXiD9u13BCTUZmATx5Aj4cH3eSRpCEYsVmlj4Eb18k2PR05zHspHyuFozYWpIh1J+SbYm0XxzlKU9pahvLdCugyueKCENqwSjn4nbHyv2M7u7CuHhRnKTx+KGAb6KIsKusIk/h90CE6MpJ3ykjYjekf4IoQKtFO2k4DsRJhuN9S2WBQMlSCxwgxLmw2pVWlQ2/UM7hp8fu4zKZSLLSPi4rjfbmz/+eef8f1fvmfemAdDzExdufQV7dQN3Jm9iZsz16VS43fnbks2SkzjTjGIz0wzb1y7gIsXv8ClS+f4PIfpG1cxd/fWswvIS8wgbn7x2C1n2E2ngpT0oLBigCqyT2pldUMEZh8qG0cJySScdYPYojbjVQbwV3bJsNg3BkuYLRZSOV6ghXqRVmoxAfmvtkUCprAkwkILxpzyQpCawTYBqw1iZisX7gzua8zZ2GjNg7qhHZNnzqB7lEG0xoHC+nyqCLMHbVHfSBf2H9qLjn2j0FU3Y3uWE57GHLxpyIBXegE8UrLxliWPauTCptxiuIuFyaIyZBw4iNHf/x5dJ9/FgTMf4rPLX+LEx4ex90gH3vlwDw6d6MP48U6U95UhIEMLH3MC3jLq4E61WBOnkO68ctfJmT0UCM2IQwgVLa4kDSZCsj1RhvXxclhqnNLaRGC6Dll1VILyIoTnmOBlEoDJsI0WMZHfU9lThcruUtQw61S0VaN5uJEWqgZW5o3cujzUHqhHsbjYeqgKhcOiqE4JikdcqGRwD01RwCtmh3SEN7XSiqRSM5IrLQgzybHebwtWeq9jMN+Mt8K3wTd2J/yV/ohMDEOshdaSdjWt1ipdRFcyUsbvT0dUkgKff/1HyVbN1/94Kp3vEPupxLU/QilmGbgvnj+Lr859jgvnv2SemJJmrq5eJQwz16TdulNUiMuXzvJ5XgruMzMM5jNicfCqtKIuABF7s55JQERIXxKow2p/LQJiMqBLrWBQ74LN0YrM/GYUlPehpmVM2oZSVNEvwZKcVQX3SB2WEY6FPjI8v0tJ5dD9CkfSfwDgv9oW8nsX8Gf8E23aUqFMtG9uScwi6Xa8aRHrIw7oabP2nPkMRz56H4099ciiksiYO7LKMglNB4bfPgjXyD4E5VfAw2yHh4k5JjkLXtZCeBIQT1Mu1lj482z52OAoxRqq0zZXDYJrmxHe3oWMQxM4fuUibj+YwYkzB3Hk1BAmTvTi+Cf70XqgBX5mNbYkChulxhpRqVanwhsadkDmCD/mod1mlXSVjyw/CSkVaUh0mpFSloOKwXak1+Ui2qZn7qmF1ZWLpBIrouyiuFAs/NM1SBNXfnaXoW2sBb3jHXxfnbSRsnlfI6oJhCjzXDJUKsEhSkBndziQ1mzjMx+F7eXYLg/E9thdkGeqoMlPhixbh/QaG3yVAVi7azM8g7ywMcQbO+W7EJYYwnAeDa1NhWhaLpsrHTX769F7rBelIxXQu1IRzb/rWY70Yq/Vb/XMxcZDsQYiVsQFCKKDn//qM1y98jWmCYKYoRId/jKV4cbUFSrJPDDCRon3zMxcxJ2561SW+dX1q1fOSwr05PH/wYGp/277TUEWE5CVBGRXjBVKvRNGWwMMliqk5TYiS4T2yiHkOruRbm+EKasGCmMRlgepsMRPgQX+atoiKgdzxP8EDtGEkkgqEqTFwgAl/bsGr2lSsDo1k506B2vT7FiXRhthL0Hn2+/ik6++xOj776KwwYnW0WaMHT/InNKO7Xzd31GGrTml2JZdih1Zpdhqo9WiimzOoN3KKcFGvmd9Xgk2FVViE58e+aXYVdeM4JZ2ZI6N4+zcHVybvYCJUwOY+KAfJz6ZQPd4O0KsSngnxmIdlWOVkvZIFYvVymi4KcKx0yiHIi8BNo7eRqqHotyMKnboigHaI7FHjLmpargGfcf6pLLOansqm7hYLgWBBE+Rk4B6WrvqvVQPWi0nM0V1f/l8Bah9NRzdXTBUmLBDHYotkQHYEOoLGcFSZRukQK3MUEs3tccxgyU50xGUGC2dNfeK2YlV2zwIx1ZEpUZAJW4tSQ5HPN9vdCRCk6mRoBh6fxTtkx3QFaUiwBANpVmLK1OXpNrmv/zyi2Sr/vGPn6XNhvfu3WHumGPInsHNW9elnCG2jAirJCARYDzk6+J9d/ieC19/QQt2DnfvTeHBoxnM3hGLgxdou+bzx5PHz+JerF8BeXF3Al4nJJtCkuEbZkSIPJOB3YV4YwVSMuqQbK1CckY11ElFiIjLgrfMiEX+KiwO0nHE1/+vwPFbm1cRPV4Mjuf/S4nFkfFYqmEeSc3CyqR0uKVYscXqgGv/YYx9+gVtxl4MHB5D955uDEwegrqmBevTHbRmdsJQhA1mKkVqHjbz+ZatGBtsRdhMi7XdWUOLVYyNjnJsyS+Dt8grFXUSIMqBQTSc/hjTf3qIL698gpN/PIzaVifKG4uQTlXYYYjAWobs5QzcK2OjsDwmFOs1ETAwIFeKEb6/CGlVZpgJSFl/IRqlWoEuVPSWo+doH2rf4WBTZUMsc1MaO7ZV3NruTCVUqVIlWnEbYuuhVobyJmYssR5iQV57PnIac9lp1VhHu7Tcey07/XpsCPJGFMEUxTyb9jcipy4ffnGR2MUQvjnSV1op9wz2xlo/L7jv3oqdCn/IGNrlqTGITI6GyqJGgkMPa18uGifa0bC/CckFJsSKNaWMBFy8ekFSjKdPf5JslmjinMedO7PSdK3YgDh7hx1+9gYBuUY4pqgIzCF3p/Gv332Dew9u49rVr/DF5x/Tgn2BuXu3MHd/hiH+phToZ2/flOD48a8/PJuAbEl1YmGQAUsCtFjNLLI1LAU7w80M7HmIYFMlOqEwFCFGl4dARQY2sxO/Fqhl59VK6xsLCcei/yU4RBM/SwC3MCQBi4M1eDVah+VxqVgWb8Sa5Ex40GqtBbYlDQAAAy5JREFUTbFha4YD4WX1sI+Oof/YCVQMj8LRPQxNdSu8RfagvdpsIRwpzDBJ2dhiKcDWTCe22svgaS2iIuXBI6sImworsZGAbCxwwbeqHtFdfVAPjSLnnXdw9OplPP72CT796iSKK3Nhs5tQ110BRXYcPDWhBCQYv5OHYq0yFL7iBvZyi7RZsmqPE0Xd+ajqK5UUoLLfxfxSjA52vv0fjKOo3YV0VwYSsvXwU+5mUA6HtcqKOoLUMtGIMn5fVX8laobqUNhdQoWIIzzpUlFP0Wn91UHYETt/tkNl1aBpqBE9x/vRNNGBxGIrvKOZLzQhcA/0gpvPBmwI9pIOeokV9O1Uk8ikKMQxK8nSFYhJiUZcuhJJDOUFzcVIdVoRn6mVdiCkUuHO0wKJGSyRO4TVEnuwxOnCb74RF1kTkIdzhEWEcmG3xJ4qYbOmCcJNPH5yF/cJyJUrZ3H27GmG8i8I0oykOmI268GDu3j0UFSp+kZaZX82ATFSQYINWBSYgGW0WW9STbwJSbA6B76RZuyKNsMn0oQt7Lzu7LivMWssCeYI/6tqCFv07zv5/6QJQAR0Cxj4FwSopZX4ReG0WswjK7RmvKFPx+/4XKsXl2DbEE4lKB4Zg4ywxJQ2wNvswBqDDesSacsSbPBIzMG6hExsMOZhE4HxZHPnx+4mO7zzCIbDRUBc8KttQXBrJ2Q9A1D2DyJ5dC+cx47i6wf3MT13DZ3D9XA1ONDUX40MWih/s0yq5eFniEEQ7UggO7mx1IjirnxUDpaiuMWJzpFWlLe5UNpbhKKuAthb7Sjha6JOuSiPFp+tRZg2kmE4GvpcLdWmWLrjqoxwVA/UoulAK2ppr4r6SpDbVgBHRyGKO0rQsqeFnbkAsRkaWCttBK8VHW/3Ir+rHCW9VUgoSoHMopC2jfgo/OCn9icwwXQIW+GnCoDSGstwHoEAqoxYiDQyL6UViTMladIZEEtZBio6ylDZVoVrVAVpW8mPP84vEP70FN9+JwL6PXb2W9ICn1COa1cuUCkuSbnjzuw8AHf4d5u9M4XzX5/FxYtf4zzD/PXrV6Tvm6P1miVYYm1k/rb4+/j/ZHsZSYtds3gAAAAASUVORK5CYII=' width='200' height='133' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=ff6a48b3391c4a24b807af0eb08bb6c1' target='_blank'><b>MusselFarms</b>\n",
+       "                        </a>\n",
+       "                        <br/>Feature layer with bounding boxes around mussel farms.<img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by api_data_owner\n",
+       "                        <br/>Last Modified: December 16, 2021\n",
+       "                        <br/>0 comments, 2 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"MusselFarms\" type:Feature Layer Collection owner:api_data_owner>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=b46d3fe7378d4873b901ec035623089e' target='_blank'>\n",
+       "                        <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAACFCAYAAAAenrcsAACAAElEQVR4Xsy9Z3icx53lu89zP+7de3fHO2PP3HFUYM45igkkQeTU6EbnnHNGdwONBho5J+YoiZI8nvHYY3s8O06y5aBIi5kUcwIBgjmIkmyfe6pAz+5zP9+V9aGebgAd3n67fv9zTlW9hf/03m3gL9Xe/fP9yT/h2O1PMXH/IS5du4jew60IDfkQGPLD2mOHK+9FtCUGV2MI+qQDnhY/siNZZIYa4GzxwZRzoHGkEU2jjUj2RtC5px1Dh/rR0J9EpCMIb4sXjowDpeYqVDir+DoOhDtCsKRMMMTUUAWq4Gw0w5uzos5fBn2kFqnBGGJ9fsR7Qhjc34Ydrw6gc3cO+ZEUAu1eVIcVMMcN0MXVWKsvwFrjVkQ7Exg6MIgdr4xg+EA/Ona2w5FzI9ZTj7ZdbcjvyMLX6YUqZUR5SIUt1kpsMpRhi7YMxW4VLDkXgv0hODocsLS7YG51QNdghqLehNKUFpu8lRjY1YtXvnsY5qgZtf5axLpSsKd82KQuwnrVZr5eMbbZKqHya6D0quFu8iLDc1VW78NijwULXCbMc+ix0KnDErcR3zLV4RvGOnzVoMLfG5T4W30t/o7tq1oF/l5Xja/rq/CisQrLXEq4u4KIDdYjOBiHu8+LwEgItg43KmwVKNeVQmWrRrWpEjVsloAGxXVbsa5mPSwxE5xJC1xJK/R+LUKdQST3JOAb8cPW5eLnMKBQUwVj2AhLwowaTw2/ExU0ASXs9RZY0zYY6m0wN8VQFgniO++fwpmJ+zhz7hyuX7+Gickx3LhxBRMTY7g1eZNtAnfu3ObPE7JNTk7i0aMHuPdwHJN3r+P+w0k+76p8zP379/DgwT08ffoYT55MtXv37+Dhw7u4/+Au/tP/t9N+3u39yanbI3f+iIknhOTOTXQebkHXwSYMvpxH1/4mZEbrkexKIJyLs4O2onEgy5Mchq3ZCWuzC65WDwJdAST6osgMJNF/oA/Dr4gO3YzG4RRihCFEqLbpy1DtqpGAJHoiiHUH4Gu2wVqvhiGigjmjgzZaQ2iUiHb7kRgIoW1nE7a/3MvWg5GDHejfk4ev1YsVugIUmYoR6QxAk2bntZeg0FEJbdzMTulGnvD6cwGUOGqgiVj5PmH48wH4OwLY5leggJ1og6YMa0yl2GitQrAziVa+trcvSEDc0DTaUJkwoDSsxRbCo2NHr42a0DbcgVx/CzslXzdsYIdysUMqoHUqofDUYr2mEJv1JXxPPbTscOGeGN8zhi1hOwExY75dj7k2DWaZVZhmUuI5k4pNjefMGnydoAhIvmaoxTcEJATka7pKPGeoxBxRXPh6Ln5eW7+XANvh6fSgxquE0qXCxspNKKjahJK6bdDyZw87tJ3HW24ug5P3vVkXLHEjatwKKJI61DUYoE3qYWlzoManR6VVDXVAx7/XospRzUKlhCnCn121qODvKvi3Ip8Ttel6fP/ISZy/eAlXrlzGrdsE4s4Yxm5eZbuCSd6/d38Cd+/dxt27dwnBHdy+PSl/fvQx79+7wefcwNWrlyQgjx/fx8NHd/H0k4f4+OPH+OSTj/H4yQM8enyPz5n4ywPy53bq/h/x4JOnuHnnBtIH02jem0THviyadqaQHE7IjuXOepHqTqFpKIdIVwz2ZjciPVHEe2NwsNP6CEqsO4TWHTn07WvD8KFOtO9ohC/rhrfJRziUsLJCRdqDUmm8hEMfqYM2Ug1zUgMvvyx33soObkGaldLf40NqJCHh2PlKH0YPdmHnoR6+RwQvGbehxFeF+r4ErG02bPCUYYV+MzZaSrHFUgZTwoRIawQqfvkFVIgtzkroGk0wsuOXhVUotFez1aDUp8IGVxWqYnqEqB7x7UmUZtXQNjlRw98V++qwmUpRw9cL5WNItqVhjFigDbDzN8dQ69aj1l6LUL0dNU52LHYqW8YOa4ODyhUjwHGoUy6sC9iwxGXEAgGIVYMZhGOaUYHpBGS6WU1YNBKUb1BJvm5U8laJr+sUBKQKzxuqscKphrnBTVUPQdtuwVZHKRQ+JSoIejWVo5yfsZpKo3fVIdTggS/j4u9reHwKgmJEvDXEguEj1Hp2dMLdZIQ1a4e+wYpiHoslaoc5YUWZtRqVfJ4+qIM75eB3RqU1lGOTTY2VRi22+j34l9++iwsXL1ApxvDgMUGgMly/fh43xi7iwSPRsYUy3GG7TfWYwO27t3Dn3jjuPRjH46e3qRh3+NgrVJLbePL0Htt9PP30MUGZuv/4CZ/78Bbu3h//4gBy+t4fcffxI1ybuIrWV5qR251AciQCN6tUigrSuKOBticJV1bYJVawtEtarYbBBkQJiJ+KYGeniHdF0La9Ga2jGbRuT6OxP45YexTe3jAC7Nhmyr09ZYOjwcaTX4FCdmqFtxSOrAGxXh+VyQ1f3omuA10IDUZhbrNiYF8H1aMb3TuzGNjbCl+bDwUEorK+jkC5URZSYJ5yLVbW0eIYy7BeW4xyZy3sSdqkqBVFtFKbveWwEyR1vQ7VETUtlQLrLfziqR5LtFsxV7UBq50ltDF+aLJm2gkXVIR5k6MKL7nLsIHWz9jiRjifhC3lgbfBT0WNocKuRJVdAV+KQLmVUAf1tJ5pnrM0rVUj0iwmipQXy9wmLHYaqCA6zLbUSUCmIBG3dQRFjRctWjxPJXmOSvJNCUiNtFizrVSwTBhRAhejNQoMRGBMWXjeVKijjfPR9hrcWigsNaixVMPDn91JO3RhdvIGJ62TFg19KaT70/C0+qFOmxAcDvE7zcBASGwEuL47zr95URcz8DPopN0y0UZWUxlLqF4FFjXWWI0oDvnxgzd/QQW4zI4/jkdPJ9npJ2mxzuHqtbN48jGt1L27VJHbePj4loTi1p3rBGQMd9jhn372iIoyIeF6+EQ85h4+/vQBf38fD57w8Y8I0sMJ/v4uf3//iwPIqbt/xK37D3Dx2gU0HyQge9Jo2dmA5uEM6gfiMPFEK3wGVHkptWYFytkpFDENTLRZQXb8cHcUriZaLdqYhsEMcqMNaBhKIdWTRLApjCqfBlZ2MCeziKiwpZYSbKhdhyJmBy0zR5CdN9btISAuePOsvr0BZh9+8WmjzDKZvjCyfRF0U51ihFGZ0qCGgOipCvYmO7ZRBdZrt2FFzSYsV9B+WSoJshvqGPMGFWOzuxKGjBGqqBq1CWElVHzvciyoXo/Z5WsxX7kBG5wVqEsaoW+iTaMlMVNFtvlqsdJSiDXuIjgIpshcuqCRFdoHhVODl2q3sOrWwhgl8A4F9CE9UkP16H69HW2H8lTfRhSErFjk0FI9tIRDLe3VTCrHDLYpQHjfPAXINLYXCYnIJl/XK/BNfTUWmZVIdmTQMNCA5JD4PtKoH07D2SqKlRNavxrGkAkuQqr1aqFi1dfx1pVwoJ72LtkVR/NQE/Lb8/BQvT19tMM769H/SpeETYCSJtBBnl877WkdIdeEeK74ujUERO2nklL91trMWO+y4Z9/8m+4fPkyO/0tPPmEVf/TO7g5cRHXrp/B449FdriDByJDUAVE7rhzn9nk9hjzx5hUjMtXLkhb9eTpHQmIsF5PqCy3bl/ja97E+K0xvt4NCckXBpBjzCBXx+/g2NnjaNidRXZHkqE7Q8/fhiwrT4Qn2pZ0YzOtyVYGbQOrq5Ph3Nhih7PNA1e7UJNGuJhJ3C0eWe0y/DnAHGChVBviVlY0I+wxKxz0xEqfAhtr12NlxXLYM2bkaG0ytA8Ng6IRhqEITFkTrLREXr5PiHC1DqaZgRqRpG3x1ftRQ5+sbNTw2AIw8ngKzOXYQv9fYxUhU0tL4kR8oB76vA0bXeVYZy7GFlMFQ3QNqyItlqMCyw2FWKIqwDbmhzDzk4+2TpnTM4yqCH6IMJmwLVgLD5WlMsSOyKDbsacb9dsbsJVqtVaxGVW0NeW2WhncLTELAUmh7eUWtBxohqHZj5UehnKHBvNoU2YTjtnmKSimGWsxnYDMlApSN6UeVJLn2V4gSM8Zp0Cq9jvgiPoQFmos1Gk4x4yWRKW3FtakyHAWRJoDaB/N82c7tjCHlGhKmENcyHQxW40IRc8jPZBBbIBKsiuD6PY4wjt4HgfCyOxII9AZ5bl2w8ZzVksgjPUOWi4zswgLkUuDdVYtltFibfLZ8eNf/ZwKcpUZY0IGbqEityavYpyQCNW4ffcGO/wDBu37Mkc8fHRHBviJyWuE4TauXL+IK9cu4er1y1SdywTrCp97DSdOHCd4l3Di5AmcPnOaf7vyxQHkvdt/wntjT/DO6TPoe7ULydEQBl5uR8euVobsOKtQCg5aC03aCk3SQB+vRE1KS//vgoGWyNBkg7s9gGhXFCFWqcRAArmdzUh0JuDtCDITWKXd2aotxbLitSjUbUOxfisqLduQ6PAz1ySkxWramUDDMAN1uxP6jB6KEAMnK3kPlWNoX7vMH+Z6YS+YDVylUDXqEO0MwZS2oCZYRwi1iDR4kWgLw1LPY00Z+f4+5iM/PMxM2pCweC4U0ocvo7VaWLOR1mwLPHk/MrSEhrwdtQ20GIQq1B+FKmZGrD/FEB/FZhYGPTtO9/5+JIbrUUmo1PT0dR4tqmm1yoyVMpj3vNyBztc60MLQr0wLe6XFQmcdFUSDubRXc6gWs54pyAyjsFt1hKWOcGgIiVYC8qL4HcP6coISbk6jaaAdqV1ZxEaSaD/UgTizYJ1fy+BtgpJWyxw2o2u0DfaEHZW0RHpmL2/Gg4aeNKKtYRaYMNI7WPgIrmOYsGf1KE0wqGeDiPRnCUg9bZsbGn5H2riFBS4BPbOLKW6GJmLm9+3A1ogPJVE33nznLXbkiwzSk9I63X3AoH77KibZ7lItHgnr9Ii54ulTPHnyhJbrDv82zr/dZGaZwONPJnkrcgkV5t4kLdctCcaRI0cY/K/w9gP588OH975IgIj2JxydeITDP3oZ4aEgq1UYQXZ4R0sQ7Tv5BXUmYSQg1gYTg6cGVRnRWKnbfQh2RGBpsNMKiJGuJiRYufxNorJTLcIGrFNuxdqqAlajOobcqVGVULMHzayKgwfz6NzVyEDrQrJPKEickLnhydlovQIM6IMYPtCN3r15NLKCuts9KAxVoiqhRONwHD27ckgOxOBkXhJDuMZGK+rFMHFviMHcCHeHC+17qDy0aaqQjp3aiFqCtJnBfYVuK9tmuHIeZIZj8HQzezTTnvR7kNvLDsmO0jbagiSPUwyzNg7msPu1XUj1NUBNu2llh4x0JKGipVlXvRGVDP5J+v0D3z+Eg9/7NkFLMZxrsYgheyEt2VxrHWYze8wU6sGcMY2hfLqhjkCoqBpaabPmOHi+wrQ62XqehxzPUxTRhijzTCNStL2Z3Rk07m1CgMcjMl2RrljaKi8LQ62HFtLBbOJWwxG3w0pFM6Ws8LJoudjsPR5UpjUsLjUoZ0Zb57WgMOxBaczPwB5CsJ3FkI4h3lsPe2MAlRE7lvOY17hMBMSLrUEnfvLWT3Ht2nU8ZmadoHUav3WDlugyFeIq7lBVnnz8iNnjNj799CnbpzKw375zQ8Ij8sVd5pIHj27LYVwxcvWI4fwBVWZ84joV5xZf5zpV6Cbt2hcOEFqt25/gX9/8IcwMvxp20ARPlq8tghB9v5MVWJc0sYoaoIgoqSY6Po7AtDgp+XxMi5eduBPNI1l6cjvKTAoUW6thpLpsNZSiQLUNOr8BdlZhW8qMKMFqG0lhzxt96D/QwlCfoWI1IcXKHWnzskr6kR9txP7XRtC7px39ezvQvqMFXkJTlagjUF7kWFF3MMC3726Cqc2Ojf4KqBpoEXhc/l4qHgHZ7KmAv5MWpZNfuE8NPW2egTZCFdSgwF2BiqAKIQI+dKgdPfty0LfwOdEqNPLY2ghf62gTtu/rwfC+Xgzt6MfQ3n5awmZaPapeVwyORg/KHTWosFTwM4XQureNrzOK3O5RbAzZaa/qGNCnAJkj8odBgWnMFi/yVkAiQRFDvWIkizZLqMdKhxnB3i7sPHwQ4aYYoh31VLgsUlSBGPNDaHc9Ar0RdnofzCkb6gh+sC8Kb08QtpwTLmYTa9zGzOeUf6/yKqXFrfCpsMlewVaDgrAdq0MOLPXasNhmxMYAv5eWOJp2tCJM5SmNubA55sDmOG+Dbmzye7CRj/23X/4UY2NUjrt3cOvWTdwcv8ZccYagXJbh/N69e3Ie4/ETMXT7hI+bJEDMF1SQO/dpyx6Jka1xOcIl5kFEZrl7f5Lw3JTDwA+eTPBxN+Tjv2CAUEHG7+P1f3kVkZ4wlBkLbG0hpPsb0Uib0dybRLjVBwOrdGVACVVcD6sYkWq0w51zoZFhPjecQojPqWVFlY1fnL3LC1WEwc+vkz5dDB+Kod8AgWqmVdlzuBcD+/OUdS9atqeQ6Y/QNvnomePo3pXHgdeG0UaL1bG9BT07OxjMbaisVxKeFKLD7JC7G9G6qwH6rBmFAQXcrP6VDXVY62HmsFdik7kCtTEDgTYTblrBRq88rhJW0coQg37CQqUMo3NfE5Umi2CPH4YGGxpZRTvEiBxVY+duQjzYg76hfippBqnBLJqGm6icYfgY3G1pG2y0dLasg5U9iqq4E+u9RiywqagatYRDjbk2Zg19LV7UVeEFtukSkFo8r60hLEpaqylAZtLvr/Ww+rc0YuTVXYhQhZp25hGnBRQKkmCoju5kqO6Ny9E2L8O1l+csuTMLb2cY3q4QEoMJOJs8cOR98rMWMJsVMjNtEyN3/NybYnYsY+efFzBjUdCGZREXFlFNVvstKE77UZT0Ym3UgXVUoXW8XWrWYbGuDiVBC3713u9Y9R/JOY6bYzeZL8YxPn6dqjFB23WXgNymtRKAPMInnzyVWeT2nQkCMInJO+PSkk3cvjE1N0IrJoZ75d/uXscttnuPbsqs8ujJ5BcLkPcJyKmxSWx/fQRde5gfaCuszV4YGzxsZnaIBDuDCHI2rLeVMbiVocpTBzU7vy/vQWNfAmHaMR096zb68WIG4QqHQgbZdaqtKDayutOvu9NO+Bsc8NBmtVA19r8xiO4djVBGKun3/QQyRtVyy7mQzh1t2PFyL7p259FHFckONWBbuEYO1wYIkaXLQW9NG0TbYSY4Rc5a1FLZSpldCvzVWEX7UWCoxFZbNQpcVaiM0RY1ulAR06COXjvQHqalSyPJDuWgIlUw02wLKmHiY3JDTRjd04dXD+3Cnv070TvSg9GD2xGnpXLR36f4vDRBEcBZaGMSfUlYmkUV9mBbwITFBGOOsYq5Q0EVUTNrCFulIBxUD7ZpegVeZHtOS2DEfZlDpkazFjrNKEkEEOprgofqkdrRjD4qadvBdsR3sgiN8LvJuVHpr0NdxgzvCBW8r5750IJyZiMDrbCrxc/8FWVm43kxVaDQXIbNjiqsoAVbxEyxuN6NBbSIi+MOLE+4sSruwVICslg0jwXLfBasCdmwhqoxT1OLVfoqaBMOHD19VE7myZnycQHHGNVgXIJx584tKgI792N2+geTcl5E2Kj7D6gUD8Wo1dTo1n1arAcER9i0ew/Ez89Gu+5cfzb8e5d27QumIGI2/dzNmxg43IOu/S0YZths294Ia9bDL/oluDvdaOhPIE7LtdVVjYWGrVijL8UWZzWsGTvDZAiGsBVb6kqwumYTtuiKUMjKtbBwFZaVrcWa6g2oYQdWEypjQM0c4kTH3mbsfLUXgwy0le4S5gMFfLQI0Z4QPF1uVsQAmrfnpG3LjWagb7Kiol6DsPDTOQcUDVqk2FkaRxJQxg0odqlpJzSoYT4otCuwoq4IRcZqlDNEb3XS8gnFEBN57MT+3gTtUA77vjOI+tE0NrPSlqe8KAu5YW/2441v78G+w0N45Tt7WTB60Lu9jUrWAmfaJVucBSQ6kJSBNtEbQ+crHYgOsaMORKBKstMRkJm6MkzXlTOUT4ExzSCgqJ6ChGryglAQ3n+Bv3+e959jJvmmtFsEyqrGAifzCzPMSlpCbVucx9mCEDNaYkcKjjYPytyEmYXGPRCCl5bL3x1FsZgEtVbIwmWl/bNRrau9dSikDVzL15ntM2NewoUFtE7zmAfnM2esSvuwKRfB8qiTSmLDXFq8ZVSx5Q4Tlhi1WMFjrQwwtGe8ePvob2mNJuVMuGjj41dxa/IGAbnFwD0ulUGE70nmDjFsK8K2COxPPxGTgWIScJL54r60VnfkJOLE1Ay7WIYiVEioCoESf/tCAXL07h9xnb5w7z8OoWVPCq37Uujc3yjXJy11b4Gt1YUEs4arwQVrkxNu2q1yvxqrDSWoYeeyUWlUfiOKzFUotrFqG4uxrrYAczevxNyCpdioLEAFq1g5lcQcMiHaGkQ3w2ZuiAowkoYto4PCV466QDW9fFBOUqpaTdC10cbxvUO0feomMyu0GxnaC3+HH4WRavh63Qj1BlHkrUUpQ2qVS4Nymxoqtx5bzJUoZUcVcxVbeVxFVActs1XTaB5te9uR39+E4dd74KRV0uTS0KYihCOOzj29+OGP/xmDLw9hkAA3Mxu1jjSibagF2rAJ/vYAmvY2ooW2rOVgM3pf6cbQtwfQ/0YHbVA9w24CW9xazNNXYLqmDC9qS6kUZXiBaiHyxzS9sFUKCYZQj+cMNXiOv3uO4V2szfqGUY1v0Xa9yJ+nEa7pZgVmsi2yKamgJkJCi8VcWMjPV+WuQ6AvjCBVJM5MpmVwr/QpUe1RyREpe4MbStrINR6dVI5FtE8zmY1mUx2epw2c6bfSbvmwwOfg+4gMxON2MJdYjVikUzHDmeDMJ5nTGhDpTuHEueO0TAKEceaPK7h86ayc+BMdXgRyoQhiJEvkjLv3pzq8GM367LNP8elnTyQ0AhKhJLduX5fzH0I5RHvwSEwuTlmx6zeufnEAeZ/t7P0/Udoe4Af/42W0HmxAz8Ecdrzageb9WVZOduS+DCrDavpadta+kMwpYmi1jl9YIRVlrZZ2pq4cFaxqWy1l2KjdhpdUm7C2eiOWFq7EBsVGGAL8MunXk3kqw3ADWkbrEaO1aWQwD7W4oPbTPgWqoAxVQ9doQGVWg9LGOtg6PHB1EchkHbRpk7R6dipNIW2Uvd2JimgdNtHy6dgRhHpU2OuYgTTYKGbWWcHLaSs2W6qwSL8FL9Ee1tEq1CZFRwti7+E+WrRWOHpyiI+2wTvUiGr6d3XOh8Y93Tj849ex//sHMHiwDz3DHQy7ZkRoA3MHG3luGhDoDqBxdxpNVLquPV0sIil480GUMRCv4HsvZpuvLsI05Ta8WF1IWCplDnleV4nnhZoY/icg3yIQYqnJ18RsuklYLqVcavIiVXAam4Bkvq0W2xJWKJl5yhy1qAvqqCwpeHoDzCYJlPK7EOunzHk/FKz4puYIljBHPOc14WsOPZ6zmzDDZ8NzvP+C04DpXisW+J2YRbWYplXSLWiwxKnn+VSiPKjl8z3Y+71X8b2f/gi9ewdx8uwJAiBmy8dw6fJJOYMuwvnjxw/lMhIRtgUkt2m3xPKRqZGqh3K499FjBnL+7fHTu/JxYuhXLEMRk4g3J67KrCLatWtXcOb0qS8OIEfuAGNP/ihHE9744T4MHmZFfKUTB749hM4DbWjf2QJPxgdj1IISXw0sGRtiHREowjq4KPHCYi0lCKtK1zF/lDMMlqGEHbacnndN1SasLF2LKoZlHwO9j3km3OhEkmG+cTCG/I56qkgMwRYnNEEFdKFa5hMbDCk9w7WGYbccZQmC0WDFVl816pgjAm1eBvkASp1VKPMqsJnvVeZSwBK3odpZB03UjCqq2zZajRJXrVxPtI6ddLl6C1ZrtqHab6Da1KGCEEU6k+g9MIDIUB6bEjasDuuxnM9d5qZFc9egMG5GaJRW7PsH8b0ffxuDB/qQo+WLbI8jxHCsb2CVZtFw8PzoIibEO1PIU6Hc/Ix+BngzP7M950JtVA9FSodZOqEmbLRfL+hF/qiWoHyL0DxHWL5BSL4mlpoYVfiWWNBoFFaMfyNQ/xMSFUpiNnhaw+ja141kTxL6mJHnxoQqsbAwZMR8tw7PeYz4hlAJBvIXAhZ8lUB802XCi1SNmREqRsCO590WzPLZsZIqsikVxJZ6L2qYwewdASRpsV29YQy8MYqXf/Q6OgnIe0ffZ06YxNj4JSrIJdnBH7GwiuFdMTF4+94YAblLWMS6qgf4+KlYfHhXLmocn7yKCdqxydtjuPOAt/euyceL0a1bd25inIH/2tWrEpCrVy5+cQD58O6fcPfpH3D95jVaigFaqzzBaMb+fxjEyCu9tDAxJPvSiObDMvQVE5IqqkElmyVth5mh+yXVNmxmExYs0kkrlnVAHVThJUUBKh3MKVEDPHysg1lB5VFA4VEi2cXqOxiWSuJi2HSymaMaQmSDm6+pC+pZhQux3FyI1cYiLFBsYEfTIs7ntQym4KJiVBGAcsJRxveoctWg2FoOR5MLvm6xXMUr52fERKAipKb9K5dDzsGOOOLdSeadCAK5OCvjMOq392B9xIyl9OtLeGyLma0W2MqxREDuU6CmyYbWQ73Y991DGNg/KIebowNxaOpNqA4IJdXBmKJ1ZAZp3puVCzLjnSE07E2h5VAjEl0pZMVgBJVrnrGUUJSy41fQalWxUUGYRYSSCBX5hlEAopSwvGCpo4pU4VvCnvHvs80M/xYeH1VyS9AkJ/v0WT/sLSFs8+vwkkeD5bRTX3do8WUC8VVmjhdidnydgPw9w/c3gg5MYyCfzmA+P+XDEj5/dS6MAp6HbZkQCsI2whGENu9A854WWslm7PrODnQfYD9oS+LtI2/j+thFXL7ykRy+nbwrVEAsc78pO74EhFbr8WMBBsEhJCKj3GRWuX7jEsG6xuwyKUeyJu9ek8tRxJITsbjx6pXLuH7tKsZory6cP/vFAeTM/T+wKjzBxWuXEKXXNjMghwbC6NjThN2v9qFfzGJ3xWCpdyJLCxFsCcBM1dCxQxgzJgQ6fNAnjHJmOcoQ30nFSfDx1QyMG5VbUWGthLfBCUe9hbc2GCMG1NA71/fEkGbAbKKCRBk667uCSHSE4EiZYSJIYlXpRgb9NfpizC1diWU165hTalHfHWZozsMWZ8V0V9Nv10IV0tJuaKHic/R8vjFnhSKghlsMJ7+SQ2x7hPaN+cRaxZDtQSgfQX1HCr0jXWjfPYiKhgBWBLRYwNdb6KrCAkcF5tlLMc9aggVUqKWOShTG1AjvSGPv919FD6FqEuub8iE5USpgaX01h47XmtHznVY078vQivoRGQ0gdziFeuaG9v2tzChx6Lus2BhRUQkUzBhT4f0FWqznBSBCRcSSd7mqt5ZWS4T3KYURaiMC/1yzkselIiRqLLHVYTWBKAiLnKHFKreGmVGLv3fo8WWqxdcCVjwfd+PLXjP+xmPG3wVor/jzdCrFvIwfy5rCWJEJYl0yACPVz9Dmg42ZztkXQGg4RvuYQ9/hfgT5fSoJ5Fvv/JJwnMMlAnJj/LJc4i5m0gUAYuRJhHOx9koM8z6i7RLBXCxQFNAI+ySyi4BBjHiJjCLmSaRiXL6ISxfPs32EixfO4vSpo395QMRFUx9M/gFX73+Mx/SJ569dhKu/HsURdrakBc4WD7a/1oeD/zCK9pEcvKxUwWYGVFbfpt56duogTKygSSpMbm8O6eE0hg/1Yc/hYQSa/Sin7y81MkgSlHCrH4G8G8FW5gfmEA2DfWYog8xwHEl2eG/Wzse4qUBWmGK0VyEqFBVBrHlaWbsZ67UFKHeWQRWgv47rEWBOqBXXQ9DrG+NG1Po1hNQMd7sfasK1iRloVfl6mFI2VvEM4tujUslKTcw4Pi2PJYjmwRyDdwcBb8SaMEOpl52WcMxzlmOOowxzbMWs2EWYYyagpiIs4m1BWInBHxzGP/38R+ja24P4oBiGzSC3qxkt+1vQ8Worul7Lo34kCv+AD8HBANL7WACY2VoZ9vu/34aW72YQGQmjMuXge4i1WGJlby2eNyokIN96Bsg32b4lfictmMgsVZhJQOYQmnlUlgVWNRZaqXhUkxUONZY76rDKpcEypwZ/z7D9N3Yjvhq04e8YyL/ss+DLHiu+QhX5VsSJmSmGdQb2WVEXlsS9zHsxZHbm0bivCY6+IFIEPHswC08PVbYvDi/V0Jh24c3f/VwqglhbNT7Jjn3jPAO5uHDq6jM4bhCEsakZ8odTo1bSetFC3bo1JkenxPISsepXTDZO3prA6ZNHcfL4EZwhFKdOfMjbYzh+7IMvACCE4zfnbuDM+Y9kkLoydhmuzjgKebLN9NBilWfX/jbZsqNZpHpT2GyugoLe3dvogTcnfLce4c4wIoQkwvA+8nI/BumL1fTxW9SF2FizEbXs6J2jzciyM/kISSDvkdeFZAcb0L2/E4Ov9GPg5T7mkWb4m72EywdrSlzdpsBaVQFmbV6CddotKHKUEpoqWip2cn8dM04ljGEDj8UtgUwwPHtprdR+LUoJZ6G2hJlEQUUxMi/EoI1ZUc6qbWTIFVdEdu3uRW5HNzTNMSyjesxnuJ3N15xjJxxUj9mWInbIbZhl3IbZ+q2YrduCxeZStHznIL7761+i9+Agon0ROXLVQL/etD+H1pfzCDIfqYJK2h6x2jmMOGGJDUfR/kozGvbE0fF6IzK76lGVcsrl7DPY2aeZVXhRhHJhq0zMH8wg3+R9kUGEgjynr5SZZYaRNuuZisyn1VrE5y8lZMupJisIyGoCspyAfJVB/2+dOvy1W4//zoD+FQEI84YA5GtBO74ZtmN6xIVphGYtbVewP4ueg920h80EJID8wRb0v0Zb1ZeARlyeEDKg2mfEW++9JTODXIN15zouXDqDGzeZR25dkbPfYrnI1EVTU0oxtdTkpgTjxg1askkR4G9TNa7RRp3DuY9O4iRhOH3i9zjB21O8FXAcY9b5iwPy3vhT/OqD30tiBc0XKJ1dBzvgYAh20Tb1HepG5/YWjB7qQWYgheaRFhQ5ldhoKkc1VaaYvl5Ju2TO2QlNLfSs7PFudpjeJMoslVhfU4D1ik3MG3XID2WRpeoExRWIrQIQ5ojhJgwc6MbI4QHs+vZObD88KifoGvqSSHWxwrKKLy5biUXFK7FZUyRX6xYYS1DIbFDJar+ZnVZBBXHQvuV25eiXc7Ax52h9OpSZa7C8bIPMHt5OP1xUPlPCLi/eCrRG0ba3i8Ugjc1xBlRmnQXMHXOZZeYw+M+0lWKWtZiBeBs75FbMMBRiJt9rhqYA843F6PneG/jBu79G78tDEg5nq4u3aTSy4jYfoJ1jDlHT8tkzLgbbNrTta6W6ZtC4MwND0kC74mF2MWKZjXmCmWKWVQBSJ8F4Xl5lKEaweEsIXqBaiAwi1GMaQZnBNouQCEDmEJ6FFhWWUUGEevwHIGzftGvwNwTvv7L9NcP6f2f7G6cRX3aY8bcE5atuE5732AmfCVtou/RZD8L9SbQwd6T2ZNF1qJPq3gBrzoOttiqsrNmKAkL6i9/9jDmDnf+xmOCbYJZgtiAg47euE5pJOdwrRrXEKJaYJxErdi9eOouJW9dkTrl//76cib/Aonz0w/dwjO3U8d/jww/exnFCcYL3T1BNjh39CyvIu7f/hA/HHjBo3cLDhw/kBM/ZC6fQ/Uo7A1kOieEkg6ifVkuHPobO7v3N6N7TJkdJNjFTFLkV2GivQBltTrkIyOJa7Dg7RbsL1kY7CjXFKGEgVniqWbGNyPSk2enjDONW2GnLNAEVYh20HVSNjj2t6KGSdO/ukPMj9fS7uYE0dLRZ65QbsFG1GYagQS4Q3GapYCDWwlVvR5GlHJ5WH9wM4437s/T7CQSoTGLoc3HhaiwpXsP8U0PrFiPAWlTYa9HMfNS1bxDGtnqsDZuxjMF2qU8j1WMe1WY2s8cMSzFmmAmEecszQLZiOgGZRkBm6wvR88+v4Z9+/TNkdzYj1BtALT9LOUO9u92HDp6/tteYNUZTSAhr0u2FstGI0qgGupxDXqYsVKWKNnCxVSED9yx28llWrYREACLU43k2AcyLBORFQiHU40UxksUwP5NZZQ7VRqztElZrKdVDKIi0WE71lMXi3/5vnQL/ja/93wjLX9l1+Curfiqo+2z4qpV5RGvAc1oTtnltsOUC8nqTHK10bkcrGmgHNTEzSnnOVhOO5RWb8JKqGP/+1v+Qo1EyjNM+iQuhxIJFsfjwyceP8fHHH09dkz4+jps3rzOYM3jTmYyJBY20X+P8vVCSC+fP4NTJD3H29HF8dOY4jh55hz8fZfY4hpNUkZO0Wn8RQMSch8geR27/Eaev3eSHmprEESHq1PnjyAwSBvrpzr0taBpJIzMaRmjEA3ufHRZW/hJW7DW6EhTZlahg0DZEzShjp1Kyg62rKkAJQamjkiiZCfwNbuRpozKDCcSpCGpfHYq0hSgxFtHqlPK5GrgJk7gSsYHZJ9oaolXywtPgQKonziBND8+sYUs4CBThizkZ/EU2UcrHFhiK4enkY3pDcil4w/aMvCZCRYjLaLG2Um28LUH6/yRVxsvXbEDPvn4Y2+uxOiRGrLRYIpoEhMHXWYOZ1lJ2SgJh2oLpBgJCMF6ktZqm24y5PO7V9hrkDvah6+UBWssIP4MexeZy5q1yBNrC6D/Yj97Xumg34ygTK5n5mVeymKx01WKtpxbbQhp5vfsGv4oZgkASgJnmKUDEOiyxcFEsWBTXiEyX167XTs2+i1GsZ8tUpuuEiigY2JUSkCUCDkKxnNZ4tUtLQHT4ik6J/6JV4L8Suv+iV1JJNPiK04CvO2m16vT461odvqTQ4utV1Shj8Yl1J+BqIuxeA1VZgwBtcx0LyGZNGV6qKcTy8o3YqC7GT976d1wbuygtlWhCQcTk3i1mCTkh+OlnuHTpglSImzdFNrkxteqXt7fvTvBv53CCqnH0w3dxhnCIUC6yx3EqhoBCAHLuo1O4fOmjvwwgQjneHf8EF+8/xeNPxOzmU3zy6SN54fxVfqBIVxqWjBPqjBm6vJUV0ouSUBXUDXqs9zN0s1oqPVqoeCItcSfCuSB07AjRfAg6vx6lVJfaQB0cYkFi1of2wSaE2wIIs7rG2aEcKQsq7eUoMmyTFqrUVCwX+gWYZ1zMPVZaD1+TUwISpg0LERjxHrHmqFzwuEaxEWuVBbDRvlRSveJiqcmBJhjqLYTJD33EjFqPBtqQhXYqhEibuNakHq1UqC7mIy8LwCoBh0/PpsVi5qmFbjXmEo7Z9kqqRwkr9lZ2yALZBBxCPVYym1hZZbsPDbPK5glvgsfglsPeFYTGFLdQZbv4swPlXuajqBHr+LpLmBEW2QiDRUFLpcRLtKhbAiJI12KuhUrACi+uNJxt005BYlZjOvODuJjqz9euy9W/OqEgU7PwM9hmG6fgmsvnL3bw9WRI1zCkTwHyZZUS/7m6Gv9nTQ3+L50KX6J6fMXGLELF+FK1lvnGTHtmQhG/x0B/Qg7p2uudzG0VqOJxV7hV2KgtxXplIRZtW4U5m5bKnWneeudXVIRruHbjEjv+FSrJTYbxe4ThhrzI6eb4DZw69XucZbYYHxeB/ZYM6kJ1zp07TSv1O7z/zlvSTl04f5qQHMPR379LOD7A2TNHcfHiGVy+fP4vNw/yzs2P8ZtjZ3Dl+jVprcRWK59+9piQPJTXpDvzcRSzAq9ylGCdsxQVkTpUiapHMDZRKSzsvOIqQX9LBC0DLegZzksQfM1BWb3F6t74jjiyuxqR6IzCGbNByYpviRkRafEgSVBCYuLMXo0KWxmKzEUw829BsegvYaLy1KIuUENQ9LRaUapZG5r7sgizs4vrpA18rJvQiCX46qiJ4bdeqoeCna7CocQ2WpEqdpRwvp45h1WxwQMXO7a9qx4laQ9WBMVolQ4LCflCgrSIKjifxzebPnsGlWA6Q/iLhPd5KsYL+s3skIXsiMXQU8k69uflKoO2va1UiyCK9BWo4HN1cSPKqQa5oRy26kuxzlCONbKiaxmgNVhiU2Mxg7RYwLicuWMVj3OhsFfmKRUQF1DNZoUXbYZZXEBF5dBPLW6cwZwhcsc0kUEIyvRngAgFmRrNIoDMMEsJyAqnGOYl+A4qhKIG/7m8Ev+5rBLfIBhfc9nwV1SOLykM+BuVESv9bqgIc4LntokWV2Q4R1oodC0V28rzyO+/ajNWla3Fkq3LsICtluC8/cFbcnHi+PhNefWg6Pxixa6A4SLV4QI7+MlTH8hh4IlbYk5kUl4nMnHnGk7QQh2hlTry/m9prY5KCM6dPUkwjlM5PsRFWnyhMJcvX6CCXPj8ARErdo+PP8LFq5flhxQjDA8ePJDLAT5+Kn5/Du5cXC7Wq00ZUJRQ0itroGTHLY0rURCuRHGkFgZC4GIHidLHD2zvQFt/Ezu0gxZKy8yhgr3VidiOBCHJwsNKL/Zjcsdt8Ge8SOTDMFLSSw1lUNNm6Bj2axwKGNnBFe4qKpOCoBiYWeIYPTSA/a/vRAchbOrJINIcQrYvLffeSo9koY6Y4O+IIDmYhjZqkZe+VjhUKOWtn7atfiiNRH8KOirLWqrGYqrGIo8YrVJjgVvDYK4mJGrMZ1WfQUs2zVTGJma5t+J57RYG4y0SkHm0Vjp+5sa9aTQdyCC/j4qVNNNWKVDLMK6n2m4jFLqIEVu0RVhrqGRw1jAb0L5ZmQlsosKLnwmKVSmzxwILqz87+CzZ2XlLMESbLuCQ14kIMBSyTZdgEBKdsFlVEhLxHBHURVtoE4BosMLFwuY2SEC+RPX4P4or8JVaFZb6bZgb8eJvbTb8PyYbptltWO01I9gZR8t2hvLhNHz5AGpcKtjiZp77GDZUb8SiTcuxsmQNlhetwqKtK7BVV4Y3f/vTZ8O1U7PmYihXbO1z4eJZqRqi+p+iZbp2/ZK0WGLy8O49sTfWfakg77/3W/zqzX+ngrxHQAQI56WSfHT2hLRVlwnItauXZPt8AZkkHLc/xZ0nn5D6B3LtzJ836xIXtoiAdZEHnGhnZhjIIjaUhKuftqfDwxNJa9TmkoGzIq1FsCeIvt2t6KTVaB2aumYino/BxwptChnlzhjOVjdy27Oo703CzM4bzYXRMtgGZ8KNFaXrsKxkFQp1hVDRl1fbKghJBawEUYAhlraPHBzA9kNDaO5vpM0KMJe4pELFuhLoPtBN/0+QxbJzQpDbnZXLX1T0zkrCZyGUsRFxkVEDvH1JbOT7L6ZqLBaqQTDmuwiIi4AQlPmuOsy1ixwgRonK8KKY5eZxCUhe4O1SRzUKCZA5ZUXzcBM69uWZeQLMHla40j55NaHIICpakloWhxIxekdLtcKhIxTa/2hLJTAaOSy7kJAsYDifLzo4lUCAMtv0DBCCMV2vwMxnbUoxpnLHdAGHBIRBXSrIVAb5MyDLaK+WCwVh1vhKZQW+VF6Bb9VUYi2V66WgDXMIydJIEMpcCOaOgLy2PTuQobUVG9ApUG2uRpO4EIwFZWXRaizYsAgry1ZhXc06bFRsYgE04Lfv/VoucRedXqrHo3tynyuhGufY0c+fO4MTx47IzeGE3RJzJpOTN+VzPjpzEu++/Rbe/s2bMncIQERYP8/McZG3ApYrly9i/OYYxsZufD6AyB0UJz7DBzfu48rkHZL8mHBMQSFGHMRS5Kn7j3Ce9Hvp9b0tATSMNLBSZulNG+T+VI3DGXTtzEHbYEJ6KIGRQ+0YYEdu7s1iZO8AGlnZU+1RZHtS9LJ2OHnSs0ONtGK0IuYKbFGXQunQY13FZswrWIalpauwjJWpzFCKKlotZ9oiL8wS1SvWGkCsLYRwCzNFWE3LpZKh38mgnRltQHwggfZ9beh9uRudB6aGIxP00d68H26+X7AzhnYeXysh1hKuJcwZC1xCKf6Xxp/nOWmvqDjz7GIDhQoqRgleEJAYhM0Sk4MVqIzb4cn6kcxHMLC3R9o+d9pNOKiGnfU8bi9qqAgqvoZCbCDnVWOb38IsYMAqp562R081YdYRE3q2PzehJCqqC+/TIom20Epw2dlnEZCZz2zUTAGCuE8oBCQzRAZ5piJiJGuuScyFCIslZtX5WrR1i2mzlrn0WKAqxUsmBdZoy7HVOhXES9M8n020pF20iTs60TbCc9SfhS1mRTGtYR3PRa4zjQpax9Vla7Bww3xsrl2PamsJtH4l3A1uHDnO7HDhDFVknO7jrrRJJ08cwamT4vdnZdD+8PdvSwW5fuMKb8/hxthlqR6//c1P8ObP/hW/fvOnUkE+Onscv//gtzh29B3Cc4Lh/DRt1jlpsz46+3ktVqRyHL1+B5du3JCZQ1zmKFdWEhQBhxiTFgvLxGzn6XMnEWKobRpMYfSVTtSPRuDqZUffUY+OPXn4GcS1TVa07M6g/+U29B/owtDebvRubycILgRzzBE82ZWOGnkddGpnhtnEK+1HgaoIK0pewvyC5Zi3ZSUWMvitqliHWnp4Pa1WjpW+sSdBq2aGNqhmZa6FntnHnDDKSUEjX9ffEpLb/tibXGhgxknz9fMHWlFPsMJ9USSG6tG0oxnZ7U2EOAtHgx9bfOKaCg1hIBAOqgXbHLb57EzyZwbnOezgLxKM57QM6HoR0kvYMUuxyWOBLhOCvymGlpFm5A+3yPOQ7k0j3kcgW31y6x2xK2EVg/o2XQn0BKoi6pJwrGQlX/kfgKhlHhFBeoVoVJOV/P1K2i7RlouMIlSFajJHwCGGc8VolYBB3BeACJsls4gARIF5JqFEKjmTvoQZZJFoVBEBYCGBrWABqKRiVtPiCpupJOj6eq/cjrX39V507WVxaU/B4DfBSIV1RczQia1+nCpUWoqxqW4DdK4aVJm3ocpaCg9D/O/efpN54feyw4vZ77d/83O889s32dHfZpY4id8zY3xw5Ne4clXslXWeWeQk2ykc/fBt/Oyn/4yf/eRf2H6Ao8fexolT7+Po0bdx/MR7OEJQjhKsk8c/wIdHGOTf/tXnAMikWKn7J9x8/Nkz1ZgK5E+ePCQcH8thOQGIuGxyYuI6FeQ02ll1W3Y2o5NWovcAvT9tSqAjJL1qsj0DLa2Gp8cnoREXVYldFJu3NyJFz6/0qWFKWGBJO+BpCyDE3+nFJglesccSwz6zwfqaLZhHbztn3RJKd4HMH1aG3NbBBtiFr3eUMUdUoM5XyyrtkHvLinkND/NHh5jRZ65Jj2TQyvDeeqAFA6/1IdPPfELVaOIxilGr7HAzVYWVkVV/bcAo4ZjPzjPPLiChmrAtdIjNFDRyZexsi5hrKMdzmmJ8U11Ea1Usr+WYq61k51Uh3t2EpqEW5F7Nofs73ci/0YKm17KI9EcQaY8RaAPzUy2UITUUCRvWEgxhsVY49M+aDit5K6BZJe7bGKYJyGoBiW0KlBVSTZgnCMh8MUKlJRSaKgnINHXlf9grqSRCWagg80zP1EPAxeMU174v4edaaapBmYNq5tdBxeynyPlR2uSFoU2MDCbQuqcNPYf70b4/j1hnFK6MG464Ay4eu85Xx/yxAWXMXQo3c6JbgXJzMb+7UljCevz7T3+I99/9NU6ePEIofsc88WP85lc/ZQd/hwpwlgH8d/jo/Ie4cu2cnGG/PvYRTp/5PZ/zG7zz9s/x29/+BO++80tasVMyowiIzp8/gfMXCRIzyLFj7/DvvyB0P//fD4iwV+9TQc4/+Ax374vc8Qh/+OOn+MMfPpP2SjSxh+rNmzflcNyFq2eR7M0g2Z9Ez55muZNIfjSLhu56pPtSyNGvhvNRFPp50pIaBLtCcrl7gJ68Z1czDDkL9FkrrDkXorQ8YvtNbVQHQ0gPDW1OtDkMC6uUuF+sK8fy0rWodimQbI2gf2cH8sw+xpieClTJL6cGjrRNjm55GnwId8XQ9+0eJAbrkWCu6XujH52vdmHg9UF07u9E73523B1idCmO3EgrLG1hrA4aZdYQcMyXm7epJRhiaFQu1WDHElvxzHoGyIv6MmmzZpoqsTVgQ208yPfrwvDhfTwP3fyMtCUsHJ2vtCO3s4kth6bRJjhzzGk9LAj9YdQxF62RgOipFlMqslq2KTjE7Rpxy+NYRVBWEJAVVBfRlvJYFhGQhbRZ8zSVEtC5vJ3NNp2QTOPtDF2lhGYOVWWpVVi1OrnUZKkAhIoo1HJdgMDGrcyBUcIRxEZ2/i0JFwtWHsP7Rvm99qJndz86DrRRcac2Ine3iJUGJmjCdVB6lShQbsRW1QYomA8FNIaIXm5f+sN/+2d8QECEPTpGmySAEHMax1n5P6JFOnvuOMYnL2N8QuyVdVVu5iCWo5wRI1VnPsDJ0+8x0J+SG16LkS9hw65eu4Cxm5fl/llCTY4dp6oc/7yWmkz+AafGH+LBw0dSLYStEtuxfPbZZ3K1pdh5+/7Du/LSxwtXztBXpxHriCLH8BthJxPXcNd3x5gxkgi0BmkrQtgsJr7sJSihNbJkHbQb4roEZoORCFa6i7DJXwlXF337AP3ucAJBZooqWw22sjJvURWi3FQuJw0L9duwTVuMruE8DhzegZdf341Yc5DWSos6j5LKYoGTX6435ZNbZ/a83oW2/S3I9NWjbY+4TiWPDuaQCI8t0hZjSyI22ARPXwY1LV451zGfnnz+s43bBAzz6PXnsWPNZSCew/uzGI5nmsXVexXMH+WYxtsZpmp+Dlq7dAT1A10wtdRjc9iBxEArcju64OvPIbunGy3MYGJzOm9/EA2HMoiPJuBgdtoSsErFWOEwYK3bhHVsAhrRBCCrCcgqYa94HMvFKBc7+TKRS8zMIroaLGATt0uMtVhAO7VALDFRl2N6XbnMI7P481xarEXmqSFe8VyxWFHs4bvCy5DuNWBjzI6ilAcvRRxYTtjXxN2Ib+/B4e+9gVe//QoGdg8h2zuluJ6mANWmDqaoiQVQXPdjhIaFq8JSBGNQA1/KhXiefSHjwo9oj44zhF9iXhWrbsXcxblzop2UP19jZ791R+xiIhY0XsHYxBU55Hvu/EmCwXb5JFXlAiZuXZdb/dyauElYrsr9esXI1QmCJh4noPl8ALn9R5y9/QhPnj7BE9qshw8fPrNbH8u9VD/+5B4ef3Ibt++P4fzV0wh1p2DmiXUy8BrE1pZJKyt/CAmxKVw+CFejh75WjXXWCmzyKqBtdcDd7UbvKy0Ijvixyr0FJuYUYcusVJd6sUaJNk1NuS9mhV5atAYlxjJaqBoUGQtRx9fYe2gEr3/7AAZ3diHAIG4M6plLjDAELTDwC3en3GgUa7l25NAiVs2yerfvymP/68Pof7UPaVo8oSLZ0TZYGJy3pmx4iV+yGLVa8Gzbz/ms1mLj6DkEYq5JLW9nij1yxXCquLTVKP7VQAWmGVilxYpZdj4RdjW5BLYlPLQvemyNuLHWb8MyrwkbWZFtVNtARxLmBpdc7h4fTSJEddNkfFhj12ENIdvotWC9x4S1LiMtFVXEPmWxVvBYxMZwy3i7hOAuNgv1YDMwV+hrsZi3SwjBYmONBGSWpoKWq1JmEQmIXIdVJ4eRV1AZXyIcK9nW87yt9puxgrliZcCMJT4LFvAYFgRt2NgUhGWkBSP/dACv/tNh9O3oZzFMwCAutHIq4Gvxy72xxNWR/iYxPK9GtjOFA4e247XX9qKJgf4XDNrnL5yWIfzCBTFqdQzXr1/AFYb16/ydUA1xpeAkIbl5S6zTYkC/QPt0+Qw7/RmqyQnePyuXzIvXGBsTy1GuyN3hz9F2nTp1bEpdCM/nAMifaLE+w6U7DOSfCEv1RM573BP7ET28h4dP7sjNhx88Hpdr+k9dOo7IaAMqgiYp0doGJ/ysiCGqRrgrLK+t0PBkljHEFVM9NoQUSOxogK7ZJreasbaKndZLeJL9yA83IsrniD2pxCy3ilApmUO2qgtRaa9GkK/lpfpkOmJ4/R8O4NDre9CzoxPRXAh2qobaa0QVrY9YS+VmwGzd3w5fRwQJhuO+w13ofK0TPfxdx15mIAbzoVd2IbW9D+vDdqkci9xauenBYgfvs0MuZJsnZqxNwl4JBVFjppitltt/ilEssVeVAIQVWgRlOYSqkkqy1KnDfLGJgngddvCFfM0FLnb0kAWaPJVLbJRHdQ2KtVdUXVdHEEU+VnGfGRs9ZqwXCkI1WWHVMYxrZVtKIBYbqQACDNmoIDy+hTye+XoFFuoFHFQJwxQg8xnc5wg42OaIESyCs5jKt1Sqh5bvY8Aytw6L2Zb5TISYBYJtnseIOQR0nt8qdzBZQ8uqYbE5+KPv4MC398nti5QBDTQRHVLMdo1iqdHuTnS92oZa5iqFvQYxKszwri4qTga/fPunuEYFEKt5L1w4hdOnj8iRLJEnxDXmt++OyXaDYIiOL0awRB4RF1hdZgG+wiZmy0XIFxOCYgb+5vh1+biPPjrFPCKWqAh1+VyGef+EDyc/xY27U6oxFcinNuwSO9eJ64LFfkR37lIOSfu7R9+WGwJUxU0oZSerCBnk3kuuVq/c2HiLtxYbaJW20GKVRbRQNlrRc7ALYdqb3PYm+S8RKuM6+NrDcstSY8aCurgWG+oKYQtZEUkHYKSS1HnroKLFEntkCdXoEv93pCeNbHcag7t6sP3gCJxUMQFVia0aieEUM0cfsrtzyImVpq93opWANPI9Ow4RFnFdRn87KpIhVnu/7LwiiC+ilVnMjikAWSDVQyW3/pxrYS5hZ51tfmaxxKJAdroXdBUEpeo/5hjms801iQWBGmnJ/gzIArZ5DjHhSKtElbN2JlFPdYv2pmFkJ3Q0+6Csd6OAgGzwCDiYRageyywCDA0tEcGlii0y8jXF6xOKBXz9haIRmnmEYz5D+gJCscgo7lcRFgJLRZn7DI45bGLEawk/10LmmLlUyXksCPPEEK9bjyVUufmEZqZ7qs0SP4etWETrtY6hPXCgF9/98T8yj/TQFXhltmt9uR15sQZP7OI4EGN2rEMpw3qtt4Z21wQn3cPPf/cT2qZLePBoQs6ai4lBMeQr4BBXCIrrQcZE+KZdEv9gR3R8oRZiRa8A5PqN81QbcWGUmBAUE9YTclb+xtg1qSZiIaOYQ7l69XNYavL+5B9xZOwhro1PSEslABGLysTWkPcfiZWYU9cJ3xi/gGs3zuE37/8SjmwI5bQm5X49yiNGlLHDV9TroSAwK2mrqqNWKJMWlIbUckZ9z+Eh7Hp9BIOvdKNxVwMcHT448l5sI0zrLRUwETIxlFufi2PvwR2EoQ1G8Q9mQhq0DTSxZZGmirjr7XKm3ZMKoKGvCYGWkJy5rQ5oEepJoPVQB8HoQesBMZLViPRIGm2sdFm+RvfeIVQnAtgYdMCQb6TFsE6NUonhVXbMhVZ2ZtHJCYPo7KLNZmeUzST2yq1j/hDXhldKJZkpOqBYxiFWzNLqzDYQLFHZCddCmwBEj7kCEAbiJfT7hUkn6tqisLTXQ8e8ZM+zODTHCYgF62itBCDLLLopQPjeS/g6wk4t5OvOJxDiPeYKANjmioBOizWHgMwhGAKSeQzr8zRVUkXmCUDEal7j1DCvmD+ZR+Bmir1/xTERkoXPIJnFNp33pxOQGYRlvlhNELVhSdyOlzJubP/HfehlphIjdNnteTQwsKe3pxDuCaC7J4lkEz8Lc6A5YpGXSBexWP3rL/6VHf2CnEUXtujG9SvP/v/HhJxdn+rwYrPqMUzeviVX856n0ly8TPW4dlparUuXz0mABCBjBELejokJxan/TiVAuXTpcwDkPQLym7OXcJZyJlbsChV5yFD+8PEdeXGL2FVbrKg8f+EYATmP3594D8aEF8WU7jL6Wn3WDl2edidrwUtiGbhiE5abKrCB+UEsdRf/gGX41Q7seqUfI6/1sLpnYG9z0mI4UeCtwHJdEU+quMCqFvneHL77g29j3+u7YI6ZURtUo4OBum+0XU7CpenlPRmx8NEKb0uYFSwrr93I0g+LDd4i/XF0vNqO9r15eflvsCuIoV296B3tRu+eUViaG1AU8WBb1I/1Qae0VqLaL7ILFWHndBmoAOzcVmGXtP+hJKIJUKYTCnExkoBDrHMS8wwzdWxaMSchLBc7s0mARjWyCUDE3IqGMJpQELVjiUcvFWuZmBykpVrlNuMlFwM622phryx6CcZCvYqdnrCJrGEQ6lE3BSGhmMX3m6GuwgzCIIZ4ZzCUCzjkSBZhEdAIdZknFM4oAOYxCWWk/ZspBh7sYsROKxV0tkuL6TyemfzcMwjINIIzg7+bHzRjIdV8Lq1XfFcnehnW+/dvR6ovi1h7bGr3/JwXjc0RDO5og6fBzbCukHucGbI2vPXer2iJxuSu7CJci5W7omOLXdnFtqNiweKtSXHF4G15kZQowJeu0lKxj527eAwfnT8m1URkFnGZ7XU+XsBx8+YYobki1UNcgiv+xcL/dkDev/Upzl6/SSrH8fFTMZJ1n6F8Kpg/eDwpd90+f/4kzpw9QkBO48jxt2FM+lET0svtcywM2Y3bMzCI/8HhrsNSfRFWm0uxwlaKJbrNUNRrMHC4E699fy/+4QcH0HUoj6GD7Qgxg1TFtKhNmbHFWIKXqtZhs2oLq5FdLjnR+w3YrC+d+tcBdgU2GUphSbrQupOwvbEf//bWr/C9n/4b0r3tULLqxRiAEwNJOJrEVYMptO5tRxetXf+rveja3omD3zkMe1cjlrMDLBYTZewgi8X/AXToqSACEmGNhM0SOUTc6uStCO0SEFbzGWL5uFlsLK2UcMyWdoYdV8fKbhKZRSiQRr7GKobexXyPhXyvpazQIqcIOBY5xDIPI5aLESsqx3pCIgBZ6zAREMLD11hsFDaqjmpAOAjeXCqIUKiZBnEBlJKQ1GJa3RQgs3UM4zqRP6bmRWZpqCo6kUXE8pSpSUJx2a0YoZsjbJYYzhabZEs4NJjJczCLgEwnHC/YVZjmqJO/WyT2wvLbEN/dg8PfPYzh/aPo2tuFXvFv9w42o21XE3p2taNllEpOa+2jzc6yH8T6o3jju2/g9ddfx89+9jO5E/uvf/0Wc8hp/PCHP2QmucDf/xRvvvkLWnYxinVdjmCdv8BwflHkD5FFzsrMMUZLdeXSeblJg5hmEO3aNWGtxHCv2NL0//d/wfYnvCv+5+CkCOZ/kj9/8P8y997dUV/p1uC3mDVzux3JBoxNFiAhcg7KOZRKlXNJKqlKFZVzzhIgMjbOobsdutt2O0ecwESRJBCIZGxsd9/pPfs5Je59J615+16vWf7jrF+pkqSqs8/e+5wnXL6JS+PjKu7qp5/uqrKOP/1DuvdIrvA4//hTOPHdJ/ju1CfqxPOLbz+ifnYixS/+IxtpHg0MnOwa0rGkXCaVZGOTK4NfeAJXwg3IDGjoQSoxeKSN1zpYWlwobilBGUf9nhoUBEyIT1+vCsitydyIRJr77YWJNN7JWJ+9GUsSVmFx4mrE0aOkEzROypRnXn8ZX5w4gT9//BF6jxyE3mOGKWxFFb885Tf2tuEP7/8Zg8/sIWNVoL6rlitdO9xtYSy1yyEgV2cDpYeBxlciaQUglCCy0soWr7CHAESBZZJJRGaJWVedn6QvB2XOHCWpOJHzCY58SjGZ0NocxJi0yK7wECQFUY9jiAJR4p+WyC6VAIIgWUGWWWEgUAyUWLwu58+LtVEPslhASpDMyxdZxd+fLztr2ZhFBpmRlYyZMggGYZI5BMSsbDlRT+HfIPFZEupO9tAKe2RN7s4RIAaJEpDwmRzMJovMIpvIdTYBMYugEYBM53NmEjyxJRYYGiLY/9ozePY1+pC+Dgw9M4S2o/SDh+sR7vGjRs5HunyoJoN37G9Dy1PN8HSV4sizRzA4OIhPP/0Ux48fJ0DeUwD54x//hC+/OobX33gdL7/8ogLHtRuXo36DLHP+wukoQOhZhDEuUabJtrCwRlReXVfXixfPq9uSefirAUQOBKNda6PAkPHFtZ8xck2AcIeSSsYt/PjLTdz7+wTHDdVf7vLoBbLHMZw+c0wZqG9Pf46aPdUIDJTD1GxFWiWlUEia3pBJQi4UcQUvCJmwypSEWP1W5E7GZVUMhRDZFYSu2oqUYml+mU3DbkeKKw+xyesQl7QW8SnrsT5nGxIMSUi3SsRtkmp4uaUgURW61hRJsQYD2oe78dxrr2Dg8F44KrzQUb6kmrJUo56GQ43ofKoXr73/Joae2qV2YBo76iizmlXNpkT+bYttnMjGtChI9JKLIT5EQJL7n7tQevEleQokAhZhBwUQCS2/v7OlEdnDVZoTd4GWr6W8mk+ZtESvwVqHkcyRT59zHyAcOvEXWWTXKDCWC9Pwd8pYRvaINZJZeF08ac6FQR7Pm2SPPGGtdEwjMKYTDNMp62ZKUWsCZCaZY0aOxGFJbFY0eFEYbq6AV7yVfvJcRwBBWfyYgEBPQBMs8SVm5BIIuQ0VWOo2UmZlK2aZRz+yo9wFX1cLBg/tQ/eeAew5SgWwuwEVBESgRUJ2QujZz8eP9KDnSCd6n+lGNRfDj7/8gIxwRq34kh0oPT1knD17ZpIZJOz9bLSow/WLk3LqLK/H+bpv1Am6gOQCASOguc8YUsRhbGxUHR4KQOTnXwUgn92MZgd+NfF3fDPxCz4b/xlfUFqdvnILE7eiOcK3bktJyGu494uAY0IVC74iNY0mxklxsoctiffncOLsVxh+aQAVe4KwtNuRHNIgoSwfBr8JHo8FzpAdPn54xhonCqr00NXokBLMh77BAt8gJVC1AztowGP0O7HZnoUcTyGWJazBoo2xWLx5JeZvXoEUa6YqG+SX8qFBqzpZd5VbURR2I4lAkLyKokgJfNU+6Dx6GEtNyKK+lwNJOVMJkzUad7eojrPV3XUIN4cVi3QPdxHYVUivsWC5O4tMkkYgcILrxVhnKx+ygF5gvkG2fXMnAUKg6POV3Ipu+UYBIrdnc+IKa4jvEIAs1BIcOskjL4jWrDXJ9i9/livfU1hBwtqj4KDs4u+Qc49lnMTL9PJzvmIPtXMljEFQzOX7z+ZQzJGTimkCitzJwdtTCZBpHAIQifCdyfvltjCcbFPLtrUMkYpz+H/O0GViemE6r/wfyBhb+bkefeMFHHz1ZaRXh+hL8hWbLCD75dKz1e8awPDTh1Dfws+zvp5e0IvqAS6QPeWo5UJZO1iFI68cwe5ndqOWJt7X7sOXJ48przExIU06J9SOqOxCXR6TxpzX8eO9O/Qe0Wrtstt1/MQXOHXqG46v1ZAT9YsXZM5x0KhfuChh8WNqA0nC5sWky/VXk1hf3vgHRm78iCs372L81ve4NME/+M49/HDvR9wiKFQy/a2oYbojlbTvXqP3GFUnlaITx8Yu4MrV8/QnEzh9/jvsVQDxQ9dmQkqIssqfDwtNm6HcoCoH2iValibZ2mzDjkAmltl2YnVxKjKrCxGiZtURJDH6bYgr3Ib1uduxbPsqxG5fjeU7VmPBxmXYoUtCpLkcLZ0VcAes8IZdaGjwI0BQpBAg0i46k+AKSuBhfxDlpHl/Z0CVFCrvLoenowzeTmnHVoNQWwTF9aWqp6CH8qx+sJYSrBZ5tTasLdFguZUruoUMoqJcJ7d8DfdBkqdM+3zdJEAKpOPTffbgxBXzrLZh+VoCZAmfF2MoVGOZSUefQV/BsYxDwLFYnXGQLZScip55rDBEGUTk1VKdgCxbbeOKvFKyjWM2gTKL4JieTUBw8k8VBuGYpoYAJJGgiIJEGGW6gCVXEq3IQATHXHooyUScxet0ehIByEwBiC4N8S4d+o4egra+GiuKbYj32JBWE8KKIjPyK/0YpnfrH96L2uZm+CvKlT+sG6pGw74aBHv9vF2DV95+DYdffRGWkBU6epEPvvhIMYas9iKPxFzLbUmW+p4AuXR5hBP/Ahflq7g0ehpff/Mpvvn2c5w5/Q0uXRTmoO8YjZpxaR99/z3kfC6arz6qzkK++eZXqIsl+eVnbv2MOz/e4x93V8VV/XjvHn75+8/45d/vqpZXshUnf4wEJMrj0kRRWvbKfvSFC6f4j33Hn8+ptMmzFwmQZ/sol/hh9btR2GyiB7Eh3OFHupdAiVA2lWqQFdFjXVkqlpg3Y40tGZud2cggm9Ttb4K9oRjL8zZjReo6BYqYLbEESDxvEygJq7FTmwCr1wQL2UXPEagqQW2NF+UBN3KtZKz8BFXgzVBpQkGwEH7Kvc6j7Wg4WA9PdxnKBwIIDYRQNVipOuzKKXBuSS5MfiPMAbuKtPXTj1gbi1Sb57UEiFQalDBwYQ4BhrCGXBWT8Co7U8qcaySLj0CRbV1KoScoiRYQGIv5fGGQpWSPZUYdVpj0iCGLLOFrYwiIKED4/nyNbOWKzIqyBl/Dn5eK/CJAFtGDzJf3pe+YO+lrBCAzxZgLY2QlcSQrqRWVW0lqzBCgZCXyMQ4CRkCidtk00Qagkss+kwCZUUh5RRaZLWE1EiFsyUfn4UNwtbUgwV9K2UzWPbAXq0odGHrhCA49dxRNrW2orKtDRUMl6tprUdNZje4jffA0lKHjQA/2vniEXpByt85NxWDGwecP4+OPP1bjlVdexfvvf4CPPvoIb731V5r0s/jwww/w4osvqNg+kVEnvvtKhY6MjZ3H2OjopAGX8JLLqjKjisfi/bJrJTJNehW+++67+OyzT/77APnixr/jwvVbavtWonPF2KgMQdmxuidde8ZVqRVpuniFNCZlIG/ekioUBM0VObA5TR8iPa4lROAyvjzxOVoONqPxQDVaD9ag41C9Wk1a9tSjqq9C1a2S7kq+jiA2+HKxnSPLq0VGkYa6tUxF23bs7YA+YMOSnWsQn7AOa5PWIZZGfJNmG/RlhdDS7BeW6FRilTvkRKShHFaPDtmWDGicGmzL3KoSd0qbSlRTTG1Aj8gAv7z99QjSPNYOVaF6sBqVgxGCpAo1uyvJNl446xxwV7tR0x0hu1TCGrGgQAo8k5U22DmxCT45E1lgEOaYBImckQiT6KIMMlMjBRIkYUlO28k8YqxFGtF3LOWIMRZiuYkMwusiPrZQ/E2hhJdz8usle1BOyQU0Epio+Y/DwSWTAFEMQkYScAgwZufKEImVHmWQzCRMyUjEoxkJvCbg0czomE5gTON1qgy5rQo4pGCatFAooKwiSGbx90jLhFkEyBxDtHXCKrcejvow+vYO4Mi+YTz34ovoPXoUeVWV/C5b0bunB7UN/FwjFejs70FzZwsaOloxRBBVdVRj4OgQqnbVoqq3RhV1kNpih549hM8//5wT+DO88MILeP3113n7c7z55p8JlA/x17/+FYcOHVRsIExw6vR3aktXAHH+/Hlcv37fjF9QC/fY2JgCh1xlF0u2jkVyySHjfxsgcs7x9dhtXJ24ibs/RE/Lb9y4gV9+uad2rO79fAs//HRbFaWWA0Ip7SPxLyKvpFTkxMQVlTd8584tVSLyOGnQ2xWm/qxE79Nt6HuqGYNcvXc91QNHswO6egtyyR7bizKxqSQDeREjstxaaP1WMocbg4fbEOkJYYM+GUuS16hAxNWp65FmToO1TA9vpRsOsofWpUGePRfFFW40tFfwMSOZJREGeg4TPYk9ZOH7uZBiSMM2TRJyirTwtpehcR8Bu7ue4KC8GggjSCMp/QmbCOBwdxCelmJUdofQtrsRLr5e+hUmW7Kxw6HFCurvxWLWZSdLK4eFZA+RW5zcwhSyeyWprvfZY6Gs+Lr7ABG2kEGgGLRYYij4D4As5ljC913C95HbAg4JUlzO944R0FAGye7VfDH5GppqAmR2vnSbIiAJjMdypI8IgUnGEGA8mLodD6TswAOpO/Bvqdvw+/QdeCRtJ6Zm7MQ0Pj49M1FJrym5UnExDY/Qm0yTFgmUVzO09FCUVnJGs8JO9u1o5kLj5+fpQL6bPzdVoH33IDw1YRj4PdS11KCppQn7Dx/AwDNDaivdEXHAXkPp21WMMKWtBIXWDzeg53Afanvq8MmxT1SmoOQUyYQWsBz78nPFBFL6R/zIV19/hVNn5JR9RJ1pXL0imYXRxVrAcO6cxGGJgR+hL5GdrChQhEFUC4Xb0TTe/z5Abshp+b/j5PUfcPO2JEPdoYy6rVhEOvr8499/UtVKfrx3SwV/ya7VeRqkS9KGlwZJttQEzSK9JDvsO6K9fk8jeg9xFTnSjLo9IZT2elDW7YG+1ozcWgOyK3TYWpyOLY5UpAULkOjJQypZpL6/GnuP9qkgx2WZm7AhdwcSChJgIDDKq0tQTu9SHLIhWEeZVOOB2auHrdyMkrATzd21yow7vRI1SiZoc6HQr4O+RMvXm2CkV7GE7ajdVcUVsAuth5rQeLAONbsqEZKtyF0h1ZtDclc81UWUWcIoLpUm66D5z/bZVXStAER2neQkXUAhXkQYRLZvBRiz5ERbzjoKZceKYBIWUSChGddFARJj1JIdCgkK2daN+g4ZcltklrDFUjHpBFgMby8SY14QZQ7ZCZuTR3DkkDEIjGlZqWQFAoPM8TCZ4+F0AcgO/D5lO36XvA3/lkKAcDxIwDzC+x9J2YlH+JyHBEiUYw9Rlk3Jl0BLAlsrcisNTxqzsNptQFqgCM27ulHZWYNAU0CFiRgr7PA2BFBMv6d1aTG4dzcO0aMcePkpLjKtZGJ6vVavasbqaSniZz2EXU/vQ9PuJqUOamjgP//6M2XC5dRcFlmJqbo8dk4Vkfvp71JfbYIy/qzKBRFvOzYqQ1obXOU8u84FWfqKXFY7XrI4C6AEIAIUAUl0A2BC9UH8VQCi4q2u/4yx6zdV3zgBx/2ARAlOvEPWmJDm7FelJMuFaPzL9asYVRXvzqigMKmVKqefZ0fOoJngEPnSTfZoocQq7SzjpLer0/Tkslzoak3Y5ElV3VKzacxTPfkoailFI2VQy94mZJbRwKZvxOqMzUg3pqkkHK+U3+EX5OIkr+gIw0d9KzIrx5avonYrmytQQENpLNIREIUEZZmq9eugbBJzmGqQUGyD2oJs2luPisEQGvfXovPpJrQerqH8CqP+AKXXQATe5hL4mothKzPARYby1JYhqcyCpeY8tR0bPf8gaxgmT9Y5HicgxJTPke1X3l5AcCwUgMi2LBlEAYOssYLsEUuDvtKsI0gKlP8Q5lAAmWQT8SOynSumXMJLFhUKOLKi5x25UXBMyyYwCI4pBMfD6QRGWiIeSkvglSN5O36fsAUPJG3l4DVxq2KQB1KizPL71J34HccDZJKHxdTLzpbIwoJ0Fba/ymUg+1ahbU8/ug4ORU/K97WhaVcDymqkpnIt6jqbUEXmPvDUXgy/sB9DT++nbJXQfYKjnf6z2kNPZ0HDQAPZuBN9Rwa4KLVQ6gbw3qd/w7g6+R5VDXREkVy/OYYff7qposOFGU6fOaFC2i+NnVFSfmxsRHlhMeXj9B9S5X10VCTWBXUecplz8eTJE9Ei1upcRBrr/Iot2L4c/xFXrsmWW7SsowxB4W0yg3QivXxpRMXMyN70hbETuHDla5y59AVOXfwU5y5/hfOXTnEV4B95/iR8/TS4lEsR6f60K8wPtxG1/RXIJBDED7gbncirKCBwPLA3u5FQlIU8av2CICckV5+MUk6g7K3Ykr8DBdK/MGCGnn7DXG6Alz6lcbAJxVXFKvPQVmtDoc9IuaWBprgAhWVa5EjsFX9HeCAIf6dffVF2vxO+evEfdajm31JO0FaSNVp2iycqozTg39tPObC/Gi2UeZ0He9C5m8a+rwHepiAy/GQ1s0Zt9SpJpZcQ+MndLGERAYxijShjKHYgMJYRGOIlRC7JNZbssZIAiTeLUS+ISikBCq8SoatAIn5DfMnkEN8hpvyxnAzKKJFSMiiLsug5MpLIDDujzCBXssa0VPqO5K14OIWD10cpuaYSIL9P2KyY5CHefjBNWIRSS85GpMgDr1I+aG5hGjZ7pPdjC9oGOujHmmm6JZyEaqCvEQ29TZRYnWjtbUfPng7sOzKM+i7K0/YqBLoDCPcFVa+RsupiWPmZlVR6EKTkbtrfgaFn96Dn6XZ89vXHqrCCLLqyK6pyOm6MUaJLTd4JFXd18swxXCYwBCBj187iyvg51UlK5t/VaxJndUpVMJFweWGg8+fPkkEkkPGyAthFzlcphv2rAEQKwX1x+RbRHN2lEhaRq+wjC0ik5PyFS6cxcvk4zo59htPj7+PMxN9wavxvODn6Hk5cfB+nLn+Es1c+xbEzH6L2YDVq9kRIqZUqQ65uqAK1ZJTi2mK09lWhqS8MS50Fvm4v7C1OmCqt2GrOwLLC7djiysR2RybWa3bCSCaxh80ob/BQUhWhKGhFeVM5Goca4JL0zxKa9EY3rLUuPs+BYhpsd0sJdEEjzDTYkd4Q2g80o+NAC3Yd6Uf3nk70HuxE+74WdB1qQ/fTrainD4l0yravB8UNRQROCAayU0rQDl2dl6MchdU+JJa7EGvXq3MLCQdZQD+yyKBRYzEn/hKj3JYMQNnKzadfkfgpDcHAwWucUXI5ZPtWTsm5ANCoy+PL1POFXaJMIuBYSMZQQ8JKRFoJM5E5ZmSnKdaYTtYQYEwlc0wlGKakiLdIxhRO/EcJkKmUUtMpo6bTc0xNIzh4+1F6kYfIJlPktpJh2yjJdqqtYDlVlxwRCW1ZR6+VFXKhmp9xoDEEf0MYZbV+VHRHUNNXg4qeCkrhOoJD4q+aEG4NEQxeVLZTqnb7Ud5VhpKGYqQWJCJFk4xCdz5sVXb4eyJUB10YeLoDJ858w8VWAgzlmCC6VStSSVofqGODq+dw7uI3BMdJjI2fxej4aXVb+qNLeoX0VB8ZOYXTJ7/GyRPHVFWT08qvSJGHUWUBhFkuj/6KwYonr9Oc3xRjc0MBQ3ScgETOP8aun8HZqx/jzPi7OHv9bzhLcJy9yds33sXpqx/g5OUP1fXs9ffxydnXUH2gElW7w6oYs/TerqbUCQ6FsP+Zfuw63IFQbzm2BNKQFMhGWasHhiornkxfjyW5W7HWmIwEexZSHdkqMzDc5IXFb0R1ix8eGsUADWPD/jqEB4PQesk6ZCRhoQgneuVABcraOKnD9BwEXXlXAB37mzFAcDQPd8JPNggONaF8VxOCe5pRe6ANYcq1Eso7X28EJW0B6CIurHZywpuzECONZOw0zGSnpTau8latOtxbZKLpJgCWCgjMlEyWQsRZdAoUsZNDggzj5GoSQEi4urCHgETAUoB4k1add4ghl12r6C6VHCjKqbtE6mapk/K5NOFzKKlmERzTBSCZ9AwExSPJZIKk7bzujIKEEutR3jeF4HiUUkrGjAxhFsqrVA5hFAJE2GRKOoGUvh0PESRi3KfnJPB3JGCztQD5HjtNeQDVfbWq0ktVZ4RACSLURyB0eFBJ9u1/qh89BzrQPNSIUE+QviNM004WbvMhsjukipSn6pKxkd/p1qxN2K7dofqf9B0dxvBLT+Hb0ydUWZ5LF86oZKmREcnfGFNKRc5ALo2ewplzX+HiKBmBYLl4+ZQCjRxU37ojFd4vqnKjZ09/y/cZVVu8Erkri/kEjbl0mooC7VcKVvzq5j8xducnUpxUJ/lebaPdZ5KrEyM4N/Exzt16HyM338c5gmLk5nsYuc3bt95TwDhzhSAZJUh4/ejsH5BRbkQipZGmwgxvrx/Ve2nODjTg+VcO4M3Xj8LX58WaQDLSawoQJCVLX4yY7C2Ym7ga2fQbu3d1oKWrhmxTj/7hNtS2B1HXGkBDd5XK+WjaV4f6I7UEhg2+YS+CR4NofrYGvh4vSjvK4O4oQUGVUQUltg03o31PDxK5Kq6hp1jF91/F62pe13gNyKS3yeJYVVKIlQ4pipCJhTLMmVhq5aS1SWFqAsROQFgJHEu+OvmWSNs4AmOVje9jN2K1zUhAiL/QKIAIOyiAmAvV/QISxSLG6DWOABFgiOcQj6FC2JWpz56MscrA7JxUPEav8RgllQBgamYqHk2jGScoHhaAkDke4lVuP5gkoCBYOPkfIWs8miaTfxuvZI2UzSqbcHqamPStvH87wcb3IHCmEygzs7ZjmS6di0UD6rsbydLSLzGM6j0V6B3uRXMfF5VWH3ytpQh3h9RBYDXNeGV3BY24B566Mui9Vmj9Znh6ytS2uSPiRKImUZ1frdixko/rUberHn2H+/DNyW+VXJfT8KtX5ST8jNrNEhaR845vvv2QcukLXLwo/kOYQMy6RPiO8Xa0DpbEYN2YEIN+RQFEslxl7or5l463Fwm003zefwMg/1SHhJJOe2LiJ4xPSB+GO1HfcfuWMt2StCI+4+zEewoMI//DOH9HGOMDnCIwzox/QBBx3HgPH537E/JDdhSWm+GjX3DzQ82sMmGbNwdhalGJzdnhzca64hS4at3o4ATe+1w/iurdWFGwnXKnEk8d2YWh3ZRAg9S87RF09NSimv6hKOziB21E65EmVXKm5Xnq4yMVqDzIL+1gBJ7OYgQHA8pohykJ6skUvfv7+DdUYX2JCbFuTuBiHWJp7uM44j2UOkW8j2M5/ctym5jkNMqnDCwieywhOJbYyBYCCsqPpRZhEU5wmxar7QIMg4qpWmMzKKCskLyNSYDETgJopWKXQt4vLFKgfIiwyDId31Mnkip6+LeQQ07c5+VlcjKnYRb9xQzKqBnpSZiWnswhfoPswZ+FNR4WcJAtHk6V2wSIAgllE0EwNZNASBfm2EymIEDSeE3dREBtJqCi44HkTQo883J3YhP/53WFycim97NVOFFW56GUCqF+uAq13bUqpVZa4vm54AgAvFQA0rioVCpOuvJgCxZTRhXD0ezi588FkUwu6QSZ7hxVVWZd1kak2TNULbLW3c04ToBIBqF0hpJuthKVIYfPKt5q5Ft8eUyCFz/jfZL/cVpFi0uoyfHjx3BCisudPq7ORaJh7dHt3Rs3JGZQdmFvqvO4sSuy6/VfaAP9ycQ/8cnN+wGJwLHrf8f5a8IWN4jA2yr55OZN8R4SBnAO5+k7zhEIZybexsnxv+Db0TdweuIdyqv3CByRVgIQ+o/rHxJEn+K9kRMoa4nA4behuMYNE/VnQcCADbKl682HucWO5Eot8qtNaBqsw8CBTvTta1UFHjabUuk3gjh8aBAtnVWoaiO7NBIYNHumYiMKHBrkFGkQ2RfBrj8Oou2pVtVbo/25ZjQ9XYvQbpryAR8c9XYE2sg0A/U4cHgv7LURrHYZsKKoUI3Y4ugQkKwoKlBjmYvsYOdqLsWirVlkjFwsc+SrsHcJKhSArCBAVtl1WCvAICDW2qJXAUe8TUf2kUJvmigghE0m2SNWDLlZtnajO1kxch5CgMjWreRzPKmZPBnPzVDbuLPoMaZz0k+lkRY59XCSSCca6gwBDb1GilQ7TIhu197fnUraqsDxENnjYTLH1CwyRSbBkLaRxpwjeQOfs57A2MjrJoJpI2IN6TDRF1Zwsrurbao+crA5hCAnfmQgiPaDDfBK9yt+rq6WYlgq6RcrHKjb0wgvGaWQC0sapVQeP1MHH7c3OBGh9JUWFLW7quHr9CHLJRX1CzgfLCip4wLWFcGxE1+pbVsJV5dzDVWCVJ2an1MNcL787D0c/+YTnPrua1V/VxhD6u+e+OYLVT3xzOmTZJ/zyg6I0hm/dp2GflxFgNz5/o4KNZGoj59/vvevAuSfODbxd3x342ecvnkP39F3nL5KcJA5RE7J1tjly3KucVH1mB65eBEj/GVfXzyOD0+9j49Ov4WPT/8BH518DsfOv4pzlFpn6DvOXhOQfIyTN07ibyPjqO1vgd1n5TDDJPV2/QXYVJaJFc6dWO9Pg6HDgfBQBJ17W1UnqdZdtWjcXY2yZi+qO6rxzNH96OhtoMatRyt1ridcBF2JEWmmbFUXq7y1DH3PdaoGLeYKCzyUVJX0OPUHueLtrUCIX1L1QBUaemvRvbcH2ZFSrHTrsdxdqKqyx/Eay7HCVRBllSIpUJCvJNUyAmMpmWQJby+V6h7WfMUasfQf8bZCrHUasJ4AWWOT3HkdVlkJDo6VHMvM0SSnWN6/QkBCXxIFB383jXmMQUspRQ+jJTg00gNd8jnSacIljzxL3Z5D5pglrEGGmEJWmCq7U0niMxJpulPUmEaZpXwIGeQheoqHkrcTBNvwIOWSjMfzkrCRQE8uJUANaZRr9BwEykOJazjW4cGEDZiTuQ3Z9G/CBuIjIgMhlfIcoYx1cGEray1WJX0khq2Y0tVc50SWtI8ImFQ5VjN9Y36xpNAayRYlqjtWoJ+eZV816g/R6+0NwsDHpMWdy29CWcRBcPhQy/f8/PgX6mBZTsajpULPKXCIF/nuu+P0FidVlcQRKUMqOeYc0pDz3JlTyogrvyLh7JRUyjff/h7jt6WfoSTz3VXnIirc/V+N5pUDwdPjt2l2oiV8bt4iY1yV7qKS4ijx9SNqO/f8hRGcuDyOL6/cxRfXflFdpD668iM+vHwDH54/gw/PvI0vL/4JJ6/9lYP+Y/wYAfIpTlw/jncvXEfL3m64g3bYpaJJoEA1f9nozcIGTzq2+zJR3F5C01yvPtBgrw/uFhd2P92Dwaf70bGvE2++/Tre/+R9/OWjt3HwxUPw1wVUmU6php5Jn5DtzIeNq1VphxeFfj2M9WbU7Kmk6a5Bw+FaNPDq6+Aq2FGBwsoyrC4yYrlLjyWTlTri3CKtuPIXk1WcnES8vdwh8omsQVO+lNIqhtJqGb3HCprzlfZCSiodfYYuKq0EHMIaluiIGnQCgABZRoAsJVvEkD1ieN8yk4DDgBijnuAoIDAk7D0fT+RPAmQyZP1xSaoiOOakJ2K2bL+SFaZy4gtIphMcM1MptwQgZBe1EyXyKlmYYxt+l7BFAeTRzJ2I5d+fHbDBIuc30q8jbFH5OallOqw3JWOHOw9bbRqkuAvUjp+PDOymHAp0BFXjmwJ6BY20kqh3oKKvAu6KEthqHCrIVFuihSVghbVCDgxN0EdMKGqiB2yvVFvhUoky2BdB5f5KlPWWwVRjUslSNv5uT71Lhb8HBiP44sSX6hhBNoLkLE0AcOZUFASnTp7AyZMnCYbT6qxNFm3pEyIhJyOSg84F/JrUypKi1hPjfM4ELo2N4/a9X1SN6GjAohwoSpfcH/91gJyZuIt7P/+sCr/JG0TN+A21MyAIPn1+BN+M3sDnlF4ShvJ/eg9Jorr+D3w0dgMfnP0cH515A5+NfkuZdgPHb5Aer53BB5euo/NQP0qr3NAFDdgZyMNGgiLOmoQMnwZbitI5aU2o3VODov5S6BvNMDba0LCrDkNP96GejPH86y/hs2++watv/QUtuztho8Eu4ZdZ81QVrPVOGIJmrnA+hOk1Slq9KCKjhMR37AqjtKcU3h4pUheAs64c69xGVXR5mVNHwx2t1LHCpVOMEk/gyO3lBMlygmGZgMIhwIiCI9aupaSaBAeHyCslp8gQwhrxVgM9Br0HARJjKsQi+oxFBMlCGvBFEk4iEbsERozJiKUGPeZrNXicAJmbS3+jycb8/Ew8lpOOmfQcMwUclE+zOfkFJLM4+WcQBLN4+3GacwHIdD4+Xc495FScYwol2INyKJi8jVJqhypgHerhItFfjxqybwXNdDlX/0BfueqB4qiRIuJOFDcVc7FxwtvMz7CrAq66ImW4Q20hbNemIL0ol88heNp8CHWEYAybsFOXgIIS6cFSRB+og65cpzI5C8qMyOFnqC+3cVCi8T08jcUwBY1wtznpM+2weA2oHAij9UCzCmI8feGMAsj9jSDxu5IVeOHiBRWZMUZQfPPt1zhDxpDdqUsqY1AMukRvSNyfHFafU5G9VyX3/IJ0oBpToJH20FIGV3y0gOVfAogMqc5++4ef8Y9//BKtbXXvJ7LJ9+r08eTZs2SGq/jkxn8CI5pE9Z8Auf/zx9d+xoej1/Hx1Rv0NT/js5u/EIC/4O0L11Az2AJH0IbcskJsJMWu0O3Agtxoqm1CUTbsTR5q1Qj8u2j2KIc81KqWOjfZJAhHUykGnxrGH995C8++8RI8tV742v2o31eDphfqUPtcFQJD5aobrCRm1fbVqfwDkVmqBCZXLE9LKVe1MHaWWZWx3lBsJVPoFUAWW6WvhQCCEsghQDEglgCRiubL+dgKAkOBhSOe9692RAGiwGEXrxGVU3FWAQYHrzG8LiFjLKT/eJJjrl6DeboCzDfosFBvIFiMWGCQ8PZCMoV010pHbNpWxEiIR1Y6zXeq8hhTk7ZjFif6jJSteIzSaQ6Z5DGCYCb9xgzlQcSsJ9F/RMNGpmcm0XjvUId/D/J1U3ITUdFexRFS8rOOJrt6WBaOcrjanajiZ+3vK6OfcKimPf4GP0FSzsluJhjkM5MWEAVYr9muSrUW1bng7fIjr7QAGTTZ+UUmbDNkINGahhTppUL/IXXK4nauQrIhBfFJa+kR86H161RBv7XZW7AmazNKCcTOIx1kpGq0HejCyXPfqZK14iGkEaeEKonZHhmR6ogSznQRn33xKb4jm6gCDtekhI8EKp4lMC5SVhEEKqj2Dq5dv04rwPfgdVxOz6+PR19DFrlOH/IvA+RzssLZCalSMk7Xf1e1T7tz+ya9xhUco6QShrhv4P+/xz8JkB/wPhH86dVxfM4/6EP+A82722EP2ZHND2udNRlLC7ZjccE2bLakIthars4ntBVmFfoe5pfpbfBhvT4dWQEjkvkF1fW14IU/vYyGgTY4qopQPViFrufb0PVcO8LDQX7gHtTtphHkBy5FG0prPSilnPA3eOEMOlViTqS7GolldppuDUFRoMCxSHajrMIOlEKUW8vJKssJgBUccXYZlF8Exko+FufUYo0USiOwVjsIDAGHw8DHKcvIHMs4YgQkdskMJBAoqzaXkyXrNmMOzfhjNOJz9Fo8XlioxhNkkp0lFqzJTuCEMyLTrcEanWzlpqndqamc+CKnHk3YjJlp2zi2k012kjl2cAhAhEHkcDCBfkTON6IBiLKTJezxUMYOlQFZ3d+ACKVOiPK1Ypcf1buCqNxLHyFtmbs8CFPSVg9WorzeBw/lk4fGuaiuhJ+fF3lkV2nosyVvGxcaA1xNdjj7SuCqL1IF/6S/4/bCnfzZQWlVAj2ZPNOSge18/oqElapRzsbczcgkeLZpdmJdzmYVgR0kyBr2NcLXHUJpewCvv/Om2nmS/PNvqBROnz6lDvUktF16hJyjklEptmQPCWuX2lgy5LZ4C2EdKaIuxUOuXJPGOtL08w5u8SrJV3co3a4RIBf+q9u8IrUka/BbSqnTou34x5wcHVcFGmTb9//6/P+3ISfwH1+7h08l1Xb8b/j83Ms4fuV9HHxpN1wRJ/WqBWll+YgzJyKWLJJalofug23I83Di5ezAVmMmjAHqY2cBZqVswIzsDXhSUmjNuZRWbajrr1Vh6fVP1aHqcAVq9larXI6GvlYMHBxA//5OHDzaj93PDyJCaWENu2j42+hj2lHZV4MdJVZO3HxVxVAAIod9ywgEAUWcmHYCRO6T3PB43haArBTGIKso9lBXA1Y7TbyfcozgWGYz8PkmGnoDwWYi6IyYZ+T7OLIQ2r8E5q5VmKnPx3SdBrMIEBmP0Xss5HPWUE5tzt6BdHMmZYoBify/xXsIg0xNp7dIlXONzTTlm2jOt2BGupyIU2aROWZOsoecnsvzxH88JM+X0BE+54H0rQR9NoI9FWjaI+E0YQS6fSqqoXpvCP5BH3y9xQgMlKGKz5HzpBZ+RtJaO99byO/BgsJS/o1ZG7GBbG+LmCnPylBCti7nIraTzLFk+yo8sTYG2e4sejwPPF3FlLOl/J4LsSF7I+ZvWIxFG5dizqr5qnC4Maij/MqkP/FjO18fm75FLRBHnntW+Ywvv/ySAPlWGfMLl05ynFA55xKuLjFVEjoikbuqGMOYFIe7irNy/nGToKE/GRkdxSXK+9t3vleSTap+imyT4woJkbo58d+K5o32Gfzo4k18PHIVH5wiC4zdjT4mhRv+b8//fx4ixz6jxDp+YwRfX34TX577I9758GXU91SpVcpAJpH8c5FZSb58pPsLEKtPwJpC0jMnSm6JEZu1aXhk0wrq7bWIyduOTQXJiLRV4NArR7D3pT0YeKEH1ftrqWFbsO/5Ybz81h8w9NIhBHY3w9YZQXp1MZKDLmzipN9RZqNPiaCgJoBYlxGLJIdDiiPIIZ+NxplSSUAida9EdonUkk5JcWQNAUe8XQ4MCSACZiUfX0nWWEmAxDnNlGJmgsvE11sILDPf04gnzQYOToT6Ldj12kxUHlqIeZYszDDI77FhXYmTXsaIdYZ8pOqzkW7IRJIxTTGjJmCnSU+nVEpVO1Ozk5Owk++9kX/DfKnCnhE9DZ8xyRoKHCoYcZs683hEBSgSJHzO7zKlH0ki0vgZSK/3yoEgqujJKndFVNpr1VAQ9XurVC2wSoIi0hZAoa8QDppn8SBOXk1kcCnGtyF3Kyd0Ajz0LaX0Lzq/BUm6FCzYsASL1i/CFs1WFPB7LIhIofECbM3fBD1N/NLtsZi7eiFiKbl8fE9b2IJ0axYfT6QU24aFm2OxcEs8XvjDi6oPyInvvsGl0bMq8e7y2GmMXR1RUboS1i4BsHKqfm5Een2cU4wj27dXxi+qsKfvzp3HDbLFD/eitdrUIeHNW9HT9Ilo2q2wzH8ZIPertn8mjCFmXKTVNfER/7Py6n98r3/i2I17ODnxNT45+RL+9u6LGNjTirb+JhRTf652JWOFcSe2e7KwXCPbkBuxhPS7UZ+KBEceVpKOZ21ZhbmZ67HFmgGdz4y63loc+tMR7H5xCF2H+V5klIGju1C3vxsF9TTfHiOW0ExLLwsZUvxAFVeQ2CZO2CWWQt6vwXyOBRYtFtKLyFhi1XLiUl5NAkR8SBx/juc1XgGCg6wR5+Lgz3EuE59jJqBkiJex0tw7CRALgWHCk7yu8+UQGLHof/Ux1D31JBY70jBNT3AWlfBvrUI6pVoi/8Z0SqrEvCTV+yTcWQlblRfzCZAZErJOnzFnx04kmM2o7KxDWXMQqZRii2i8p0loSLKcjktISYKSWY/I+UiaJEPRk2QTXHmp2MzFJpO/y1ZjQ7jHh0BXKa9BVA9VoXlvDRoPECD9fnqRGuU9EnWplEkmlDSXINQZpMk2QBfUw1Fth7XSAmudDUUEW7I1E2afjhN9K2KT47BDL41TtyA+bQ0WbV2GdRkbYSzmZ5W6Bk9sXor1ZKF8pwY57lws3RKHmG3xWJWwHrGpG1SpplfffImq5YTq+XFx9AQZ4TKHBCxKlfZoxRLJPVIpFZelmsk55SmkcrtkEF6iHBu5cJE24Tpfd4t+JproFwWGHHJPKJBJ2Px/GSD/Of5HQPzr4Lg/BGhf0XR9efFdvPHnp9E11ISm3npFz8vsO6nl05ATtEAfdmOLPQfLuEqtIFiW5m/D0pxtWMuJkOs1w1FZBEeIPoITaOjZXeg82om6AclGbEFudRmBYUIMtbKcbi8w5VF353BEKxWucstjOmWUZQgwFtMnLOJYbNVxaDmxBSBR36HAoYawhk6BI56sE8exzCESzEgWMvP5JrKPVDuRYaaconSzWPA4J/MCSi5b73r0vfoEGo7Oh2/PYhQPrkBqzQ6sj+RjJRkkhe9XyMmba8lFkjYF9poS1PbUor69DtYKP1ZKbJaxEJt1WmykDAvxfw92VSAvaEOc1KNSABFjTnBItqBs8/L6CMExNTtFVVTRhoMIdjfBU+WHJ1KC6taIysn39ZWidl8F6neTNfbQpPf74O8oV8W7XXVO1ZyouMGlOgR7m+Q8oxxhso2/20ufUUyDH+EiVwJjuR5rM9arxqn6Io2qUbZg/RI8vnoB5q5ZhCfWLOFYRADFYxOBFJ+0Gtu1O7F02woCJJav3Ygk+hUr2eit915TJaIuXpYK7KdUhO7o2Ai9SLQgg5yJCFvI6brsXEnSlIST3Lx1Q4WWXOZjo/S852gLLly5pmIHb9yQiooCmOu4++MNVfdX3vdXAMivNz678Xd8PXYSb7/zEp55dggd/RIq7ke8LQmbynIR6m1Gy55uGIIOxImxIzjiRG5xJcsts6LAa4HFZ4e7shg+Gu6agTq0HWzH3qP7UTHcgw00uctkq5bgEMM935RPIOQrcMyTMHQBBg3yE1J5RLZcCYol9AqLySbCKPfBIcCIlStHPIGwikyxipN4pVO2hE1YwREjZpySatmkpFrCIZJqAX3HAqsZ8wiOOUYz1pdnov2FhRj84+Noff4JBPctQPuLT6DnlXnQ9WzFPL4+qdwDb50XrnIbMq05CNAD1Mlp80AHP48BOKvCsITLURwpV62n/b2c3P112FFuxmOa5ChjqNgrMeZy3a5O0acogKSSOfNhqCdDDPShoakOtY3VaGitQUVXWEVMRyi1qvaF0Xq0ATV7quhPKunRQgj1eFE5HFGGvqjWrXayqnZXoGo/AXWgBjXDkidTo1hH4yvA+pwtyDClIlWTiBXb4/D7J6fj9/Om4d/mTMH89YuxozAByeYUJFtSsTZ9HdZnb6Lh38SFIR2pphQugjtUa+jX3n4lWqH90rcqEFFKi6qUConAvSz5HbLdK4l5ktItZl0OEqXWVTQJ6uylK/QgtzhuKoCMnJfD7cv4QYBx5zru/BituiMtFH5TABGDf+za9/j6u8/w3juv4Olnd6OsoRSr9Dux0ZoGbYULGg5p0ZbmysN2WxaSS/JVeZ+VumSa83Qa2AylXSVXvOtAN3oO7sLLb76O3S+/iNSwV0kj2ZkS831fQkWBka+A8YQxenuBOpPQqrGYYwnZJIYAWW4XcAhbCHMQGPQYAo54p0gpo/IZKzipl8vPLitfI1JOwEHGMBnoL8yYazJjlo7eg+/n7F+LvW/OxZ7X5ih5Fdy3ED2vzkXfH+ai/pnF2FKRim3+YngawiimT9IW6VDWGUBRRwgpLdVIb6hGsKkBgcoIvDVBhNsr0TDUjPSAA4/Riz2SuVNt50rYicRbKXCkysk4/YiEnWRJfd1c/i9GFFRQVjXVYnDPEHoGu1WkcrArRA8SLSjdMtyMyq5KFWVQs7uKht6Hyv008/1SkT2AyqEKVOyrRN2BWoQGAgj0BVBHQIX3VMDb5UMWJdP6tHWqMecTq+i1OKbHzMHCjTHYTNbILM5CkpmLociv9NVYk7EW2fYM+Os8KKBHWUvFkEC59se/vEwzfhrj10dUuLsq0XN9nGxyYbIuFsdkGVE5A5GrmHXJUb88egVnLo5h4uZNMofEC0rxhov0JhJ7NYoff6ZJ/+EmJm5dVf1FfmMAAd6/9jM+u3IRx49/hDffeJY0H8S6okxqWwtqOiugr3LASRnlrnSrbd4dBMmCrC3YZMlBXqkeBUV50HsK1HZwhwQscoX9ywcfwtRah8SQh5PWoM4yFhMkcignIFnEya9AYogyyIL7wyRAkvpTNJB8znLKr1jxGHKmMWnABSDKiMsulW1yl4oAEfaI4VhCebXYTkllt+NJAYnVitkmC+bSf+g6tuDI2zMx9Me56HxxIXpfmYuW5x7H4bemY/BPj6HjxXkIHlyBeC/9TXER8socCLWEKG9qYW6htKqLYHnIi/zqIOraa9BDdm090Iq6ffXI8tsxM1t8hgBCYrF24gECROWap0R3sCSbcAoZRKrMZ5TZEJtFWWfJQy8Xlb3P7FEn6Pk+Pdr2dtKHVCDSHkFNd7XqbCWGvWFflWqu6qC0qhiiBKMMqzlYiyoyR1mHl3IrAHu9DaV8jr2xGNtMSUi3pGAr5bHGmYPqxjJsz9mIghJKRzKEFKfeqOF3qdmMNZnrkOfKgZHeRefRItmYhO26BOSXFuK9z95SrZ2vXZcdqos02XcVSKTGlexgKYDIwR99h0ir8cmyoiPnJE/kMsYm5BBQamfd5ONjSlZJjvvpM8dVdfgbtyUld4xS7P/vNtD/E+Ot8Z8wfOo7fHv+G7xDFilt8mGtNQVbbGkwB63QePWwVJoRaPcjw5eHZQWbsTh7C2Jp2ILW7l8AAIAASURBVDebk1FU7aQcKYbJZ4C7qgR9u/rw4uuvITVYhlzq6zVFZur//P9gEAUABQKtqle10CCVRyYHQbJISutI6IeVvsMuhnzyTIMAWVdkxWrKqniCI84eBUgMxyKLeBbDJDgsWOxyYj4BMs9mxRyzhQCxYlmRAcED8dj/59kEwpNqtL4wD50vEywvP04GmYPhNx5DywsLkNmciAVuG7Z4KWmGOiix6pBZW4FFZI3HQz4kkjnqKEfDzZQ3nRJCXgZnczHWOnMxRfI2UraSPbaqIgySVvs7AYnsZmWmYCZNfnrAjeqeGnXSvYGf4zZbHtI4KZOcmTBFLAi2B1Quh6/XS+MeUlvl4YEQJVS1WsDKd1NuUXa5G0tp2EsR6KTkoyfJKy+Ao9MJZ3sRDHUWZHhykWhJwobs9cgvyoInbEaBKx35nkyk2VOQbk/DGs0GLE6MxWoCRHa70qyp/LvykEJgJZnSoCnW4YPP36aJFhBIJZxRVQgkmkZ7WXkP2YGS8ww57xCAyA6WyCuRUqdGLlI63cHdOxLaHm39JzlLwi4iw66MX8aFS9E2CbLb9ZsDyJ+v/ITIsWN448IpvPPh69CH7FiSuwXbHTkori8hSCxoogYPtHmRUpqFeOsObHZnoMBvQIaRJq5Uh+IKhwqTDrUG0d7fjYPPPA0zpUgaV1vZgRIGWSi7U2LEOZSE4lCAMBQQHNEhp9uLjHy+hJnTqMeSQeSwT8x4HP1JnETiki0kuDCGHkUO/uJcNgLEQINvwEKa8oV2+g2yxhyLFXNlWO3qdk5TCp56ZxYO/GU2meMJZdJ7/vAkul5dgIbnFiB8IIYjHvnN27Dal83X2DHfWYxFxR6sCvixMFCOuWE/noj4EUvp6ODqXkFzXtddC19jtDfjSsoRCUmPhqdvw4Ny/kFp9Xua9QczkvCwpNxmp2Ej/x9dmQkb0jYjuSBFdQTewhU9pTgH9moXGvc1kj2C8HV5Ud3doPrCyxmHocYEe1MRnE0uhGnkq/fUIdAt9XTpSRqKuIDloKBaB0uzHaW7vfAOlsMYoacyJJApNqmWFFp3DtIcKYjPWouYzFWI06zHktRVWLBtGZYnrcJG+pZUSmgDwbSN3mUDJePbH/2FfoGTe0x6gFxQLQ6EQeQQUFhDTtglJ0l2sm7euMmrhMX/iDHed/b8Bfxw9y5u34oWZpBzD9XpjI/L62XH69z5E6oMleSO/OYA8ublH+B45120HPsEf/v6Q7Wd6awpQceeVvhbfbAGpOpICcFSDE1YmlzmIjeopQQzo4yM4SaAfLVi0svQ0FWH/sF+7N87jNreHiT4i8gWEmGrUewhY7FF6lVJqEihCuWQsdgosVAFWCxA0eWr+5Zb6DvswhYGAoJsYpWT82jISJwKGTESTDrKtEIafz1NuB4LCI4nbQIMYQ0LHuOYZbSQSUwwdG6FY2AD9J07kVhJ9gtkIrYkA7GeLCx0UfY48vGYVYsZRj0e1ekxTW/BTLMDT7pLML+kDItDISypCCEuXIZt5U5YGyQjz4+GvmZE6BE2FmXTY2wiODaRPbZM5n4k4KH0ZPyOIHk4IwWPZkuTHrJEdSnslXYk0iTn2HIoYR3IKdVyFMBZ4USkL4iawUp6Cp86JAzTdBe1O2GoMsLR4lTbvCW9HtQO18Pd4IGrwQ1PmwelveUo5MLlqHeirL0cni4/StvI5JTBq/PWIy5jFTSefNUwdZN2K2Jz1yCtJAvaAL0cPchG7Raa+0J1eu4m4LMduSjw6PG3j98hY1xRbQtGL8sWbzQXSXajBBjCHjLZr/L2NT526Sq9Blnj3Kg07LyinhON4ZKzjmg0iABEOi9fuzGKy1fO8LXn6HF+iwC5eBeml/6Eor/9Fa+dPIb2wx0oavWitk/CqB3oomEsbypDYdCIXH8hnNV25PgKkMsvtPNAZ7RoG7/EnuEO7Nu3C739Pehob8XA4BB01OzRHawoOCT2aSlZQthhmUUCA8kkHEslnZWTXs5DpAaVhJnLiKVsirNNDrscAIq0ImD4c6yZZpwAeUKnxVy9lmacXsflwEKHg7fpPcgas2jOpxlMmG404Qma91kGM2aTGWZScs0y29Rj04xmPFyox1SC6cFCAx7WmzFFZ8YMA1nI6sITzhI8UVyKJeUBxEeC2FZTDm2YEmmgHpWUOb66cjKlAY9mrMfvk9ZTXm0ie2xRu1aqKBxZ4wGyx6NS0SQnlZ5JQ2CFVWEKD72Ei+xr4mqd7s6DrcKGYLNftZiTs5AKAq99T7NKDdCGCpHqTEdwmAZ9TwjudjfKO4LIK9Iim4tWSU8JfYcT24wJSHdlwhA00YtIO28PFzMTUvjaTJekRqdjbd4m5T1W564nc+1EWnE+1uVtxnZTAoIDYXQ914ea/Y0obilVnbM+PPbRf8RK3c9e/c9zjGgYyVWyxsjYNZwnOM5cGsXotRsEi+R+XFOyS3az5LUCEjko/PGeRPFeVglW5y58hUtjJ3Dl2qnfHkDeOH8H2gPPovC117D/+DE8+5dn0LavGeUtHlj54URI7wMHW1X/jy2k5vyAFnleLYwhK/qe6kbz3iY0Dzaif6gde/b0UGK1o3egE52dbQh1NGJrqV2dgYjEkh0qkVEChuUCCDKFAESqF0rtW7lfcjFWcOJLkpLcL2AQI75CfAdN+EqnBavIFMsMOr5WTwbRYZ7sVhEwC8geC2w2mnO7Yo/pehMe5eSfxok/g+CYpjNiJhllJoExg2MKH3tIq8MDvD6iN+LBAt7O1+FRjQFTCwxkHxses7kwiyPGW46kygA0lcXQByWUvxiRnkpYQg6stWXgf9sZj/9152r8PplAIYtIMpTU2300IxkPSUlRjbSezsLaIh1CAw2o7KpGLc2/sdyIDFsmCsv18PIzD7cFos1J+yrQeqADjYMNZAEvDBEzjFUWuFrcvG2kN8iH2WfGppxt2GlLhrnJClOdFdn0DzllecinHynpKEOGOxebtduQTL8YRykVm74GK7PIJvQcWwu3YwcBksS/X1uhJ0sVo/X5NnS81IWGw82wVDlQVOfBMc6LaKHpG5OJencUQK5PEASUVGMTN3H+ynWMjV9Xu1XSC1PYQRL6hGUuXpK4rHHcmJDi11Irmqb9rmQmjqlavtH+IZd+e+cgMl4/dxv5u55C7suvUmZ9hDc+eh2Hj/aibbAC3cMN6OWX1DncBEstTSuliI1fUgVNY8+hDnQfbKd5l8JjPrjDThh9Jjgq3ajrqEZlWwXquurha6tXFf8EIIsl54LssVwmPa8ipZYQBDEEx3JJUrIIU5gIAIsCirCIRN8uIdssodyKITDWlhZDW12BeBvNP8HxpIDEYsJcgwGPm4zRw0CHSwFkGpljCuXSdAJEMYaObFJIkAhQePvhfC0e0hTigQIBih4PavT4fU4BHsotxEyCZAafM9vuwlxHEZb5/EiqDsPW4IWR8tIYtqhwc+ljssmeiX8jQP6XbfH4XeJaAmSDyhQUBhEPIt5jmrRZM2QR8LnY4beqA9mq7kr4GwMopdfzd0jIv4/eg2Z8Tw0qdkdQQyYJdoRUX3NJKhNw2LhQbdXshI7m2RFxYVPuNuSTXVzdRQoQ3k6vyrUJDQWQV6aJHgJmriZrbMCSncuxMmMNVmdvQExyPEGTrvJPvPQwFUdq0P5SOxqeaSJLheEZ8KK4o1SVADo58p1qJS6gkIo5N2/fwqUrV3H60hguXr9Dr3EDo1eiO1fSYlz60tz7icb8brQi/NmzcrI+jls3ZTfrNu7+IMwi9bKkXTSZY0xy2KNtoX9zAHmDADHsehrpL7ykfMg7X7yD557bg6oOP1pI8bsPd6OuvwqtNI7OJidMtWYEessIjg5US02lzlKUSS5CbRk0brKLORvmUgM6DrSrnZqW/b2qsNl9cx5Doy3gUAlKAgyCQjEK5dQKyqCVBIgkLcXy/uWSvGSV6Fs9FtFHLHHYEOcpgbOtDZuK3ASHDo9zzCWDzCZQ5tksUf9BGTVDGIRjKqXWVDPBIrfJIjPIIDMIEAHKIxodWcRIljHid7laPErWeIQgmcbrHIONz7VivqcUjxeVYIHXh5gy+d2VXPWt0FBiFnqp92UbnB5gKf3EAwlkkMQ19CAbVeagVFB8UOKvJHBRk656eMwy0vPY8znRy1A3UEMpW4sqSjVJlZURlGaaPQTKnjCC/SEEWqPZlnJYWNxWDGerS3mRoPiSJg9SjBmwV7lRtaeaXiVCL1IK/y4/vP3l2GbYgXgCYotuO7bot6uql45yOzLMmYhLWkPzngprtQNV++pVEfKO57pQ90wj/H0BVUijYjcXOv7ur09+pWSVSKqxq2M4c/48zo9ewanzFzHxfbSLsmztqmax399Uhl5AIE2cJM9DooBl5+ru3TtkFskk/F6BYeTCcRr045Re0eQ/CVX5zQHk9bM3kd97AOnPPo/2r2jUP38bR48OoIrSytdYBFOkECUtDhx+vg97nu5EuNsLf3sJKvkh+jqLUdpXrMpX1rfVQGfNhdGuUdq6flc1/L0BBLlKrncZVX2qxVJ4TTL5TFFZtZj+QaRVvMuG9SVurHRYaMKjwJCyn8qTWCQKl/LJQsZwOhQAFlNCPWHQq6jc+WSVJ8gmsymx5hBEc+xWrvr0GVYbFnJiryjzYabLRaDQsNsdmE6wTKX0eowgmkbWmE7QTNWaFDgezivEo1ojpvDxmTbKNDLREr5+RTCEJ7ylWB3yoaSzBlYCJNeRDT0NsZ3erGpvCLUHGpAbtGOpXtoXSPG3HZiSTnBIqm26FJ5OJ8vlYLlbDjI1yKDfKKl3wVplQ/lAOaq4aksqbXVXBM1DNXDWueHv96rCbvX7a1XVSUuzFTZ+F/WcuBH6kmBvGIawEaaQCWUt5XCTicp7wiiVfJImN3bqErGBXmMV5VSaOwOrUlZiS/5mrE1ehzUp68hCGgJVOnnVoutIH1qG21XX29q9jQhLkfDhevh3h/HlyS+5+k8oL3H28jjOX5JUb6nSPq5Y5b4fEQkmO1yyDSyAkJ0uAdbp02dUopQUaBDpJZmFEsMl0cBShfH7uzcxcV06Md/47QHktTM3oR88gtwXXsTu777Ep19/gJdeHEbTUAWKGu0w1pgRHvKh6UAEw8+24ciL/TjybB+ef2EIjbskqK4eEUqNqq5alEdKYXDpoA0YUN7qVyVMpVK4rbmKk10y9uTwz/gfkirWJmcZwhoWrKXBjrOaVC74ckv0vjinFUs56YUpFloJED7ncU70Jznmky1k12qeVQy4GXMIpBl8zxlWAsHhxFx3CdYGI/AO9iG9sQZzS1wEDgFGqfW43alYRoAwhYwixnyG0Ybp4jtozmdSmk3XkUX43AWuYsT6yrEhQpNe40caV3RLlVNVjwy3BTlRq2Dv96Gg04P0hiKsKy3EgoIUzM5OxGNSJjQjURWRW6TLxxyNtEjLpQzMxVqfAWmOfOQUaxEgCIqUfLLB21xG812mCnRLr0gpCVvUUowCvw62WgfcTUWoGhDG8aokKekhKKVXNfQeujIt8ulxane3KVbJofE3BS1ItWcg0ZSCbYU7kGJJRhY9z7aCHQShM5rENiyepwoBslRpB4HWUKJ2wSoosz2dJfj8+Gc03Lfx3cgILl+/gtt3hR2i7cUlVVYOAKW+lWQHRkFwR7HI/VxzqfAusVc//fQjpdePqgzp5dEzOH/hW3UdV0XVRaL9SpUVf83x+sht6A4+D80rL+MoV4pPyCC9h9uR22JEfqMZ7ZRWz784gOGjzejaW4NhGvNnXt6Ng0e74e8pRQ21sptmXushMNwFlFi5SNKnqtWxfMCH0gYfnC3VWCwHgdJ3Q9hDmtIYJWzdiFUEwRq3HZs8LjKIWe1cLTMbEE85tabYRf9ioX8xUGIREA47FlhpxPUGPGmSyNwoQOaReRYVuSirjAQIJ7jDgVmuIiwq9SG1shpZlVVkkjLMoyyLKymlVCrF3GI3FpaXYXNzLZnCiRkEyVxKqseNNszWRn3KfIcbKzw+eo9qTs4g9A1+uLjCu+pLUd7MVbrLi40VOszzZGC6MwWPGBPxaP5O1UJtauZOzNakYVpucrR7VHYapuSkk62yMKsgExs8ehRwElf0VKlDQHudDXleDQqDWlWxJNQSRFlbGSr6ySxdIVR2VvK5lfBw4krtMk1Ej7jkNdCVF8LdSBbqcqGytRzBpjIcevEwOnb1QCsV8pu98HX5kUojnkAZ6GpyQePRQOPTqkKBjUcb0fRUK3xkHmd9ETJtOdBROob4s0g+GyXYWx+9iws02bd/uI7v712PNoX9+YdoBO4tCSEZV3Whf6CkkjpX16+P4vq1UVVx5waZJSqxJvDL339S1eClyPU1accxeh4XL5ydjAI+rzIQf5MA0R98DsFXX8brX7yLp17aR9ZwYW15JsytToKiHkee6ycFN5ItpJp7P0c3dbcdpV1u1O+NUCYYoXNpEK7gyhN0q2rrVUNh1JFhAu2V2F7qwJNSR0q6Nsmu1eT5h5xlxHKCx5Ix4gmENZRacZz0y2QLlwZ8uU3irCxY7rRhqd2GRRwL6Ckep/GeoyvEPAJiHpllLlljPkEx22ZV0moGmWJWUTEeLy3DAgJCpNYSeok5BMJiMkIMgbGsyo+8AUqKV57Gk6Ul9Cgm5U0etzkp1Rxqt2ue1YHFfG1aOEi5GUaB1wQN2dHZUIwyGtsdFQRRSRZmOtPxsIl+Q7sTD2XtwNQsCUxMwDQpOSo9PXIJjqw0zMjPUr09pmozMduQjTiyh6amGG4yRLo7nfJnGyenDs6IQxn48iZ6kd4IfJyoFX0hFacV7IygergKG3K2Y+GmGKQVpSGnPJsyqwD9exvQsbcOXVzgJGe9wFMAW6VNhaD42/2w0dTXHqijxwjTYxRTGlah5UgTqg7UIDJMAHYHudjZUFhWqApuFASMyCoqwOsfvIurlEzf37tGkFyNBhhSDklraImvkm5REtouxeWuXJHGTVcVOOQqABEGkV2wn3+6R08iYSbnVTlSeY0MSbaS4EfJdf+NAeSfeOv8bbQ8+zIOv/IMnn1xL3xtfmxxS6mbHdhcwVWm10v26EYttals//bRnLcM1yArkoOaQxF0Pd+Iyt3laOmrxO6hFjjLLfwiLJQf5Rh4qgvBngbEW6V1gLQS0GKBNp9Akb4d0vevUAFitcOqzjVkKP+htnAlSNGCFU474sgOS21RcAhzzNJoFTgWc8I/QU8hwYjqYJDgeIzyaSbvn+UuoqzyYDavs+hZnnS6MYfXRTb6Cpcb60JcWff2o2zfLoKoGE8QVHMIsjlOyi9exZssIsgW8ufCigBXajvMYRtX+iLqfisstUXYEKQMc2ZimjkVD+mS8GB+Ah4kc8julYS1T5GyozmpmKXLxtS8DAWSaRoCRJeDKQTJLG06YqT1do0TJgIvj5KpggCoGZJeKH7l5Sr7qwkQvzLo2mAh8n0FqtjFyuS1HKtQUJqDnNJMZFtT0EBfWL83jIbhCkozCVcpJQPYaMQtNNyV6DjQjUg3jXyrj/+HCyWUafWHGxAYJvD4+yr3RBDga7Is6cgjy6TasuCqduPtT97H9dtSXYeMcUdyyKU6icRdXVLsILtX0cJwF5XMElYReRUNObmBEUqz+2WqpHabFJyTaidS2EH6gggDydax7HD9xgDyv+PjC6N49k/PYuhAp2q7ll1pxBZfLlL8GqRX61HYakdZnwfVeyoxfKQbuw/3cPUMwNFiQ9PTNWg+WoXqveVo3leFhv4qFDe6ySzUzzT5XQe6kOcvxZLCfMRz8q+jbJKDQDk1FyaRHazVlFgb6C3WcPWP5aQX+RVHVoij2V7ldmKZVSJ0bfQh/wdz7/0fdblvj/4b997X2duGENIrhCZFVKTX9GQmZdIm0zKZJJOZTHpvBAihhl5Ewd4LoCJNsWJFEekdRbHsc866az0j53zv97f7unef7Q/P6zMtA4RnfdZaz7uVIaqIckbHuVzyIeMrKxEvUJQQNDau8gqMUoxDDCLwiEW8BAgZIYbAieH7ifQYycUVmFNdy39fM2YEgyYdJbJIko0ehz8XSYMeRTAKIElkLWtTCFa/A4X+UrNh1NS7pKsK0+uLEVupccsESD4NuWWxCRCqk/uo7GXGnCu1ZLQBQx7uz8nAfXmZuI8sovVgUTYS7bnIpJ/RdKzSulI0DAVQRuOdHyqAl3Konr/r6sFa2BpLkOPjZ72ZlHiVmEJwzCufz83uRuMQJd/ySkoxmvRVVejYUI/mLQ1ooPF3dDlMi9fOnSrrbTejJqo6+Hl6Kf/qen6mmTfBegT6a+HorUC+JwdpBUswJ38B5hLw6RU5eG7/67jxs5q8yXgrek5JdVMBv3DLHhl0ZfBKPqnuPDyQUxNxLxpgKECoGYcaoqOakbvzCvUZASMcYVeXxb8YQE5c+R0nTn+GXc9tRAPvPgWtFchpLkcJzZtdx4nLnQjxl+0ZcqBm2EP26Mb2p9ZRbq2Ab6AKnTsoo/Y2EiTNGNzH/4ANTea8XtJqYOty+AY7MYWAiLdkI9VWaKY23U0pmUhDreNczf+bRMaYai+jL1HjNoKGUms6QTOZniO5RHETBxLJHJFFRQRJETcVPYf8CDdvTHk5IkroGcxpVDHuKbBhjJ0+opSmnh5CuVRxbg8iueFHU0LFl1Ugnn5jqkw8JdhEfy1Zhwa9RHUjLiRzxRJICQReikegKjPMNafei9xWL41tNWo6a2Btc2JSbQFiXPQUdm36pbg3d7E5uRpj5oGoeXUGIvhvH1OQjSibhXIrE/fTsN9fmGMAck9BBv8uWZhfno0F1sXIdVoQ6KlGMVlCfqHAV4gmeoHubV1wdTgx1zYflpDFSCPNaJxrnY2iqlxK2goE1ceq2wsXzXxZg4x/AA3bWlDUVm6i4/qZukFlRNjgH6D32LISdZRhzSOtxqSLtVSVuCR/PnI0LdeyENMyH8fcwjQ8e/AdXKVE+vHncKDwuoJ9P4aNuioCBQIBRFm66mCiNqJ3JdPd6LnS3wWscFKjWCZ87BuecnuD4LplRin8ZQCiMdLfXr2Nz7/7HJ0bulHYUmF+mSZBbnMTApuDsK9yw7eGentdFarWOA19r6eh6+EvtaSjDE3b69C9swEDuwiIJzrNBKih7YPYsXcjukdWctPbkJCfS9YgKGyUbVwCiaTVZALh7vRYXQUMAWYa5dY0yqrpXje9Bzcs2WIc2SOBviOiIB+RBZRXJaotp6zia5E07KOKizGGn7mvsIjSxWaSFMdTWsWaTF5KMDJKHKVSBKVYIsGi9yYSOJOqqxFD5oqyq6CqDJOqvJjMNY7gS1BzBzJciseJxEonUoMeTG10YhmNrI0Sy9buwiMhehCvhd8bBsgoa7iZwxjVrKs3Vm4mAZ2H0fnZuI+A+bui6pnL8LecNPybJR1/44osyiAT5CKjKA2zs2bDRtC5O+1w8/9DrUUDy+u4mbvpPcjulFN162vRsrUFwRX1KKspgdWdjVx3OgpdGQiEHKisK0FhIJ9MQsO+sSG81oXg6fGimqxXwZtgQF0VV2tSV7MJRrYRIJ0jPQj1UUr6iuCg15qbowh9OrJrC3HkkxO4xc2sklg1j1ODBeVUhedjhntaCTACgKlPvyxpdfnPDvCqHJSMCo/mUOsq+ZG7szX13JyC3SCgbv7/NmHq//v66MZ/4urtX/HNd99gz0v7sOmpEQTWKq1aQSYfHGtcKF/lhKdfp1E1qFlbSTapRe+mVviHfDR5bjTtDKB1Rwg9u5rRxrtU/7ZubHhiLXY/9yQyKa3GFVqQaNU4slwk56vxc36YNZRWQlCIOcyRL5ljqqPMmPSHuSEn6LhXcsyhKVG8g5eWIio/nxIl14BjjCWfep4bz1qAMQTFKIJEDDA6v4iAKTWgiCLjRHPFERTJlGIplVVkAzIS/ccEnw8TCI4kept4MpXiJ/FKX6nyYBKBGVdRghhKwPhy/t28Lsz0V2Jmmw+TuGFnNFRgqceK/EApZgdLyVD5NPZ5ZtLsAzTkyr0SSO5V9q6aWVvpObjuo+z6ezqfWyitCJh7LBn0LGQZWwZmEByz0h/HQssCpJUsRUlzCW9U1eaot7Ldi85h+r+dfajb4EcTpZPytLo2dCG/pghzVdRUpprzWShy55BRrCgnwFppxusH/aaOpH1nO5ppwnt39KKK3+vtrUU7zbwaw3Xt7kFgfZM5cs5xFSOt0op5xUsxp2Qxyjpp8DeE8PHXn+KPP34zjHE3tnGXOa5fl39QEPGKafujuhCxhAbMChxaipeEZdhZAyxl8/73uI5bhj2UtHjz9l+oYOoEDfr523/gm9On0NAf7tYXWh1C+7oWOPsrUbaqAv716pJRw/+YOrhXO1G3rpp3M1I1X3dTcrVuDVLrBtCzuw3rdw5h19M70b1pCEtqKgkGmnGCIslKBuGdf5JNowaKMYFXBQEnaREYYhTFPnSSJYZJKaIUUwTd7SBInPQqYbBMrfQglu9Fc40tLDByazSv91qtvHsX8LENsZRQUQRIIiVWioubn9dkeooU41UEPDce9QcwzuMhk7gICvoX+p1opa0QnOPJFBN5TRZzuEr5uAK5NOh1g62w9wQwj3fsx9xWlAQdCK5qxcy6Yn6PhUDMITgzcL/mB6qRNdljTG46xubnYGwB39PpFeXVg5o4pZFsfO0emvd7+TOjKbMWeGymBj7TkYu08mUobSFAhqoRWFMLd2sVWlcTILv6TTM+/R91beqGgwzzSMZjSHosGdMWT8HS/HlIL1yMxzMfMyUKSjQMdPvgIaBdLS44mxwmZUVmvX1DD1o3daB+qAEdmzrpGWtNgqOnhT5G1YjDQbj7vfDS03hXVOGjr8K5WDfJFDduXTENrG/eCo/+Cw9v0hDOcMfPcGLiBX5e2b6XTXxEPX1lxuVDtJS4+Msvd/7M79LAp8s4c/YUvj3z5V8HIB9c/Q98dfEGvvn2FGq761HcWGZ++Z1r20zXxJKVpPnVLoRI6Yry9tDkbX1mI3Y8vRH9vDt1be3A+j2rsOGpVVizcxDb921BC8Exv67SjDOLzstAgiUHCbnhlZQbZhH1up1EXzKpOOw9JhRr7EApplPqTFDrHT6eWFGKaTq5oowaR/aYUGHHBIJkrNWCSAJMQcL4cpXRFuFei9WsiCKlo7joI5yIIZuMo5RKotmOI4skuQgG+pjJYg6a9vEEiGIq8U4yjVJZvGQWZxmmVVci1U0ZVlHMny3GQz43TW4bPAE3yqrLzdzEmRmzUcjNHFjfhYdqyDKuPIwtyTYAGW2V58g0o9cUOY8gMCLIFmM1MJRSM5K/j4i8bNyfTXlFgNxjoSSzLEN6yIP21QO8+5fQFKfD0VdBH0cwrA3AT6kkGdS9uQN9/DMHtw5g1RMrkFOZCwvZIsudhaXF8/n3s6DEm8+/WxEqNa+xmf9/zQ6CuZSyrQRFlF5VvTWoHQqia1sfPWcrGtc0mdPJqtW1cA66Kcca0bK504zgbt7UQikWMMfLJ8kg8hFihtu/3DDDbu7WgYgFxAZ3vcbdDF8FDO+a9Z9+umZSUAQYgeNuRq9AZUp2L6vR3Hc4e/HUXwkg/8BnZy7gi2++grfdj1L+MuupTZvXN6KNv5Tq4RojrTo3hbD2ieXYvmcdXnh+D158YRf2UI5teXoddr24Hc+89TR2vvQE+nesQ2ZDDcEhFsgzHc9jaFLjcrORwo09kUAYX5iP1CIyhrwH17hCjU0mQCijJpcRGKVqxuA07XrGlZUgiSBKoQdJKeUqLzWZu9HFlFE2m/EeY7kEjFEWMkg+NyvlVBzlVVypHePJIGKKFHqPJIJlrL6DLDSOK8mpmhEyTaWDG5wAIjhSnKWmo8k4XpMdJUjl6zMorwqbGtGxup9ypQP5VaWYueQxLMxbAl+PH1mdVUgkQEYX0XzTfzxATzFa06U0Bz0/y8Q/xByKfwgsYyWvstJxX9Yy3MP37uHnR1FmZTaQJTZoEE6diWJ7l/swsLkP3es6ePPyIzgQMvMEW7ShN3Sgif9H8woXwNtdSabwoKQuHyGa+8ByjVOrNrMmg6v4XTTuyjpuIANWtalG3YKavlq0jbSjTd5jUztZKmTKGEo7KxDa1kQJ14LGtQ0Ibq43/qVtpAOffBHOxTJZvLdvGp+h0WmXueHDRv2aadqgqHk4cHjJzKpRfERGXQwhjyJACCCSWUp+vHXrOsEWblOq4TtafxmAfHL1N1y8eh3fnf4Wvo465Nba4O3zknKb0E/NqsDglt0rsfUpSqe9G7D3yU14+fkncOCt5/DSC7uxYd8IGmjEy/tasKDWhRlO9YTKQzw9h+RTdEYan1sJAhrzfAsmc7NPIDimlBQbyaWxAgKMDHoqV7Kec/M/TOYQQHR6laju6jZVHhYjWUFBAuRBgmo0fcd9eVZq+ULDFpEESVQhP0NJFUOPEkdzLgbRiqdhVywjniykYiqlw6fwGqsGcpRQqhNJVKMHpb3w+URT115Cxio3TSCmUn4VtDYjp7Ee6TUeLCuzIM9uQWNfA1o39mNmoJz+IxOj8mnMueE1zTaSoBCT3Eu5NYbX0VpilJxMPJBOj0IGMRLLIlmWhsddhXD3elHJzdy5rhfN69oJSN6shhrRONiI9rUdaB1RY+sgGSDATV1vupo0rVYqiiSgD1U9HtNkTpHvyi4qgEAJHzspeVdjx3PPo2toBeblzoe7wWlyuNo2kilGmlG7ug7WYDFVgwtl3Xa0bGlG8+pG/ttaCTL+OQTU0RPHoYE32vzhVqJKKbkZllmUUgLD2XM/mPclrXQcrH5YFwmi23/GN5TZq1p2MYw8iQkc0qf88otGIlwzhl7Hwn8ZgHxGgFy6chWnz5xG23A78vwlcHZ40Txcj7b1IYw8MUjG2ErG2I7nntmGfXs349UXd+HA/udx9OPjCG4cQmyhhlVmmHEAmp+h49xobo44boSY7CxMpAQywKBXGJdvRbKFRt1iQUpeHhmlyLCJgocpBIcAMoGgmEz5NN5ejlSdLBFI8QRRYiHZgd5DCYpR/L6xxcUERwFiS3S3p/QiYGJt3NQEgpo1JDtdZqW49NyFhAo1caC3IEjGUXZNkAdxhCsNY2nIE7mSNfqAoEhVKr4Bh52Sy216bD1aVYnHfZXICnFz9reiso3eoL8JdfQGrpWtBJ6FDCYGWWYm2Y6l/xijsc9ZKrHllSC4P0ejENIQkalZ6enmVOs+Aup+rom2HORXlxIgXpPy4emvhrPFjZruWoQ6g2hZ1YwO3smVZVvR5jb16KG1jaaBQ3BDDeq3KsjXYnK3lP4+I+0xzC9chPoBP3Y//xQOHD2KzqEBLCJA1IXGSQAp87eRSkF5XkUNJZhVsAD5gULUjdSZHLqm1Uq7b4G9w4NDxw+bE6wfKZVu0oPc+vG6ydT9iZv+xi2NE5fcuowbN8UU1/8M/oWPeU0yI0Gi4Ti///6b8S0y63c7Kip9Xp/Tka8++9cByPU/cPXmLRqj71C/nHdIatSSFg/8K3RHCqCVv7yR7QPY98QavP7ibrzywh4ChQzyzus4/PlJlPZ3U2dzQ2RSSuVqcKVGHqchKk8TmHIJEoInixIrKwuTucEn0kinCCAEyoQiyS0CozDMGsq9mlRRhgmUURN0alWsfrwVBEqpeTyTG3QKN3gCpZXqPtTjKoqsoXhIvCLrBUWUNAXm6Hc8QZLqriQYaPDJIBOrvIghoB6q8pkuJ3GUWoqpJKvTIoGQoGYPYg/KrccC1QREuCvjQ5VkDxr2GZUuTFXQ0u3AXLLbIp8TywIeTHcVk+1KMZcMEl2WTXAsxQO5ZIw8GnQz7nkx2WQZn6fjAfNYR8DLEJFBUGQuMzUif+f7AslEWy7SHerOXmkqAAtbHChsVLpJG3rWDKBv+yD6dqwwg3Cq+n1k7iZ0busxY7AbtgQR2h6iRGunBGvFMjtvUlMTkfLoJHgbqrH96X3Y+fxecwDw6NJHMd+6AM5WNxmoGh7+eWXtduTVWjEnby4WOhbDucplEieDPRpRQUCSmY5/chw//6Kj2AsGBLrji0GU0n7rthq/3TAZvNrsYoGLFy6YxtS/3lFqyS3zWSUq/uMf/zDy6m51ockCNqdgYhgdF/+LA4VqX6q2o0cv/Wp6+17gX/TLb7+Gr7cBjg7esfpVueYyZk4z7/p419qxewhvvPE0PvjwMD7+/COc/PZLHDj5GWw9nZQSGXhQgTHeKZWxGkOdrVSS6NwsxNOMxmQSONwQiTnZZhkWsZI9KJuSyCQaUDPZTnNMwzyR13EaWqMl/0E5lVpRbkYSjOMGj88XmxRS4+fQgxQhplSNGsoRKzahSR9bUIhxlFNJBE0qGWJabS0eqq2mB5Fxr8AkbyWlk5OyS8/LTWugRIIyWQcEXjcernITEGpVascUgmO6j8AgOPT6IwTGox4XJvHPTLBZEFespnfhLi2xBEdUaVaYQbKX8O+nqVJLTMBQw3I0zFPLtB5dtAD3LVqI+wiUewmYv6nSsCATmQEf/L2NKG9y43GyUXJRBrIbKuHvqUfTymaCodUEC9U3q74vhB7Ko76tvZRPbVixux8tI2SPNZRjI42o6HQilwY+qyILq9atwPZn9mIbJbGbrGH1F6Kiw2GKpBxkotqVdcivL8RixxIU8aoWQfZeh8kC9vcQiPQ9jnY3Pjh5wkgn1W38ePu66YSoflY3yRbf0zdcvnoWd379yRzXmtLca1fMiZd8i4y6pJXqQP744w8DCsVElC7/XzXqZpCOkh3/xQAJr//E8Ys/4+inJ3Hq1Ff47MuTaF/Xg8717ajlXcPe4kVBqAKda9oxsmslnnpmCz6jSfvi3Gl8evYMPqSpf+uTT1E22I/IHPWhXYKx2Rook26mu0Zl06DSiOqIN0EnVzToqWSK+CwyC2WXjnsTrbk07pJcVjKJ6kKKkEBWieJnE8kS48gkUWSbsVwxfD0iL5d34GxEWvMJhjxuSBvGEFxxKpISeMg6USVqWWr/syeWjnnJINzYKdzYCZRh4z1iFtWsOzCJj3Uqpq6LKsR6pMaHqfz8FAJnMj1HisqCySIP+zyYqToVfq/k4sP6WTWGKLbwZwmUCv5dCJAIG4055aaydh/IDHdVvE9j1rhGExxmTqHmhSzTkE96lcw0Y9rvyVnKm0wa0jzlWLV5AxpW9WBCcQ5vBmloWN2N5v4WFAfL4FvhNXKouoNeo9OH9s1NqN8SMFHwnu39CGwMmrHazevki5qxfHcfanmTW7VtHTY+sdOMpQiuC5msiPrhAEpD9CdNDtNzIN2VjgJ/Ho1/gBLbzvccyPcUYknRIqTZ08wIvffeP/ynv/gJ18ggP/96FXf+uE7/cZ0S6wJZ5BJu3yGz3NI454tkBY0lDxty5WmZ7u23VIb7y585WRf/TIGXHBPDhKPr8jJ/CYAcu/IHDn1+Ch9+fQqfnPoWbx7Zj6OffYh3PzyK1w8fwJpd6zG4iSZ9zyq8sf8lfPTVF/iQn3vviy/w7scf460PP0LJYC83tQXR9B0RBEQMGSOB7BBFWaWl0ysBIpXSarIkk1JN6D0mKc5B8668qynlqh6kvJGsIjAEkmTepeO5GQWWSBrxMWSMB/g9D/Iaz/d0ipWgz5g6dF1VgETfQQk0hVIslu/Lp6g+3bAHN/V4XqdUV2E8QZBqAOIycZZxbjJFtRczJOEEAk2WKi82FYzj7SWmWGsKP6OUe0nAKQKPXqdPiS8lQMpzaPZzEVmUTXBouA4lVRZZRMygJnFZGoGgyLr8B9cyvrZEswsJktywQc+pr+UGHuLdfAD5zUHkUBbN9ZUi2E+j3t8AV5eXzF5DYy2DXoua4RoaafqHrQ2mzWjf9uVYs2/EFFR5BymRh/xoJVg0Vap7I/8Pn9yFoW0bjGxuWN9guppU6fSL36v4iG95NerX1/E7CcDBGtMFpaypFKXBQhPVdzU78T4lltjAVAj+dBU//XIFPxEQ6oR448eLpm3o9VvncP7St+ZUSlIrfIyr496b+Jle5acfb5i5NmZOCFlD8ZJwq6BwyrwZ73bhXwwQSSwDkKv/wKHT1wyTHDt3C0c//xLHufmP8arHhz75CM+8/jSefWUPPvj0I3zw53sHPvoY73K9TYC4hlZQCtkop3IQTb8Ryzt8bAZ9R1oaYmlEJ+hIl5JKaxzv+imSVFypNOPjaL6nUh7N5MbVqLPxXMk29cRSgwYHYiinxuZZMNYq6WSl38hHFAEWSbOvwTbRelykjF7FPuymmEpltync9LrqxEoMIoAon2o8AaFyXfmOCZVOTPa6MJEbP4ksMYE+Qw2uxRzyGqlqQqdAoaZQ0ZukqgSY7wkg8iQJpWIudWnRDBEL/2460s0ku/FqOr8TELlKM0kzhj3CjINeQhbUbMMcAxId9ZouJ2SPBWQpS0M9JZv+/Vak1Xow11UAb5MfdW1+BHvrUTMQMMa5doUPAW7mzl0d6NzcYYbcBFc2YPkOAawOrk4XmacBbWtbTTxLqfFrdm3GpmeeoafswMCOXtgbKkw9iD6rU6ogP9+9qx1d25pNx3gVaMl7tO5oNM2zmzc24cTnJ0zkXMmIt24LDPQZV77Hles/mPwsPb90RSPZvjGJiEphD1ca3sTvf9zBDSU4XlFF4XUa9Tvm9EpMYo6Gr6uS8JYx7wLMvxQg/+s6buYZhmeOHPrsa7x59H288+GnOPiBQPAp3j7xPg5xffDFlzjx5Tc4evIrHDih9z7BO3zduWIA8QUWxFoV/MunnKIuz87FeG5qMYfWOL6XnJODFEqkCQTFlD+PeieVajSa3dyZx2tDc+PHFWrUQTmSeBePlt8gaGLpPyIJkAh+TwJll+RWHL9DMz5MLXoJ5VpFKeLpI2LpYcZXuskkTj4vN90VVaIrZpngcRoQJah8lx5jYqUkVwVNuiLmfF2dVAiYSS67AYQBBqWXjnxTnaVGVk0Qm/B9NZ5IKLYiUcs04c5FjC0b8fQlUQW8QVjDK1JzRCRBJa/IJAJIhMa3pS3F/WlqA5RuGCTKwpsLlzJ/1QV+VIZGuc1BtoKRrfVo6WsxR751K4NoVC3I+ja00Xv0bu5BD1fjADf4hi6yRqupNOzZ1o0BmvoOHQsP16FpTYsZzdDA99Y8swod/HnNu/cNVqNtsxhoBdp3d2HwqQG0rG1GB1/r3dmFjt2taNjWiIZNTfjs20+MMVdp7M0fL1FmXTBNFsLsofqOs+ES2h++NVm6SlqUHJOv+O3XX3GdnuQapdf1a5fIFNfIIGSjOz8aFlFk/fz5c2ac28mTJ/86ALm7jl36De+d/IYA+QD7j3+INw4fx1u8HiBQXn/vGA4e/wiHP/2C4PkMb/O1Ax98hAPvH0f9ujVIIEAi6TkSKJ1S6A8mFBSFj3HlHdLIItzo4ywCSA6SyDATCQ6lmiSTXSapKIobO1X5UgRHTL46vJdwk1kRV8TNL1+ijiX0GHotWp/hNUGvU0bFaCKUzUqTTCCVhwunJvkUIXeYx/IfE31eU3GYrLgKl452k3WUK5Aoeu5Ro7kSc5KlUQmpiodoVBsfq1hLPX/1mmSWOWkzsstmWqYmyqzbNOvESnDk/jdAyCZRFq0sjM0Jg0RNqxU8fCB9iZmhrlytv9OTqNvi3zUvRCdaNPH/Z9o8/C19DqLzFqGkpQY9y/vQ20+mWNmG1tU04UN16N3Wwc3fit5Nfehc14mm5U1YPtKDIRVJUWY1b1ICIk395jZ07Gw1WbwamVCzohZdO9qxdu8wmvjzKpBqWNuEnpFeBFaHDAB1QrZ69yr0PNllJFfVkA9FzQ68f/KoYYqfaM6vExwXLn2HK5d/wLUb53HjJzWuPmuAoZQS5V6JEQSQcIug8PXSRbUp/cF0g1cfXtOf99JFM7Xq0KFDePXVV/D666/9FQCimSL/PVfkGBnk7Y++MMxx5JMvCIJPsP8YAfL+RwYgrx46hreOncABvnaIIHnz6Am89M5h9Gzdikm8yydxY0elZyCRhjwll56EwIjl87iMdEzMl8yyYDwN+3gBgHIslRt9Ajd4irwEgZJQVBQGCBkmDAKyQilBoyNdMoZ5n99jYiIEmDxJLK+KqsdS4iVx844TQyj9nWyRQJkURzZJIEhSq9xI5F0/0Sk/4kAqpdU45VvxKgZJdJdRjlGmqfG1x04/4qE/qTAGfaK6rTjUeNtm2qGqRNgstSpSdxa7gEpms+UZoMQU5RiAxBVQahblGhaJK8wzkfVRlFOjyRhhgCzEvcsW4/6sNNzD1/8tQz17CZSMxfg/0ucRMPPohSzopITt7+lE20AL/IPqeFKLOm5Y/4gf7SMNJk6hLN/GoWaECJ62DW1mFEI7V58qC3f3h4FERmnd0IyWNc1kjBa0cNWtkx9RW6EuDO1cjfI6J+bmL0Z5u8Zza5BoM+zddiywL8M8WwaOfnIId36/RSMeBoik1dWrattzluA4A9WIKIAYTmQUQ4QzdSWj5C1kyL/++qs/5xh+bwqovvvuW3z55Rf47DOqloP78fzzz+LAwbf+NQDR0e7xa/9OMPxGxvgFx6/8juM3wiA5evE3vH78YwOANw+/T8P+AeXVJwYwb/HxAb4nwLx55ARNPFnk/Y/x4sHD6Nq8DYurazG1hBKHmzYmMxNJBEhCVg5XFhK5HpYJVzCw0EqG4Wai3DKnWjZNmC02wb9oPo8h6yQo2KdERGsBpYwnDBYlNur4lwwxTsmM5oSp1EivJNO0wW4k1GSa7KnVPkyu8ZlTKy2dVk2uqSIgXJhQ5SE43KbJQ7KkFIGTSqDEERxaCQ6yEH3FeI1QqHJius9tRiqkal6Jw2YkVqoye/k5zVRX5/mUMit9E/9NRcowJkgIEA3GieGKtYlNckwmr7q5qzZEIHmQRv3epYtxz9JFBE4m/m2ZWGQxAULAZC/Gv2XNN5ItrbEKgW7e/fua0DnSgdZVTajrqoGz34G6zQF07m6Hn/JJfavUZKFhdbNpEdS6vQUDe8gm+wYNQNq3tJscrsBwLdzLK+FZUYngxjp0byErbQhH0jso0+wBgiF3Lqp7KpHjyUFerQXT0x/BxIUPY2FZFt4+vt90d79x6zLOXviOIDlPsy6muIYb19SPV2xwweRanb8QLoQSMGTUJaHCoxAuGUMuNjGNHnhVuW64ZekP+PzLj/Dqay//awCicdCHz9/AOzTaR85eN7Lq7nt6vP/Dk3iNTPEGAbL/2EfmKsAc4GOt1949at7fTyY5SIC8/M4ROLp6kV5Xh4ncyNEGHLkERjalVRqSKKlSi6yYzI0cPsEKp5skUXolyrDbVJNeQllFI05/Ekt2SFSVIFe8UkXoM3QaFWfTRuRzAUkZvJRYsbyLx/PuHkP2iFVzOW5+s+g/Urj5U7jxk+kxEskEsfQnMZRGag00kWAZX+UyjJKsJg+GQdQyiOAgKyTQW8hv6IRKS/JKneMnyoOoBSpZZZLxI8VmLFxKhQb+EPwugpXXJHWPtGsYEI27LQdjC7PDqe6qLsxUd5PwUM/7CI4HMpQWn457KLH+LX0+/q9ls3FvzkKM4l18TM4CxBFU9b1taOlvRi3ZQ0e4nSPtCI2E4N9A476+Hs1rQ3B3exDke107uo2UatQg0FUaud2B3h1dJhLesaUNTeuDZkComsn5N9egfn0jgvxs6yb6jSf64VtVB29XFUpbSzEnbx7GP5qKlMcmInXBDDxWuNgARC1CxRY/nDuFK9fO4ha9yC+/3sCvv9/mhg/35w3XfxAcP6qjyWXDFPIZOrUSEGTCFQNRtq/S4yWxzPi2axdN1/ivTv2LPIgY5L3vzuPdU2dw/L/GRv83g7xy+ARePvieYYuDlFivvnMUb7x3HK9LXpFFJLX0/KDY5OiHeGH/eyhtbjcnVkmWXDykREB5DzJJIj1JaoECgrmYSg8xWflWBYqFcDNpvDI/pxOrSZr6xNcEhBT6kFgyiAASQ/8RW1Rsjnoj+N2x6r1LFpI/SaVUijctRstNF3fVbowngyTJPBMYUapedKq2o8xk6Mbxc6rzkAxL4WdT+JqSExP1mXIN11HSI30NJVQyARenFP0SDfgpMCZcHVhM6olTGcU2041eAJmooUAOfkZd6506KMhHijM8eDS2JMe0GB1rzTCVhUpQVIbBWGs6WSUTD/LxvTTpMuX3yphnL0RE4RKCPgORJUuQUpKO4oAPofYGtJNBGmjMFcOo2xgwZQeaVd+wrgGda/jeKr+JgTRSLg2QMRRIbF7eQFnVb4J8mjHSs60TvWISyi3PcjdqR2oJEAJlWPNEaP51fLxK3oZGf1sLJs+bhgmPpGLCnKmYkPYYFlRk4K33Xse589+YsWtX6TvMyLQflXJCM06QXL56xhzpKplRR8Ha+ALH3RhIuJjq6n/FRTQ64UcdF9P067GYRUNAv/n2i/95gBy/pqXTqt/M+t/fF4O8cfwTvEYAvEKmeOuojDpBcSgstyStBI433yO7HPmQTHIcz735Luzt3YjOyDARcp1QTeLmV925jneTacwn2goMgyhIqByseLJKHCVWTDY/X1yKhxxOwxwx+QWIojQLe49yrlJqe0XSw4ZdANJoA21oI7HkKWiix6nRQ40KoRyGFSbQoMuIx7uUQvLnc4JHkmo8H+t1gSVG7EMW0kz0KLJcdBGZTd6CryeR6RKLC8xJlXoIa6U6yR78MxQ81OCfSZ4yPOSlTPPoBMyGcW7KRa4UVxGBUoC4cvowmvZoSq4IMoikVnwZn9t0HJyB++lD7lmyyBj3UblLEFGwBLH2dHqhdCSXp+NRVx6yPaVoW9mOtsFmdK/vQ3BVCK5eN2wNxXD2OEy2dWiwBnV9lShrLYG7w4kAN3kzgdLIzd9BCRUgYwRWEgRklAClWGW/16SR1G+uh2fASwZqQYggU2zF3ekynVI0NXc8mSNxxjhMWvAwHrOqp28mXj3wgumhq6zbW7cvmhiIxqWp+fS1GxdxlqyieYOSTYqQa4V7ZoUzeM3wHCOpwoVTkls3bl7Cz3fUU+uKSWQUQC5c+le1HhVA/jdzfncJIAdOnCQIPjCbXxJLRv3Vd4/Rk4SB8srBI3iD1wMEj9bLB46gor0Hsdk0ojrS5cZPIFDGc0MLLEl52YZFBA6dWiXRf8SRDZReEkfPMc5GY0wQxBZQNpmAIAGSX8RVSMYgyxQpUGennleBlHKswkFBSagJNNhKMnyoRnUdDkTZixGtzouUTOPpLfQ4lnf8RJl3fjaZr8e47YilRIoulzQrNvETjUwYbcnmBqaPIFjUaSWpSKdTvMqUkzmSxSDqRO8qxVSvAo5iLwLHRVbhJk42ACnB+EqyW6WeEyQOfpdSUAiSSBp2ZfOadJSiDIzOC8ut+9IW4z56j9EFiykTycKuTDKQOr+nY2pZGqYULYazy4d2dTfkZjctRh2ZeMwyGwX+QhTXFiLXq+nCVmS4M2CpyoNTHRI3NhuppbT4gGrS1wXRQG9S3FKKgiYbyvorKNEInKEQGoeb0LZFY6b98HVXoosSbh7l1aR5kzEvfx7SyjKwhMDN8Vjw1tsvGxBcvEgvce0MTTrZ4er3OEdG0dDOC+fP4JpGsv2gWYXqbCKPEV7yIbfJFLfIOAKBmMSwxjV6lmtKdT9v/I3mHn5/9i+U7n53CSBvHf/UAORNSi2BQqwhsLz89hG8+NYhvPr2UbPe4nv7+ZlX+Lq9o8vkWyWQGVLoJZSxK4AoEDiVmy+RgFC9hwy8goiJViviFPxTRNywRh4fcxPl5SEmj3dyaz6iCRgVRUVZNSO9AkmKsOs4WMe0uvvLfxAA0Wru4CN7qOCJADGA4F0+oZIs4QmvOLcWwUEwjeHdP5KbPpLsEENWiyMrxRMUo8l0Ufw7xhZK9lFmFYenXGle4nidXtk1RJS+RJ3lfU7KOP593MUGBOM9xQYYyW5dyZzecr7G505N7bWaUy01iBudT+awpVNGyayr08liMsdSvpdGf5TB78tGEsGR5FiKKZ4MMmsaHiFoSjrsJjWkaXuTKYVWBm5ZawXyavJRyFUcyEdJqBAlDTbkVeXC4rOY/lfN68kMQ0pebCNAKM1Wy6C74SXbVKqHMtmobjCEJnoQ1bVbfPnI9lnhHfQhzb4M0xZPx+KKNFirC2ALlaCyoxLHPzxsAoAa0PnDua9w6cppMofGO3+HM99/CzVgkEwSOMITbMOFU3qsE61f7lzHj7evmJnqN25cMVnAV65p+u33NP2nudSGlAC8cuavB5CjF3/FG0c/MeB4mUzx3BvvGFCINcQe+49+xOtxA5DX3iarEEgvHzyM4uY2JObTdBMgWgLHeHmKnCxMpveIyso0p1XKs0rkho8lGEanU5MTLGrEEKsIOYEVT1BE6RSLxnycWIPPY3SiVUwD7nFhKoEwif4ihQAZyw2uOo6oMiUrFhqzHccNrHFpCZUViOJdfwzv+JH0GTF8LVb1HgRKJL3Jg/RBajaXbKcHKaHHUSylWAxlNXUaiQRInJrblVjCQ0U1p91JieURQ5RiSq0TqT51cCwlk4XBMbmWrFVN415FP1SlGhTKNBp4fYdOs8YWqNIwEw9Yl+J+i06qlphR0A9allKGpSOO+j6BK5nMkUommFaVjakVyzDPnYPS7nJ4V1ehdQeN+nAtqvpVt0EmqMtHZaOGGjnhCJWipM6GbGcWpqXNxBJKNGu1Ff6V1WgkEELLAyYgWL8hgL6NnVi9eQ0qG2ppyH3o3U5jv7YNS2xL8FjW4yioKURlqAJlngJzqlXcajenZBoGevLUZyZXStLo8uXz4SKo65dw5swpE/9Q+si33377/6golLTSaZZpEUT2kJS6SqbQY3V+V+nuuYthcGiAjsChUdB/OYAcufArnt1/DM+/eQhPv3rQrBcIkBfeeg/Pvv6OkVMCzisEx0s0568cPIoXeR3YthsPq9MhQaL6j3hKreR8Mgb9RhwBM2rxYuM5orOyyTR55vqgAJKdS5mRhWiL2CSXICFQyC7xNhVFaVqtm5tXNRrl5mRqWk2VybHSSGd5j0RKpUQySiyZI6qcconAiXWXI4pAGe2gbCJIRvNxBEEiFok1zFNsMnfjCTqB0wDEROUVcCRAC8RauYhTcwmNhpMJJxBSa3VUbMfMgBPzGryYEXRhflMlHuM11acKRd4AqgigKoKEDDLZq7SXsMRSxq+qCsdYMvCgmXy7APdrHAKl1SiCJY4SJsGRQXbMwjheJ7l5Y3HyeeEiTLQuwBTrQtjaylG9uhrlzeXIrS5Ejq8IriY3rJW5KKHMKvRx1ZViRvpjSHxkPB63zMXCokUoDObDzp/19PvgG6JXWR9EaHUQHSs60NbdjOpePzp3daF9ayfcbS7YQ8Xo3dSOymYXPA12NA3WU6IFaeqrUNHtNiW3SjTUaZS6kOhESo3iFPSTt1BsQzUe4ePb8CQpxUQEjvMXfzDSSmkqP5m5IDfx8y8/msDj5etnCRCxCBmEEu7yX3E+yJELd/D0m0ew96W3CY638eSLb+Gpl/bj6VcOGoC8uP+IAcZLZA2xx4HDH+LFN98xRTjPHHgRlrZmmm7e/XnnT6RsiiZQlNGra4xOoRT/ECvk5GFMeiblVN6fplz+Ix+jCKJImXVbmDXUckdFUKo5T1FnE7fYQ3UfillwI5JRYrXhZdjJEpECCkEQoSPbWg/GkklGV5Qgkq8l6OfkO8Ri6gavJEj6Gj3WAUG0fEe5qgeVpyV/oVHR/G4fGaHeg8yuEIqXt2BRexXKhlvQtGs1OretgW1lE9LafZgfcuDhWjum1jkwtcZB2ae/r6Lv/P5iC8YU5dLoWzHfno3J3PBjcpbiQfoQZf9KXiXYyR5cKZRUD3kIEDJJTM5cpNALxHHTzypdirn2pXiYoJlesAg2Mkj3+m6U+0tR015pJJXM90KygBhkxrKZyLVnorSlGMH1tWhc10iJFSQT+FCzphZN9CbB3hD8/YqFdKN/53I06OiY7zVub0EmfY4G+QQHA3C3exDUCLdBPz47dRK///47QXLHgETmW15CbKFBnKdOnTJxD4FHkXQd95p1+QJ+Us3ILaW13zQp8zoCVg9fReXDs9Ev4cJlSrPr5/j8yl8RIL8SIEex85k38NTLb2PfK28TIAfwzGvv4FkuMckrlFdaOsl6Wyde7xzFwWMncPzz99E4sgbTlRxIFojJoCHlhldRUJSkFCXXmExuBgJHKzIn1yw1Y0gqLTFdErVhlYQYQcmlTZ/slFRxmYlRMWWl4bu/XXXjalRdak6iwjKrGBFlNjxgp7+glIqkR4j0ViDCWUZDbqfscnKz25EoH6M2pYqwK7Wef9f4UnVo5M8VyUwTMGQixVaSyTqxdoKdcim9O8gNtApr96xB44YudGzowUqlYexaieZNfWhd1YXm4W6sfmIrLF1NmFtfTaZTur1yxcggpWTI0jxMrSpG2YAP83jHj7CkmQKqGJsaxlHWcTPHcHNH5S9AUvFiTLbTf5BZJlvmY1LOHIzPmIVxWXMwk6Y9u8qKqh4fOobb4O/0ok5d4IdpwjeGzPgEV7+HYFqE7Jo8WBoLUDNEk7+hhYbcD3evE+5BD0Ibm+DrVffFOpMJrBHSjVsImk30LNs6UdsXRFpFjunLWzMYNNWNLZu7cOLzj83JlFji7hJrKACoY1sBxaS0/3gL1ymlxAQXL/1ASXXeeA8B5NYtzQ6R1FKnk0sm6Hj52ll88+1XBiAm8EjA/OUAcuiHn7Hz+YMY2f0Ctj31CgHyDva+LKkloOynJ3k3LKsIFPkQnWaFJRdZZ//r/MX3YTq9g+RVdFYWIrMpqxT8oxkfpzQRSq5YS5hFogie0fxMisppKXHkNRT3iCwI13ZM9qoSMDyIcwzfVwJiNIGk7iXKqRrDzTyGoBhrwFGMUfQWD9CPjCEoogiQuCoHxpBRZMzFHgLWeMpApblHFyt1pcikoESXqoak1DSHi6WXUVwkmj+nE6/FDQF4VnSjiYDo39zDO3YH+rf2Ys3OlVi5RX2JB9G7uhsrVvdi5eoB7N77FLo2bUDlij48XKOUF0X51f2R5t+eh5nVNuTTM8zxkjWt6RhrJTBo0Ge5FGS0EJyZBO4i/p7m8yYyB5MLCI68uRhPXzAxdy5SueaWpSGXJtzV5kaoPwSrV80XqhEcaiB4W3mT4sZfUY2KLofxLiqaatBckXU07ASDf1UtvYgPLVvasHzvIH1Nq6k9rxuqQx1ZRrMMg8MhtG3p5GsB1Kz2G2nlW15rSns//PKj/+XYNjzu+a7XCKe1hydJhaPi50xk/NJVSq6fLobXratkEoLo9lUTZNRE2+s3dHL1Pb78+jPTE0sJkNdv/gU9yDtnfsLwjuexcsOTWLf9Wex4+g3seWG/YY99BMqTL7xJiXWYiwZekov+5PX3jptTrqaNI3iMPmESmSBVYCAwYriiuCIzMzEmSxms2aYa0FQFWqwmr0pRc23WeJl1yh1JIGXv6m6v52NLbKY8NpZAiuTzCNV4cDM/yOsYXkcTLKO5wSMJArHHWLdGHtgR5Qm38Ym1hyPo4STGcLOGCP4Zpo2ox4l4/rzejxKLlAp8/Dy9zaz6WgxsH8GTrzxDthhC7wiZY207Vu1agZVbl2Ng43Ks2LASwxtXYsVQLwZ4c1i9YgDrRtajf9s6sogXE+lddML1EP3JDHqGWT4rskL5WFJloV8jc9C4P+6wYk4lAeLJo3wko5amERQLMHbJTERnPoZU6zwkZjzG1+YZ9phbugwZVTmmXqOHwHW3u1E7VI0qZeRSKtWvaaDXkBknUFb5ULu6FnUETOPKAM26egy00pT3ok/N58g6XU90o31nJ0IEVuv2HjRv6ED1QK0ZmtO4vgXdO3pM/yxlDmtO+7GPj+KKSRNRfUe4dvxuMzjlXKn5mxkFfe0i2eB7cxQs0/3jz5fMuk2/obR31bRfFniu/EAmuWgi82fOf2PGKtz8szH2XxAgt7F+96sYXLcHK0eexKYnXsb2va8ZFnny+Tfx3Gvv0qiLQQ7TjxAoOu499pG5Nq7fhMervEhSlq1YgjIrkWwQIWAQIPcvSzPGPJaeI7mw2ORbKSCoRMSxFnkABd8IgkJJHY1xrjCdEGMrlAJCBqD/ULueKLsmQmneoA2jdeUGf6CsBNEEZyzXGHoIgeaBchse5IaP4IoiAKLtasqgo2DVjZcSPPxudTQpVbCwmK+VGLaJFeNUuZHd3YqtzzxBRt2N4Z3DWPPkSvTvIFs8MUCQDKB3C1llSx+Gtq7AwHAvgm0NqA3VoK2LLLNuFXK7Angk6MSM2nLMC9qxwFuAzLp8FHeXobDVzd9BLm8UFsz32jDdlUdJmW0AMqU4HZOX0GjPmYpkyqrxZJCUtEcxJXsOFpA95pBhsgkwjSdYtWOlqQps3aqeVm1hBlnTgnqNa1vXRBB5ea1H3Ro/mvha27pm9O3oMyW7iqmoS/yKvcvR++QA2p/op1kfRPPWNnRt0xCdNoTWN6N9TycCI/WoXuUnCGvx0RcnzEAcHeeqk4nWRZNWEp54a8azXb9iGEBscPXGWTMD5Odfr+Hn366ZyPudX38OVyRev2wSHn+8LZl1xRzv3rotdtF3/w8B5NjV/8Qh1Xlc+p2P/z0cJLz2Hzh+9T9w5Oo/+Pw//qse5F0DkNcwuH4vVm7chzVbnjEA2bHvNeymL3n+9UN42TDIYfqRd8PxkKMfYeOzL2N2pbqcdxIkHiQWih0sRl6NztJpVRZBko2xOsXKL0CSeuaSPcbQi4yhUY8gaCJVO3I376pcgTb5Bhp0zTp36pjWhUj1ziUAIrjJHyR4RvN5dFUl/YYHkQRQBEE1xk2z7qI5NzEPMgsZRPPOx5RpeKdGP2tEG2UUl+pFVM+uoOFYrkj6niT+/cf5PFjQGsKap3dh66v8PTy7k3KqzxQQreAmWrtvHXq39REk/Vi1bSVWbxxCU08rqptqUNVcR9nVD8fyZswKObGwyYOKDj/SyvOQ4chBcHUzyvoDJl1lEj1KesCORz30KeXZiLYtwxTrYszMnI3Myhw8lj8fyTTb49OmY6EzHUXNpSgIFKE4UIq6AT96N3XD1e5AcE0AXTu60MQ7vuRRJ4Hs7K3kn+VHw4YGgqHVlFH3bBYweNVnt4shmgiIDrQ91UOALKcK6IKru4p/Xy8swWJULK+Eg9+T6S9EVm0BCuvt+PK7L/DrHze5ia+ZuvHffv/Z9LpSyro5teL12k3JqUvGV5h6kctn8fOd6/jlV/mSi6YSUT8rP6I0E0mvn35WqslFehWCheyhk65/PkCu/Sfe/OFH7Pn0ezz52Q949bur2H/2Nvaf+wlv/HATz355Hocu/oq3z9/Ba2du4JUvL2FghJJi49MY4nXF+iexgZJr3bZnDEieI0BefDMcF3mVvuOtIyfw+qEPqFEHMJmbebrDyeXArMpKzHQ6MSYtnayh2vTc8CJIUugzEskckVk5lF95BiiRXMnKq+JdXo2jY3h3H8sNHVtRgZSqKozSxhY70N+MKafcoj9J9NdiLEEUQRM/ihv9QUqsaLd8Rxnu52YfTR8Rwe/Rc0mxCLJKlKSavl91J6YfloCieYZkFUqzSKWuiIkIxjmhIBzDK5BH6bRseScaN61AoJ8afqAOrRvb4GyvQnVvHQY20Y+MrMWKYUmv1ahf0Qpfdx0q+hrxeNCB3BYvajvqsbAoHVnufCyuK8NUZxFiC/MQb7NgQXUFHvfqEII3j5J0AmQBZpE1PJ0uZHlzMSPrUSx2ZcDRpxkeikUEkVdVgGB/E/+8FWjf2GJOnpq3taJppJGP/Wjc2ojmnU1o2dSMwNoAguuDZkx1y0grBgiGrp3taNqqdkFNqF0XQsuebv58GDzdW/voVVpQ3uJEuisTyyoyMLd8CRa40pHmtODTrz7GnT/UA+u6Acdvv982TKAOJpJbmip1489CqvNkjguXJbEElPMEApnlVlg+CRAy46ojuX7rgnn/yjWlmJwx7KNYyz8dIGKGF7+9YtbB8z9j24df46nPz+KFby7z8VfYcOxTvHzqCvZ9cRZrj3yMjYc+QtPKHWjr34bulbsIkqexfvvz2PzEi3jqxQP0IG8RIO/ircPv4+Cxj/H2+58YeZVR30hJRZmUrRY/ecgM1iMwtArT7NT7AkJOLq/ZiOVndKwbrc4jmVkYlan0DqWyq1VPvjmpkhmPJDhG8/FYbuSI0nJKqHIzeFMTajU1KoYAHEtgRLjdeJAgeUDs4f1TYhEU95M9IrjhR+t7CIAoh9JLHIjj58Qe8QSeJlGp2lCAjNOwTw9ZSjUjtT7E+avNSLaJDUFMpXSa2R5ETtCLWVkLkOsuMM31rN4iBAfr6QP60DM8SJk1iL713fD3aCRbPWoGuzDf74JnsAlVXVVYXJKB/GA5HnLkm9T5+DKd1uVSXvL3YsvFg/npmO4pQnqNDUs9mciuyYWl2gp3N79jlRduLjV201zCAt7NNQqhl56jdq3fNHnLDxXBQzNdvUqyKoCmzU3oownvfKIL3hWVaKTkCo00oHm7vEaT6XoSIoOou3tQsmwzGXCd2psG0TDcgnRnnmlYXTvkN53k55UtwZLSbBz98Cg39jXc0vzBX38iM0hSXTaN4fSaOrNfu65a9MuGSc5f+s4kNero9jJNu8YaKFCo9qNiIZl1HemqfFdNHr797iuyyAXznf98gFA27T/7E0FxBvs+/8EAZS/BsO/kOezl810fn8Krp69hz2ffY+T9z7Hh3Y/4n78Owfb1qO9Yj4E1ewyLbH3yVTLI69j30kHDIC/tP4T9Rz4gSOg/3jmG3FCzAUdsBpdAkp2HCYUlGF9E+UJAjLcVI9ZiQaxkFQEjaaUCqAezVS9BU6/ZG2QWdWc33RFtGmFAsAgIdnqK8goz+CahuiY8Jcrl5oZ2I9rnw9hKD8ZoLEENN3VttZk3OJYbfayXrEJmiFAKivyMGlR71KSajyvUZlSTpvhzCnAqIElpFVNdiVi/D4n1fizobkbeUA+WDLZiXmUJHs5YgLl5S1EWqEDTcDtayBRda3uR5VRDAzu9yBCGdq/AMFffhgFUDrVjSYsHjRv70D7UiWxnPiqaq7HA78Y4RyHiS8NBSWUTqGnDfVmLscCtYZ423qlzkO7OxtySxXD0OFC3icBYUwXfcA0qVxIoa2rQzDt/dV81qmnIS3rLYe9z8K5fjiJ/PpmgGf5NAW74IMFAP7ElXDXYs6uL8qsT3bu6TT/e0laX6X9WRYnmppmv1rTi4XpYa0vxmGUBHsmei1x/EZnMiqyKPGRXWHD8w2PhTU4pdbeHlTq6a9Pf+U29rS7hwsUzJunwjz9+Mce5l6/9YOTWZbUK+jE8cSqcpHgVt+9cxS/0Jj/9osm4V/GDqgxp3i9fPf/PB4ipM6fveI8e5D0VSPHxkSu/4/DlP3D4ChdfP8rX9PxdepTXvrqCxv7tqGlei1DHBpr1p7Byw1NYv+05guQV7Hz6VeM7Dhw5hoNH3zcp768c/gA5LW2I4GZ/MC0D8TTciZYCRGZkY5wSDTWCIDMHozMy6EvkTcgeZBAd60bk5SOBrJBCWaaJUWMJFo0sGF1MM05ARDnJCOXquk4wqHDKU4kYrmhNptXkKG7sSM1Ir6tFaqAOqcE6xNf4EOkjQKo1vJPMUKVRagQFGSaB4EnQyZXklfpiVfuQTIDFc8XVVCGGK4rsMaGxHqX9bWjZPAj78iYsLs5Ejj0HpTXlaFnVjv5N9B6bl8MVqsTD2fOwgN6hhbJEcZLV21bwbt2NHDJJbm8Nguva0T7MTbm6Aw3LW5DRUGV6aEUVWhCl/K88smh+DqY4NLTTicUVOSZS7uzwmD5UmnVePxLgHT6ImjXVqFlVA9/KKoSG6tE41EBf1AjPykqUEyB16zSa2ou6tfRCw9XwDtYgRJnVuKXNAKNzW4c5ttU455yaIiyx5xGE9DbtFchvroCbf19bqByTF87ApPnTMH7udERNS0XqohmYx8/l1drw4ecfmI6KpmPJdYHkR1M5KGOtqLgAoqYNNxQQNMFAnVadNa9dUrMGDce5pQg7vQpZJuxNtMJ9s27c0tzDS6bi8J8OkGPX/h0Hzt/GOxfv4AB9x6FLv+LQhV8Jkn/g7Qt3cITAOEqjfpTP36BX2X/qBoLdm+Go6TUyq3f1E+hbvYse5C5AXsE7x1UT8hb2vvYcDn/yKV4//iEKO7pNzCM2z2IkVjIBEqFIeY5S2wmIjEw8kJnJu2WuST5UCnsygZFUSt9QoqQ+l+mjG0XGiScw4sgQsbzeb9PxrceAQwM446vIEO5KjKv1kxEIFm8VTXoVEuhHkupqzN0/ssZrGCSylua9msCq9ZIZPEiorSLL+MyQzgRfJZLlY3xewzoCVYyf3x/wIzbox/Smem7MTnSRCdxtPiwqWAJXQwVKgxUor/fC11aD6u5aSo5MTFgwA7Nz58FOA7uS4Ohaz0041Iy0Vg+KVtQhRGPcs2k5NuxaC//yDvoP1bTkmV5YiYU5SBVY8vPwMF/PdRfhkZx5BIjNdLWspudw0gvUDvpQp/EHgx6UNZejst+NRs1AX+6nB2lA/cZ6VK71IbQ1RBkVoHQKmgYL/pVBBDRznYCQWZdHaSa7VK+qw5yCpfQXFjzCv/t8ewbS3FaylhWP8986cd40zFg6Aw9OSkDU9BRMS38Mi+1ZKGgsx/GTx82dX2Oa5Te02dXA+toNgeYS/cY50+XkotLfb142WbqqHTl3/rQx4XcbyKlIyswT+UU9tdTGVEVV3/K75EXCDRz+6QB5hwZ8O33Hvi/OYSuvklgv0HO8evo6dnz0DZ79+ryRWi9+fQnrj5/ESyfPw1W/EsWuNkqsdehcsYMSay927H0DT9B/7H3hdbx+8A0MbO3FyL4N+PTrL7D/w49R3N2LBKWnUzrFcSUrQ5f+IrmgCBMkmcQglFYRfG90jgqf1IihGDGl9Aqa4aHWoB6vGZU2VgM4yyrMgJsIjUAjCCbS00wM1COxuhbjauqwoKsXk+vqMc4fNCCJr6427JFAaRRTX4v4IDd7Qw1igtz4dVXc9HxcRyBwJRBISXXhzycRFIn0GgnBWsTx+bjmBkzrakMGTXWRvwKuJjV+Vl+oMgT7AijxO5BtL0Smi+a6cCkeyZxNXzIH+ZVWFNZoGqwXHevUF5cavtmF7G4fyleHUD4YRBEBtaiGUk6+g4B4MC8LqaVWTHIo5cWK6c4SLLRlYqkzy0y61cgB/0gtCjUmrb/WzEyvWxEw89GVOGgqAYdDyPdbYQkVoFjp6xvFNIqMt9KHhFBDf+Ja40MXZVbnlk7KrVb4KbtszXZMy5hLcD+MjGoL8uttmJExC6nzpmPc4w9hwuzpmEoWeSA1BomPTsAcy0JUtfvgHwzg/ZMnzBFveKqtEhCvmNoOnV4pWi5jLomkGpGrN9QS6Aec0ziDc98RQOEmDvoZdS+5eEnHwCqaOmviJufOnsGZM9/hwoWzZiT0Px0gAsKm978gSL4xAHnl9A08R4P+9JfnsP7YJ9h84nPz+pOfncbIB1/g5c8vorxuAIUVzahpHELX4E4sH96D7U+9jmdefQ/Pv3EIO/ftwPIN7XxtPdnkIA5+coIM0okUjUCjEZ/MTf4QN3gcQRGVQVbJVZp7PkanqwVOuEtJYomm01JiFdgwKl/Hug5M8JId7M4wOOwERoUmPlGOVFE+1QXNiuNnkqpqMNlfjxn1zWQVP5Kr/JjX3IaHQ0EkN1JitYSQxJVSX4PUlqABSoJeJ3jigwKPH0l8nFIfQHIogJTGICa2NGB2RwusK7tRs301yprccDe7UeSzwd3q5KLcaXCjoacFVS3VKOOdNNuRjZkZj2NOXrgJdFp5BpxtbrQON6Gd+l7TahfVl5FJ3PQibqQU5yHakoVIld7maQxbpqk/kQ950JJrKhctjW6aeh+ClFOhLUE0bdWULzIE7/ih5XUY3NaLHm72DnqI1p1q+dOOBTTPUzMfQVmXndIqQMaoI7iaDHhqNvjhpbfo3dmHFU+tQs+eXpR3ujBDkfpHJ2HKUgLEb6HvycbDix/FxMcnI2VmKhK5xs+ZgsipiZi2dCZvFkVkqjYyTy2OfXLMSCqxQHh67XmTYqLgoemJdfWM8ROKeeg4V7UeFy6dNhHzq1fVq/csLl4MdzxRia1GJ2g67g9nTuPbbz7HV1+dxNdffopjR97+5wJElYNvnrllTq9e/Z7A+PoiXjt90xz7ikmeICie5WsvfXfVAEmPn/30LAq8PWSQdlQGlqO5ewS9q3ZieNM+bNz5PJ4ii+zcu50AaUPHmhAGtvSgd/tyFLY003sUUE6pGVwxkqyFiFqWiUiCIoIriewyOi0To8kqiaoQJHPEFKqFTzGiizTKwI7YUgdiyRqj+Ty6TJNl6SOclEluMgtXTKUPcZRYKdV1mNfRg469zyKVAEl0eFHWN4DiznrYVnehYstq5A/1YkFrPQp6W7GwswGPdjXzZ1qMxIqnX0kmKASM1KYQZvd3oWrzMAIrW1Hd6UPrhlYzvdbXWm0A4qKRLae8mk9JYqsq5p20ElmOHFgr8zGRd9lZ2XOwhGyS584ji5Sgkwa+iwxS2VWFx115mEoZM6FMSZmZiLUqhT7PDPD8e2YaHqBB1xplpeQigB5vcKJhS4eRQTXDdWjYHEDHjjaCoRlDz/Rh6Ok+NG8PUU55abobTbBvfukSzClagFICRCPVjE9REwd6F+9QDawtJfDTeNevo3EfpLci4HO44R8iYzyWPxuTKaUmLZiO8bMmIXH6OIJkImZnzcIjWbPpQR7CxCXTUEKgq56koteFQx8eMqdMV/+c//HfteSXjbHWaZWOeH/5LRz3kCmXHFO/LCUtnvn+NM6e/d6A5AKXpJZOwL499SXe5w338y9O4KMTh3D40Ov/XICYdSNcPRgODur6H/hAj00Xk7uvhR/r+vKXl7HU3oiMwjq4/QNo7duC/uEnsGXPq2SO17lewsbd6xDkf4SPelj/CQFq4ZLWEKbZHZjKNbm4DHHZavmTg+iMXIxelmGOecdmS2JZKK+KjTm/nwwTSfYYk2Pla2UYQ7BEFKp1aCWm+kOId3kpr6rxIEET6fAgkcyRRHmV6K1Belcf1r30Eh6pa0BmZx/8q5bDzbt0flUeHs16HItLl2Jh4RIz0y+4vJGypwcta7uQ1RbEdHqOyfQYU9ubkLlmAKtf2YP1+4bRPBREXX81Ote2om1lCzrpJcob7Px9ZGKOdRFN6wx+91xkOnMwO3MOMkrTUEAznV9VgIpAGXIcuchzWdG3vhf969uNLHrMmcubxjLEZKebtqyRuVmILQqPYbs3IwN/T0/H37N447BZMbqU/s1pxRLKudzaIhRxU4Y2BNC2qxFNe+rRtbcZ3XtbULuhOtyRZKgOTWvVnKGZny1CTn0+pVM5KtoclF02lIdcmG1LQ9ycSaggK3Xv6kUDvdHC8jRkeKyYvPhhTM+cgYmLp1LaLcIS22LMz50LizMTFa3lcPV4zCClhy1zzL9Rg3xKOh049ukxegbVkGuu4A2Tpas0kUuXKaUuqsPiOXN0e+u2aj1+MintqhRUtaEi7uEOJ7dNjYhSUpSecunyZZwie5w8eRSffn4EJz58FydOvPc/AJD/l+ulL67wlxrAnEwPnLUDaOnZjAECZPWmp7F26z48+9pBDO0aQvUQ79o9DkorB69elLfXYp6vFlPoHyYVl2MCzXZSXgGSLNTX9B7R2Xn0Ibm4b2kGRmWp+bQF96Spx24+Ii02AkXdRioRT+YYT0aILXUipbLGsMiYcg3W5HvuarNiyt2YUFmLjJ7lmBNqha1vEF3rVsEZcsDiyuKdPA22pnxulFJ0qTvgygaU1RaiPFBCsFCCDLXyzjyI7idG0L91JQZGOtE90oS+3Z3o3aq2Oi1YVJiGhQXLMGnew5hATT59yaO8q86Fo7oEBe4CLCtaBovbgnJ/mflzy/wlBIkdNq8NwzuGyKzdKCS4ppVmYyKZIdVmofz8M6OA0mpUThbuITj+lp6Gv2Vm4D5NvlXnk+IcLArxeyjhpuc8jvKeCjJICwae7Ebbtia0bG/m79uOsl47QjTmzWSF5q0tZA0/QVKMQn8x8nwFyKMfKg05MYESKnHuRMyjr6miD6pZEeLNzIkp6bMxamoKZhcuwiJHBgqbSs1Sx/e8YAHZiExGSeVZwf/X0mVYRgm2xJONucVpOPLxe7jz+3Ujny6rA8m1cKRcLCFzrVMpsYYCfaZx9Z8jEc5f+AGnv//O5G3dLcGVzBJQxCJnTp/Cd6dP4rszJ41fOf39N389gLzw+WXMKKrD1MVlsHk60dA5glXrBY5nsWH7s9jz3GtYww1QvbwKngEfSqm5yxqd1LU+ZFDPT9bIgYJCTC1zYBKl0iRbOcbRZ8QQIONoxqOtBTTp1Nw5OupVt0QH5ZWDulyd2SmzbHYkEQBxZepnJb9Br+CjT6j0Y2JNPVK8fsqqAB4KNOKRpjZMIlBm+hu4kXrhba6Gt74cxfUW1Kx2wTfkQu+WVvTSNLtayuAlmP19lfDQoDb1+8mOQVTUlJrn9WTCIPV1/co61FAazc1dgJmLZ2HS41N5fQSzaGjnZ9Oo1jlQR+kV6qmDv6MK1S2VpuLO6rSQPcggvDP3bupFy7AaTfswx6XukTlIJgBUVamYR0Su+mNlEhwESJqaxaXj3pwM3GvNpCfLwFRuwgxvLmYXzafJrkUbQdG/p4s3JZ85xq0erkYlGaSS/weBFTq1akWAYCluKad8suPh7NmYy41fxN+FcrZyvBYsdmabAqtZ1sWYtGwO7p+YiHvGxWL8vJmw1hRTivmR31iCR/LnITVtJpIXTcdS/swCgmNWwULMcSwjk8zDPMrM9z5427QZVQRcUkrToy5duWgMuJrGqYxWp1zK7P3lzk/m+Pb3f9wxvuWbr7/G96dPU2adMjJLR7ky5Of4+FN62SOHD/B6zHRdPH/u7F8TIJMK/EiYbUVaYS28dcvRuXw71mx+Blv3vILdT7+K5195Ab0bNQ3Vj+CKBhQHnPB016Br6zDmUd/PcLqQSqk0kQCZRqCM4+YfSx8SSWCMzsmjtMrF/RkKFhYginIsmv4jsrAMiXYPJpAhxrl8SHLSnPNxSmUdkjz0DFV1mExQpFQHML4miHH0Iak06rNCbZhK4MyqDaGgzot83ulc1Nxtm0NoGVH/Jx83fTXqBivRNOxHTacbJVVW1DS5ENIJU20xSni3remuNBmvTvqNTBruhZRUjy6ZhVlps5FbnodHlszG4+lzkFmUBnewAqGuOgQ7KS87+N0dNXCH3FhGyZVZkYOBbYPo29COjuFm5NPoTy7NQ3IBWTQ3G2PzaNDJGveKOdI0Kz3z/27uzL+ivvL0/y9MYowaE5OorSEqghvEBZRF9q2K2qCKKrZaoCi2otgKin3f9x03EJVEYzQx6RjTnUUTd0VQUdyiPdOTpPPttJ10fnm+z/2QzA8zP8zMmTlz/OGeD1AFCue+7vM8d3vjZeW8kqxOjEOgLYkWTg9rhRU2Au0aLUXzZCNK+kukM+j5HUUo6CxEWrUVxjKzdOVoxXAtikZciM83IMIkgx8tZrJDlFzLhL0zH5k1wgo7EW3RwiPUFyu3e2LFW+uxhYF83c4t0mKglS7AWJYOb5kf3ti5ES9vcsOWqB3YIfdDGK1qEO2XAEQAJiZmxKLg9z+I/VZP5mesvhPbTOaL6Ijt7OKGkp9+/hv+9vSv0iEpsT4iDkc9enQP9+7dwp07U5ievoJbN6fxz396TBge4svPP8bJE4fw5RcfY2b6Km5MXXr2AHlv5l/glVwIt2A9QtQ2ZOQ1orF9HMNj72Pi2GkC8nt8dOYL7JscQNOeWnSOCYvSSo9fh7GTDPNHx5HVVA8fKoeXQdzNmwzPOOaNqFisiFVhlcghCQasUDKcqgiJXtzMbqHVElfvWOFF1fAkHGvSsvkUliof6zPsWC+gsRfAg69LLceOLfnF8CU0PgQk0lmBvKZKpLKT2Jsy0DFeh7b9NXA0Z0qFZcRdUDV9ThTU50CVqoCN1kjYr8ouJ0pb8lHO/FHRV4pMVxZfV0GbpkUEFSNME4EEix7q1HjCp2czILPEBluJFfYKdrzKbH7Ojlsn6gLaCWcWWve1oYd/l+r+aiiLM6gg8/XhxYLgSlFRSq7AshgFXo5VYqmKYZ1W040BPiA7hSG4FCWtFcioymLGKEbDGAP/ZD3yOcKn12dK5zhcVKfSzhK2UrSMtKBhqEmqNhVhkkvrFXq7GS17+1FAS5XbZOffRUwZV8NKxQtNlsF992as9duIEF0o3P03YbsiAJEWJfSijHWED9x2eWJD4GZsj/GBD9VEnZeAeFrUmEwNn0k4P3VBsk9/e/qtVAdErJCL8xx//+lH6bb2b8Wl1GK7ujgQ9cOfCcgP0mLh/Qd3CcYMw/gNzNw8L+WM27dvSJVt7929jVMnj+CDk5M4d+4MbkxfxtT1i88mIJsZ0FfsToBPjBnmrBpUMYe09x/B4IHjGJv8EO9/+DGOn9iH8Xf7pFvFa+lVuw92YfzYAXz02YfY995RxJdWYDMBWa/RYxOV4k2lBssJyGsyJX5H9VjJAL88Nh7LVSKPJOM1hQ5rkizMHpl402iDe1ouAcmHm5l2y5oLD0LjyUzinmXHWoZ30TyyhdLkIpCB3tTcgtY9XchwmaWgXtiSh84DrajpcaGLI/rIZA9qekuYE0zQMHQ7mwv5ejtbC0M5Pf6eBlqxBmRQDfUEIYP2RMMR10AgLIX05+y8RjZLPkMwATHza0ZHKvLKs6UcItZIagZqkdNQCGVhOhSFGQi3i0q9/P0N4gokHdbrqR5qJV6VybFMpsBSuRJL+HxZKWqDaKRa6h60YwF2I4JyDLBS4UR57frx2vkaIKKg5lAlagdrCXs1HHUOqSxb53gnSttKEWKIRGKBBf1HxtB1eBTOIReqh2vQdqgdWe0OaeYqiCrgGeqNdbs3YUv4Dqzx4zN6OzZH+cBXHYa1gVvhGeSNreHbERTnj52EJyxFhkT+3RJdRthbHZi+Oy1N74qL4kSxHLHfSuzB+umnv0uVo0RZ6If/fAuPvruFP/1wB395+idasn+lnbpLIKal2aqbty7j1q0rhGZWOss+df0S3n/vMD795H1cvnyWAF3B1LOpIH/GRgKybLcOW6NNMKSVSVtOOgffloL6yPgJTL77EY69N4nD7w5LJ+uaGXLfO30cR059gO5DbyO7rYeqkYw1YhaLAGyMM2BVRCyWhsawyfByqBxLg+V4JVyFJUEyLJdpsZQfr9Ik4424FLgZ0rBKZ6btssLdko03LVmSomxk3lifzeCeaafNompU1iOmog65fX3oGOWI3VrKPGGFVgRSjsC17LA1PWLHaxN6x9tR1uGEiZ3akK1H80AVBo50of1AA1xtYgHQyA5nR4aTgTuPQZxZIp6A6NIToDbGQW6IhYaBW1RbEiE9hX5erHskZBngqHGgsrNCqgsYnZmMHakJ2GEyYFOyFp6GOGzUKxGckYiIXBN/v1iqRwxeipLjpUi2aDZ5LJYo5Fgkj8RiZRRWJMbC3ahCdEHq/Cm+EarKkBM5XXkw8vdziB3FzQWQc9QXJaE73+lA81gr0soZrDtqafGGUNXfitJBF9onqGbvimPC1dI2kjjmkQ3hXlQKb1qo7fDc7YVNoYQikJ+H+2JdwFtw27ERmwmJnBnIT+6P3fEh8Kdt0zoSUdRfimuz1/BEXBf6F7Ez98n89vTvRTD/f9LWkm+/e4JHf76JJz8IQG7j0be38ODJrDSLNT0lbNUU4biMuTl+/cE9CZxrV87jD5+ekqZ5p25cxO07V3Ht+vlnD5ATBGRzihMvBzJUh6dAZy5FXkknalr3oqVnHAePniYYp3Hk2AcYmxihqrRj8sQ4PvzDWRT07UVoQQU2JpgJh55w6OGuSsCrQVFYsiuUYCixOFiJFwJisSBAgef8FXghkCNosBqvhsfhtch4vB6tk9oKubjlxIQ1iQz5mQVwS6Wq2PJoq0qwkTnEm8/YsjpkdvRi4NgEmsWt5g25KGrLk669yS3LoA83QmlSI94aj6zyDORVZkKfoUdetR21beXoHmlH93Ab6nurUVJfCBdHf6EKWlsiIvUyJPGZX5HDIJ4NU14qkuzJMDLQJlj1UJo1SHQkwVFfgArCMTjRg9yWEqoGlYeQWTm6+6UbpIKmG6gMQWYtZARvtToWL8dwcKDFWhpNUAjLqwoFlsijsEgRgZfiYvAKrd062ryYApNUCap+tF5agygbLoWFOUHcUWWrTIdKrLjz36mmxaoerUP9SDNcnVVSdWI9LVEe80rn0W60TLahY6ITBd0uBOoi4ea/EW60WD4qf2wJ24EATSC8Q7fBYzeVxd8Lbts2YJvcF0G6IKjSY5mtZAhNjIaSoT23LZ+AXJdWzoWFevrzD4RC7K36i3SJg7hqVOzJevztHOGYxePvbmP2/g3cuy9mqGYIx1XMErCbVIi7tFVikfHJ429w+9YNnP/6c8zMXOZrVzF98zIBufBsArKJgCwN4MgfmgS5NhfZhW0orRlkZzqKXob10YMnpeO3p//4Jd47cRynz5yWzq5HOyqwPsGCVTE6uMkJmNaIdTJ2eqrEIn8ZXtytxsKgeDwfpMPCEANeCNHj+WAdngvUYHFIPJaEarEoOE5qCwnSkjA1XiMoy6ksK/VmvGHKpMVyUEHysK3Ahf2ffI49J0+g/2A/GujLK9oKUdSajxijEgH04hH6aMRZ4qTcYCtKo7pkIjXPiMq2WkweP4SekR6MjA2gtZ82q6sWZW0uNA/Wo7C2ALtiQxCkCoWjNJMh3E5FSWQ+YWhuLkJVawniTXHIr8qFix9XDdTA2V/L31/M2mkRTaXIbRJbQvLgY9LBI16FHclxWKchHJGRbNH8vQQoMrwik2ENc9mLsnAsjA3HElWk1F6Lj0FMYRp6D1AdRAXb4TLp1GBRax4ikyJgYhZwUF1KussRT3D9OcpHJMfAVJ6OhgNNyG5iJhooQoU4HHW4Bc7ecpjKbAhn4PZR++EtuQ+2y3wQGBcIuTEKQfHB8KblEplkB8O53BQFVZpMuuHdUmpBHG1rMjNKRWclrjFciz1X4kzHz7/8KAVxEdD//ve/4sen4pz699L2kQePb+HeoxncY/Z4+PA+bs/ewK3bV9kuEZRrBERUoHosnV1/9OgBc4cAh++5NcXndb5v+tkERCjIK8wgXpFGaE0u5BS2o7C8F3WtB6giBwnK25LVmjj6Mcbf/pDtAwzx87CsEqxSJDJvJGGzzoJ1QgUiNHjJP4aKocJzBOP5UANbEhaEJeN5qSXiOcLyPGFZwNdEWxjKj4O1eCFIQ2j4/VSWZeokrKKKrCUc7lJwz0PRyBje/vwsjn58HC29VXAyd6QUJSMiRY6IJBlUBCUmUU4VUTEr5KGytRLV7dXYd/IoTl36GqcunsVHZz/B8MQg2kfaMHJokFbxHdR21UCWrEFYQgyVJBZ6WqqknBSk2FNR3JiPAdqZcoIittvUE4xM5g8Zc8i2ZDXzlhK+6XpECpvmykSQOBgl6sRrlXhdHo3FYaF4KSwMr4sKt1SNlyLDaLdCsTAqGItiI/AiIVmqjMDyuCgEmOOodCW0hgVUpHTp1GBxTwFkHNE1ebSRHBDEZsTQpCgEakMQbZYjvZE2a1TUUa9HI61lvag8dbAFNcO1KGBOictJRIA+BOGEYqcmgErhA72VVlFM4yr8sGa7B4L4dYUlEhn16WgmXOLihpy2HKTVZ0knCr+89Jm0fUTsvRIwiCau8RFrHaLClFgYFAuAYhr33r1Z3L839+uU7h1mDkLzkEF9bpqWa05agf/m8QPcuUt1obLMQ3SDz2nJej2zgAiLJQBRJRUjNaMWeaXdqGrai4b2A+gYOMLR9x10DU6ij7lkz8H30Tk8id1mB1bLE7FWnUI4DFgdpsHKEKoD4Xg+OEEC47mwFEKRigXhRkKSyo/F57+1eWgWCIBCE/ECYXkxRId/CuRoS9he15qwgpCsszmwKasAfnYnUlp7sP/UKckuFdTkwFhAW0VLpWXQ1mXokEblECvchpwkKoMTru42WPoGoe0ZQOqBMRQfOiKp0PiZj1B59Ai6P/09jp39lIrUDF0mwaDlyq3iaFxpR0p+CnNKDkaOdGL0EIE63IwaQhJbZIF/mqi7qMSmBCU2J8djq0kPv7REbEmJw9oEhm+Diuqixptq2qiwYKwiDO5x0bSShEUWilf4XKaKZmCPxAqqxxsJMvhbtcjvzkfpsBOO5hzmETscnWINxI609iyUD1SjZrASKcUpSKvNQDa/XrKvDEXitvZ+0ZjJWouQ4KQtpOVKLLYgwqJAcEoEQlOjsEO5C1tjfGihFJAnRyEsLhi75H4I1vpDl6uUzozUTzbB2pIDW3M2UmrSqUBK/PHcHxjKv/v1Urj5UgfiTMg/fvkJf6OKiOq0jx49lK4hnb09Q/s0I+3SnZubxUMxzftwlgBM8eP5Mm1352YYyi/j6vVzuHZNzG59hRtTlxnmbz/bgHiG0ItrKLHZDXBWD6O65QCqmvehqeugFNpbeg6hre8IBvefRGPvBPxSc7EyIh4rOeqvCFJiRWgcloVosWC3VursC8OT8SJzzX/WXhCQ/BsotGFUkhcJ2zJVMtyM2XjDkov1mfl4k5brLaqJtXcI3WN7mDuykUy7UdxcKO2dijEq0N7XhMG9PRzp25DV3oZYZxW2ZzuxxVYIr1wntuU4kVDVhPT2XvgWV2BbSSVS9+7HyKmTGJoYRe9YL3rGetCzR0xnN6KP6nH45BDG6e0PvNMm3YoewqAurJRXkrhNUtwFpsZ6A1VDL6r9EppkFXalaakoaVDaDXiD9u13BCTUZmATx5Aj4cH3eSRpCEYsVmlj4Eb18k2PR05zHspHyuFozYWpIh1J+SbYm0XxzlKU9pahvLdCugyueKCENqwSjn4nbHyv2M7u7CuHhRnKTx+KGAb6KIsKusIk/h90CE6MpJ3ykjYjekf4IoQKtFO2k4DsRJhuN9S2WBQMlSCxwgxLmw2pVWlQ2/UM7hp8fu4zKZSLLSPi4rjfbmz/+eef8f1fvmfemAdDzExdufQV7dQN3Jm9iZsz16VS43fnbks2SkzjTjGIz0wzb1y7gIsXv8ClS+f4PIfpG1cxd/fWswvIS8wgbn7x2C1n2E2ngpT0oLBigCqyT2pldUMEZh8qG0cJySScdYPYojbjVQbwV3bJsNg3BkuYLRZSOV6ghXqRVmoxAfmvtkUCprAkwkILxpzyQpCawTYBqw1iZisX7gzua8zZ2GjNg7qhHZNnzqB7lEG0xoHC+nyqCLMHbVHfSBf2H9qLjn2j0FU3Y3uWE57GHLxpyIBXegE8UrLxliWPauTCptxiuIuFyaIyZBw4iNHf/x5dJ9/FgTMf4rPLX+LEx4ex90gH3vlwDw6d6MP48U6U95UhIEMLH3MC3jLq4E61WBOnkO68ctfJmT0UCM2IQwgVLa4kDSZCsj1RhvXxclhqnNLaRGC6Dll1VILyIoTnmOBlEoDJsI0WMZHfU9lThcruUtQw61S0VaN5uJEWqgZW5o3cujzUHqhHsbjYeqgKhcOiqE4JikdcqGRwD01RwCtmh3SEN7XSiqRSM5IrLQgzybHebwtWeq9jMN+Mt8K3wTd2J/yV/ohMDEOshdaSdjWt1ipdRFcyUsbvT0dUkgKff/1HyVbN1/94Kp3vEPupxLU/QilmGbgvnj+Lr859jgvnv2SemJJmrq5eJQwz16TdulNUiMuXzvJ5XgruMzMM5jNicfCqtKIuABF7s55JQERIXxKow2p/LQJiMqBLrWBQ74LN0YrM/GYUlPehpmVM2oZSVNEvwZKcVQX3SB2WEY6FPjI8v0tJ5dD9CkfSfwDgv9oW8nsX8Gf8E23aUqFMtG9uScwi6Xa8aRHrIw7oabP2nPkMRz56H4099ciiksiYO7LKMglNB4bfPgjXyD4E5VfAw2yHh4k5JjkLXtZCeBIQT1Mu1lj482z52OAoxRqq0zZXDYJrmxHe3oWMQxM4fuUibj+YwYkzB3Hk1BAmTvTi+Cf70XqgBX5mNbYkChulxhpRqVanwhsadkDmCD/mod1mlXSVjyw/CSkVaUh0mpFSloOKwXak1+Ui2qZn7qmF1ZWLpBIrouyiuFAs/NM1SBNXfnaXoW2sBb3jHXxfnbSRsnlfI6oJhCjzXDJUKsEhSkBndziQ1mzjMx+F7eXYLg/E9thdkGeqoMlPhixbh/QaG3yVAVi7azM8g7ywMcQbO+W7EJYYwnAeDa1NhWhaLpsrHTX769F7rBelIxXQu1IRzb/rWY70Yq/Vb/XMxcZDsQYiVsQFCKKDn//qM1y98jWmCYKYoRId/jKV4cbUFSrJPDDCRon3zMxcxJ2561SW+dX1q1fOSwr05PH/wYGp/277TUEWE5CVBGRXjBVKvRNGWwMMliqk5TYiS4T2yiHkOruRbm+EKasGCmMRlgepsMRPgQX+atoiKgdzxP8EDtGEkkgqEqTFwgAl/bsGr2lSsDo1k506B2vT7FiXRhthL0Hn2+/ik6++xOj776KwwYnW0WaMHT/InNKO7Xzd31GGrTml2JZdih1Zpdhqo9WiimzOoN3KKcFGvmd9Xgk2FVViE58e+aXYVdeM4JZ2ZI6N4+zcHVybvYCJUwOY+KAfJz6ZQPd4O0KsSngnxmIdlWOVkvZIFYvVymi4KcKx0yiHIi8BNo7eRqqHotyMKnboigHaI7FHjLmpargGfcf6pLLOansqm7hYLgWBBE+Rk4B6WrvqvVQPWi0nM0V1f/l8Bah9NRzdXTBUmLBDHYotkQHYEOoLGcFSZRukQK3MUEs3tccxgyU50xGUGC2dNfeK2YlV2zwIx1ZEpUZAJW4tSQ5HPN9vdCRCk6mRoBh6fxTtkx3QFaUiwBANpVmLK1OXpNrmv/zyi2Sr/vGPn6XNhvfu3WHumGPInsHNW9elnCG2jAirJCARYDzk6+J9d/ieC19/QQt2DnfvTeHBoxnM3hGLgxdou+bzx5PHz+JerF8BeXF3Al4nJJtCkuEbZkSIPJOB3YV4YwVSMuqQbK1CckY11ElFiIjLgrfMiEX+KiwO0nHE1/+vwPFbm1cRPV4Mjuf/S4nFkfFYqmEeSc3CyqR0uKVYscXqgGv/YYx9+gVtxl4MHB5D955uDEwegrqmBevTHbRmdsJQhA1mKkVqHjbz+ZatGBtsRdhMi7XdWUOLVYyNjnJsyS+Dt8grFXUSIMqBQTSc/hjTf3qIL698gpN/PIzaVifKG4uQTlXYYYjAWobs5QzcK2OjsDwmFOs1ETAwIFeKEb6/CGlVZpgJSFl/IRqlWoEuVPSWo+doH2rf4WBTZUMsc1MaO7ZV3NruTCVUqVIlWnEbYuuhVobyJmYssR5iQV57PnIac9lp1VhHu7Tcey07/XpsCPJGFMEUxTyb9jcipy4ffnGR2MUQvjnSV1op9wz2xlo/L7jv3oqdCn/IGNrlqTGITI6GyqJGgkMPa18uGifa0bC/CckFJsSKNaWMBFy8ekFSjKdPf5JslmjinMedO7PSdK3YgDh7hx1+9gYBuUY4pqgIzCF3p/Gv332Dew9u49rVr/DF5x/Tgn2BuXu3MHd/hiH+phToZ2/flOD48a8/PJuAbEl1YmGQAUsCtFjNLLI1LAU7w80M7HmIYFMlOqEwFCFGl4dARQY2sxO/Fqhl59VK6xsLCcei/yU4RBM/SwC3MCQBi4M1eDVah+VxqVgWb8Sa5Ex40GqtBbYlDQAAAy5JREFUTbFha4YD4WX1sI+Oof/YCVQMj8LRPQxNdSu8RfagvdpsIRwpzDBJ2dhiKcDWTCe22svgaS2iIuXBI6sImworsZGAbCxwwbeqHtFdfVAPjSLnnXdw9OplPP72CT796iSKK3Nhs5tQ110BRXYcPDWhBCQYv5OHYq0yFL7iBvZyi7RZsmqPE0Xd+ajqK5UUoLLfxfxSjA52vv0fjKOo3YV0VwYSsvXwU+5mUA6HtcqKOoLUMtGIMn5fVX8laobqUNhdQoWIIzzpUlFP0Wn91UHYETt/tkNl1aBpqBE9x/vRNNGBxGIrvKOZLzQhcA/0gpvPBmwI9pIOeokV9O1Uk8ikKMQxK8nSFYhJiUZcuhJJDOUFzcVIdVoRn6mVdiCkUuHO0wKJGSyRO4TVEnuwxOnCb74RF1kTkIdzhEWEcmG3xJ4qYbOmCcJNPH5yF/cJyJUrZ3H27GmG8i8I0oykOmI268GDu3j0UFSp+kZaZX82ATFSQYINWBSYgGW0WW9STbwJSbA6B76RZuyKNsMn0oQt7Lzu7LivMWssCeYI/6tqCFv07zv5/6QJQAR0Cxj4FwSopZX4ReG0WswjK7RmvKFPx+/4XKsXl2DbEE4lKB4Zg4ywxJQ2wNvswBqDDesSacsSbPBIzMG6hExsMOZhE4HxZHPnx+4mO7zzCIbDRUBc8KttQXBrJ2Q9A1D2DyJ5dC+cx47i6wf3MT13DZ3D9XA1ONDUX40MWih/s0yq5eFniEEQ7UggO7mx1IjirnxUDpaiuMWJzpFWlLe5UNpbhKKuAthb7Sjha6JOuSiPFp+tRZg2kmE4GvpcLdWmWLrjqoxwVA/UoulAK2ppr4r6SpDbVgBHRyGKO0rQsqeFnbkAsRkaWCttBK8VHW/3Ir+rHCW9VUgoSoHMopC2jfgo/OCn9icwwXQIW+GnCoDSGstwHoEAqoxYiDQyL6UViTMladIZEEtZBio6ylDZVoVrVAVpW8mPP84vEP70FN9+JwL6PXb2W9ICn1COa1cuUCkuSbnjzuw8AHf4d5u9M4XzX5/FxYtf4zzD/PXrV6Tvm6P1miVYYm1k/rb4+/j/ZHsZSYtds3gAAAAASUVORK5CYII=' width='200' height='133' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=b46d3fe7378d4873b901ec035623089e' target='_blank'><b>MusselFarms</b>\n",
+       "                        </a>\n",
+       "                        <br/>Feature layer with bounding boxes around mussel farms.<img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">Service Definition by api_data_owner\n",
+       "                        <br/>Last Modified: December 16, 2021\n",
+       "                        <br/>0 comments, 1 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"MusselFarms\" type:Service Definition owner:api_data_owner>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "content_last_modified = gis.content.advanced_search(\n",
+    "    query=qe, max_items=max_items, sort_field=\"modified\", sort_order=\"desc\")\n",
+    "\n",
+    "for item in content_last_modified['results']:\n",
+    "    display(item)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "031b88bf",
+   "metadata": {},
+   "source": [
+    "Here we return the first 3 items that the user created by setting sort_field=\"created\" and sort_order=\"asc\":"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ff4dc727",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=43ff80a8e6c64b0bb83231b32e562fca' target='_blank'>\n",
+       "                        <img src='data:image/png;base64,/9j/4AAQSkZJRgABAQEAAAAAAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCACFAMgDAREAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD1t7WZpGO0Bs5wJWHeougLG2d5BG4C/Qk8VrSUVeUuhjVbdox6jJ4hE+Ac11UqnOjkq0+RkVbGQUAFADJPur/vr/MUpbAT1BmFABQBl67K8enuE2ltpOG6HAzj8s1lXdoM6MNFOornmkV/LDepcyQLIU5VWQY5OcdOO9eafQOmnHlTNr7MuoQLJdRWtu1wgmjdpCCudp45JPXFM5ub2btFt20/MpQ6q9pp09jHIUtpJi5ZeCSVAIPtx1ouaSoqU1NrVIz9kcc7r5rKkmVOARznpSNrtrbY7Twg9pHeXUFtNuBiQlf9oZ3fzFdmFe6PIx6m1GUl3OurrPNCgCWEj7LEB1z/AFrz5/Ez2KfwL0HXkMksJ2TPGVyTt/i46UiyEWl6emovtOf+Wa9McfrzQBPEjxFVeVpSXzkgDA9OKAJIh++nAGAGB/EiqlsiI7seR0zUFkUowDt+8aQDJptuQgweme9bUIKctehhXqOEdOotmxIkBJNa4lJWsZ4Zt3uOmRHBLEg+tY0qkovQ1qwjJakEdsZFJDDg4rrnX5XZo5oUOZXTInXY2M5+laQmpq6MpwcHZjasgZJ91f8AfX+YpS2AnqDMKAGSSxxIWkdVUDJJOKLjSb0Rxms+KLF53EZW4j2mPAJGc9f8K4a9VSdkerhsHUSu9GcrrNxFLJHcqSUdMhOhjGTwfX9K5melQi0nFmpHrEN3pElpbWDJcNEiJJ5mfu4HT8DTuYOi4VFOUtNfxMnhrWIcee5G9QS2R/jn3pHR9p9iS1tkmnnLOIhEpOWyMtt46j1xQKcmkutzT8L3H2fxTChkDmVWUkHjkZ/pW+HdpnLjoc1Bu2x6XXoHghQA+xUlMkewrz5r3mexTfuL0LjcHpxUlkCGUb4wgAQ/Kc9RTARDcM5yI9w6daNALajCEnHX+tNiQ1jkZqRlWS9tYp/LkmRXHOCaLAV3be2a9KnTUFY8ypUc3ctWnyxlveubEv3kdOF+Fj2hDP8AMcqTxWcanIvdNJU1J+8PwsYwBgewrOUm3dmiioqyM0ALGihSuB0Nd2HXunFiX74Vuc4yT7q/76/zFKWwE9QZhQB5z4xmZrryrh3aBG+ZB0Ppz+Dda4MRJ81j28uiuXmjuc0lzAiSwQlwpfcJCT0AP8PTJrnPScJO0mV/MjYNkkgHjJ5Oc84pFWZd07U/sVwbxbfe0ZJx2AII/rTuZ1aXOuS+5HuNwkko2YRAzYIGB06UD+FpDGu3jRtjEKxzlTnOf/rUDUE3qaOnSCK+s7xIpZI0bcxRDhT3/Crpvlkmc9eLlCUOp6vb3MN1CksUisrjIwa9NNPVHzkouLsyWmSFgm4BiT8p/rWVaXLG3c7aEeaV30L2MnpXEdw2M/NIfwpgRwuXYMRjcM0uoFhTwVpiQhHFIZF5aO53xoW9SM8UAUgCxwBk16raSuzyUm3ZFm1OC0betcuISklJHVh3ytxY83aiJnWNmVWxnpx3Ncp1krNuXPrSAy0OUWvRor3EedXfvsdWpkMk+6v++v8AMUpbAT1BmQ3U/wBniLhSx9B2Hc0N2Kirs8n8U6h9s1icR4EUZ2ZH8RxjJH4H868ytLmmz6TA0uSkr7sw492TtZQADyeMisjsZFk7zk4B7mgo7zTPC2mL4UbVNSumj8wb0df+WagkAY7k1VtDyauLqe39nTRxI8pLm5QMWiXJRgMZ9Mg1J6mrin1JldfKMUgUKBvQgA5bA4z6Yz+NBDTvdFuy1N7ExvGynYd4iIIByCOT+R/GnczqUlO6Z3Xg+e3bQXNy6syHKkN+8554rSE5LY8jHU37X3UdVbsz26M4IYjnNekr21PMlvoRWmowwCRHWT5Tg4Qnv/8AXrGv7y9Dvw6a36lyPUoGkVAJCznA+Q1y2OssxLiLcf4iTQBW81be0WeTKxoOT14pPcAGq2W9MXCndwOvNOwiT7fbSkpDKHfoAKGhliKPYo3H5j1NAENvGFj3DktW1eo2+U56FNJcw14wEWPcQ0rHoO3es5S5reRpCPLckK7UYei96zLIoSdphkfc6nnr0PSmwIpohG3HQ9BXdQndWOHEQs+buRV0HOMk+6v++v8AMUpbAFzdR2yFnzwM8Dp9fSs20ldkxi5OyMbWZFax4vhDLJlQyvjJxkDI+nauOpWb0idmHp+9rG553daclvqHlXUhiDkAyqwPzBQTz+I/WsNG9T2IVJezvBX8inqOnPZXJjB8yJvuyAdfalKPKzajXVSN9n2I9Nlso9ShOpwvJZqcuq/ePt1qEaVVNwfs3qamtaxa6nBY2OnNLFaQxDMUnyqHA6jn0/zzTbOehQlTcp1NW2YcDPHKXjUBs9wG7DsaR1ySasy+EguoWnn2W4jiP+rQkM/Vcjtn+lMxvKL5Y66/gNgs5rieJFKrlFKlsAEHr14oHKaim2d/4Y8PXdvumvZnIfkqrnDc559a7KNBp3keJjMVCfuwR2HQYrrPMIbckKpHXP8AWm/h1No35lY1JDtjcjqFJFeaeqIAFQKM8DApMQyFWSPa7Bjjnjg0DJAilvux8d9opgSKqKwbaox0wKAGnggnpSAq20oCFSeQeK6sRBt3Rx4eatZlhIw0wmJPC7Qp7VzPTQ6hH+Zm/KpGNePgvGAHPUnvxWkOW/vEz5re6UWJZiWPNejFJLQ82TbfvbiVRIyT7q/76/zFKWwD5SExIei/e+lQQuxy/jG7uLSwgeKJPKWXeN46NjHTPQ7j+dcWJhb3kejl8Yzm030OGvb59Wuje3VvGu5sNGmVGQAPrXLuexTpqlHkixkWoz21tHGjk+WxZt6AjkDv1qlNpWFKhCcm2jPuULT+YBhXO7BOefepdnsbU21GzCK3lklWBIzucjanuaEm3YcpxScm9jRtNFmF1MYpUlNu4EiqD+h7jtmr9m9bdDCeJjyrmVr7HUaFpy3UNyk0UTIyMu125DE4GcdcYPp1q6VLnPPxVdwa5XqVh4WuZvEyWNzP/o6oJdwH3gOMCrVD37PYp46Koc0VrsejqoRQqjAAwBXceILQBHboREr4+Xd/WjmXw9ToUXpLoaUp/dOfVa849IgdmGVrJtiuSqSSeKsY58bPqaYxyPhcnoKpakvQas6TZQZ45rSdKUVdkQrRk7Ip2wzN+FdOI+A48P8AGW1PzFTwRXnnoCMyKdrOoJ5wT1p2APOjG4+YmAOeRQBWli3EuhBHUjNdVGtb3ZHLWo396JBXYcYyT7q/76/zFKWwE5GRg9KgzMHxJorarpvkI+1kO6NjztPofasqtPnjY68JiPY1OZnl9zFf2WbG4t2EvmEjC4yTxx2I4rzpRcXZn0UJU6nvxeho3umyQ6CqAoWkKTygOCVGCOg+opW0MadVSq39UZN5cvMqmZxIN2Rx3wB/ICkdEIJbHZ+Hj5vhq/LQj7Vax/upCOSu3K5+ldtL3oN9UePi4qNeNno9zlNJa9jkuJYIZJISCsrYwADnjPviuWMnG9j1K8acklJ69DT8NpMUurm4lcRwE74lbacnjt7kURk0c+LjFtRitWdR4e1a8vtYurMS/u7cELvG44Bx1rroVJTbTPOxVCFOnGXc6nfcp96JXH+w2D+R/wAa6dTgtF9QF3Hu2uHjb0dSB+fT9aLhyPpqXLUSfZoyoAC5OT3rhqP3mz1KStBEjOxRlcDJXIIqSxzouASOTUtBYVR87UDJguV5HeqAiJA4x9aL2DcpkNBKGXp2Nd8ZRqxsedKMqU7oW1YLOM9+KWIV4BQdplxxtye5Feed5WurOO5+Zo1dgDtLdquNuoO/Qyms5grIYbMBlwcqeuK2VBvVMxdeK0ZchSOCN0jQLv5JHeto0EmmYSruSaCug5xkn3V/31/mKUtgJ6gzCgCje6Ta32PNjUkdMjOKmUFLc1hVnD4WZGqeGmuYpGiaNm2kKu0qR6gdeDnpWNShzbHTQxfI9TzGayZLuSHHktHncshJIrgaadmfQxqJxUt7lu31e80zT7qytpI9spw7r3HtVxqOMXFGM8NCrUjOXQqx6ncfZ2tDkwnGRjjjP+JqLmzpRvzdSa21GWzhu4UXmfAJxkjBoJlSU2m+h33gWyiFnNqCyb3nYjk5I9c/Wu7DRSjzHh5jUbmqb6HXV0nnBQBZtuLOP6V58/iZ7FP4F6D34jGB14pIsl3BgAyDP5UAA2gkhefc0ADEnJzk0ARuBg8c4NIBkwUQkEdq1o351YyrW5Hcq2+PPTPrXZWdoM4aKvNFuZwz7e1ebvoejtqTAgqMelMCIjLAEAg9eKE2noNpPcrXPDhR0FdWGbbdzkxKSSsQV2HIMk+6v++v8xSlsBPUGYUAFABQBzHinwnHrSG5ttsV6q4zjhx6GsK1FT1W534PGug+WWsTyu6hktZJLa4jaOWM7GRuoNee007M+jpyU0pRd0ySMM0SIQpXr8vJPTrSE3rcjl+VeMru6cEZHSgaPVvAlsbfwxES27zXZwfbp/SvRw6tTR83mM+bEPyOlrc4QoAda3Ci2AYfdB/HFctWk17yPSo1U0osh/tuzkiRwZNrcnMZ4xg/17VjY6SddVtJJI4o5CXc/Kuw/wCHHQ0gLp6UgF9aYETSAFs8AdaIpydkTKSirspySl+O1d9KkoLzPPq1XP0EifZIGPSqqR5otE05cskx0z72+WsaFJx96RvXq83uxJYJ+iEfQ1NejvNDoVtoMmJcABQCR6mueHK37x0yckvdKkzMWG4YNdtCEVdxdzirzk7KSsRVuYDJPur/AL6/zFKWwE9QZhQBXvLuO0gaSRgoAySecClKSirsuEHN2RFpmpQapaC4t33pnGcY/SlGSkroqrSlSlyy3LtUZHm/jrTY7jURcxyRo5jct7hQP1ycV5+Js5nu5ZVcYOL2ONVm8piRtJfGQDg4HrXOeq0rku1BciIzNKu3amOmT0/nTJu+W9rHtOlWq2WlW1uvRIx+derBcsUj5OrNzm5PqXKozCgBtl8ybfqR+dY4iPuqR24eXvcpeEYddpUYIxxXGjuGRuGVS6gNkrn3FNgTkcUgDuRQBVuRjcfXH+f1rfD/ABmGJ+Aq9a7zzxyLuPsOSfQVE5qEbl04OcrEqX1ksRKPn/gJ9PpXnSqOWrZ3xhGK0KqTxu42Nk9ehrvjUhL3bnDKEo+8a8bq0SyetcE48smjvhLmimVp5o/NC7QcYzV0oTk/dJqThFe8V5CjPlF2j0rugpJe8zgm4t+6iGT7q/76/wAxVS2JJ6gzKWoatZabGWubhEbGQpPJ/CplOMd2a06M6jtFXPOde8Ry6rN5UGVhkGFz1I9/T6f41wVq3O7LY9zC4RUlzS3LvhDUJrQyQIWwrbZUfjbkEhvphaKNVw0MsfRU7SOkkv7ibU7e3MRZJV3MCOQobHGPwrWdZ2VupwRoxUZNvY5DxG4OqFN4CeSQRnjru/nisKvxs9PBK1K/mYWqqXOTIhgZjtKtjnAJ/mKyZ3UXb1IILTEkJnDIrKSrg9gM59+KaKlPR8p7Lp1rD9jt5I555FKKQxncg8ehNerFK1z5WpOXM00vuRoVRiFAEdq21VZTnBOfzqOaM04HUoSg1M0o3UNwwwa4LNOzPQTurkYKjfGWHDZHPqc02MmJBGc0gEbqTihgVrggofqP61vhvjOfE/AQQuEmVmGQDXZUTlFpHHTkoyTZeijEceB17+9cFSo5u5304KCsVzZqTkzTY5GN3FZl2IXtTAc+YWyOhPSuyjJOWhyVotR1G5OMZOK6HFPdHMpNbMSmklsJtvcKYDJPur/vr/MUpbAT1Bmcl4t0JbiGW/iDmcAHA5zjt9OK569JSV+p6GCxLhJQezOKubh3tYbWW0jja2LAOBhju555rgZ7MIpSck9yLSbme21GNpHwrODIQm/j6DmhFVoxlDQ6LTNW1Zr5pbfy5YIi0SSyIVDKcHGOSD3rSLcrI4K1GlGPvbvWxR1aCWS+kluHh80KVHksSGwMnt1zxUyd3dm2HajBKO3mUrDSv7elWL7QkMmJJSdm4hQQAO3PBNTa5vUrewV7XWiK2raP/Zcz2huBI0bFASu3OKGi6Nf2i57Ha+E/EKxWFpZXpCs6kRNnrgkYrtoVlZRZ4+Nwr55ThsdoDkZHSuo8sKAIo7S2MIZ1Ys/Jwx7HP4Vwyu52Xc9eDSppvsJa6dbFySrEDBALH/Patq8VCKsY0Jym3c0Ejjd3YIu3oOK5jqBooRgFQCfbFK4A8QydjFW6cHNMDMUzm42SuwRT949DwfyrWnNQdzKrT542LJgcDOM/SuuNaD6nFKhNdDQc/NXnHojJQBH780mBTnz5gz6CvQw9uTQ4MRfn1Iq3MAoAKAGSfdX/AH1/mKUtgJ6gzGuiyIyMAQRgg0DTseXeKNOaz1A7TlHIwCen+en4V5taHLM+hwVbnp67ou+Druzsbi4+0AmadVWLAzk8jHt1rNEY2E5pcuyJ9Mur2exe3UP+63XR6fOoOCPwFVB2dzOvTgnfvoZfiKU22rR+d5qEqoyp3Fex9u3aidk9DfBrmpaGXa301pctPaxyRSpGVdhk72Yk5Ofb+VQdM6cZxtJ3Q26up7yOO8vlV2digYgLzkk5x7n9aBwhGDcIEElzJFJbqpjzD/qzGAcc55I6/jQm07lciknfqelWOpzXNlBdrKyrDEhdB91vm2tn8OldvtX7rR89UoqEpQa7nTV1HENT/Ur/ALv9a5Kf8Y9Kf8D7h0SlmwOh6/StsTJKNjLDRblcug7WQdjxiuI7hzjdjI4HNAEbSABcjqcD60ANm2MjRtjJHpQBEHMBCjlOAR74oAtbgMlug70IREsyTfcYMB1xQ0wK87Zf6V34eNoHBiJJzsRVuYDsDZn864K1WpTnbodVOnCcRtdkG3FNnPJJOyGSfdX/AH1/mKqWxJPUGYUAebeOwYtYicFuUOcg4HJIx+dcOKXvJnu5Y702jI02IQ3EEk0whCSK24qWZhk5wPwrmR11XdNJXOi8OahFBq7wyxHE0TRyHpsGTyRj0FNHHiqblTunsR6xMZbiJLVVjZIh5++LncCCduev3T+dW/eQqEeW7ls3pr+ZVi8KHVtNudZs5QZGdtkWMDAODkD25xUWNnjPZTVGSMOBZTdCO4hYW4YhsDq2Djk8d+1I6pNct4vUjxE00jXMaRkkMqJ6+gGOlBWtlynonhXSDFpitcA4L7gmeDjpkV3UKS5bs8HG1+ao+U6iuk4Bq/8AHun0/rXLS/jfeejU/gL5Fm06MfYUsR8ZeG+AscHkc+hrA3Bj64/CmA3ZlgT26UgGy8EEYznHJpCImchyrLtbsw7UXAtFAylT0NUBXit4LUsIkCDqcDFF7gVzDJuPy/rXfGrBK1zz5Uqjd7DWRkOGGK0jJS1RnKEouzG9sVNSlGp8Q4VJQ2AcCrSsrEPUZJ91f99f5iiWwE9QZhQBxfjZ0SwEMzKJpJs7m6bcHGK4sSne7PUy34212OJ0q3aS7jjJA+bgn9P8+tcqPYrStFskupTJfPJDvi3k8FzlvrigUFaNnqbniG1lFtA9y32W5EAIjRsBdjYA+91wR6nimzkw0k21HVX/ADNfwbqX2x0hWQpcrkMfLO2VexJ6ZzmtI2l6mOKw6T12f4Gb4q0tV1Ke4t5GjbZv8qP5gWD7WH65/OokjbC1Go8kten4XRg2iyRyBxayTxRE+aSmSo6/h/8AWqTqnZq17Nnq2kSrNpUDKhTC7Cp6gjg/qK9Wm04po+ZqxcZtMu1RmRQZdUXPU4/Ws4Q5LzZ1ynz8sEaESKA47fd/z+tccpOTuzujFRVkUv7JsY3TbEw+bjEjcd/WpuUSx6dZ27oUjIZSSpLseenc0NiLavtlx2PH40XAqXySzzCP7KZIgMhlk2knoR+tAihPakTF2t5PnBOGl6ZB/wAcUDNt5AFAUglvegBoXC5Yg5I49qAFYZ4HShgMCBuGAP1pxm47MmUYy3KtxGEk4xz29K7qE3KOpxV4KMtCMAkZArWUlHcyjFy2GTAgAHrvX+YoburoTTWjJqkyCgDh/Gsd0t1BMDmJGDrjtjAxjvXHik7p9D1sucLNdTG0iJdZ8TIo2WZlRiPLBCoQvUe/Fcq1Z6Eo8lK17m7D8OIWYkaoruGJAAzx7+/Wq5CXiX2NabwxPLcwtcgXjiUtJIcKCpXBwCeo6/gKdjmi+VtR0VjY0vQLHSYZEtY8ysxcO2M9uPpx+tXTspCrOU4mT47iebR0eHna+XGOoI2/oSD+FTUi0XQnG6ucQdLuhNC1m+Z5YWlkiLYA2kjPT2rKxuq0bPn2TNrwn4l8syWGpSKuPmikPAPqP8+9dlCt9mRw43B2tOkvU7aKaOeMSRSK6HoynIrrTueU007MdYMqld3vj86ism4aHTQcVPUuJuAJGD8x4rgPRHgZGT+FAhCAxwelIBqRbX+Zi3cZoESFmMh2gAKOp70wKN7cEuqKDu/SkxosLZ28qgtEPpk1cvddiYu6uPa0gOV8vjGOCf8APelcY/AVQB0AxSGJIdkZbGSBQBnEljknJ9a9SCtFJHlzbcm2W7NQUc1y4p6pHVhVo2Vr4jzFGMEFST68iig3rqLEpW2FroOAKAM/WrRLzTJlfGVUkEjNRUipRszahUcJpo5XwhpUEuvsXAPkIWxjhtwIx+Gf0rzkrM9yc24ep6FFZW1uwaKFVYDGQOaq5gWR99frQgGEYNADhiRBuVWyO4zVCOP8Wxx2mlh4I1SR7jYXAyQNpPGen4VEtjSmrvU47S7KOLVLa6fEoyWMbqCCAOlSl1NqtR8lkem21vALJJbaCO3DLv2xqAPxx1renNxehxV6SmtdxLEeaseeM5NdspcsLnBCN5qJpR/xf7xrzz0yQKOnrzQAbRnHpzQAY6445oERnjIpAQW8YKGfPznj6c0Af//Z' width='200' height='133' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=43ff80a8e6c64b0bb83231b32e562fca' target='_blank'><b>Seattle Bike Routes</b>\n",
+       "                        </a>\n",
+       "                        <br/>Designate Bike Routes for Commuting Professionals<img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">Service Definition by api_data_owner\n",
+       "                        <br/>Last Modified: April 23, 2019\n",
+       "                        <br/>0 comments, 1 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"Seattle Bike Routes\" type:Service Definition owner:api_data_owner>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=718e55ece43846659f5e50969a4c67fd' target='_blank'>\n",
+       "                        <img src='data:image/png;base64,/9j/4AAQSkZJRgABAQEAAAAAAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCACFAMgDAREAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD1t7WZpGO0Bs5wJWHeougLG2d5BG4C/Qk8VrSUVeUuhjVbdox6jJ4hE+Ac11UqnOjkq0+RkVbGQUAFADJPur/vr/MUpbAT1BmFABQBl67K8enuE2ltpOG6HAzj8s1lXdoM6MNFOornmkV/LDepcyQLIU5VWQY5OcdOO9eafQOmnHlTNr7MuoQLJdRWtu1wgmjdpCCudp45JPXFM5ub2btFt20/MpQ6q9pp09jHIUtpJi5ZeCSVAIPtx1ouaSoqU1NrVIz9kcc7r5rKkmVOARznpSNrtrbY7Twg9pHeXUFtNuBiQlf9oZ3fzFdmFe6PIx6m1GUl3OurrPNCgCWEj7LEB1z/AFrz5/Ez2KfwL0HXkMksJ2TPGVyTt/i46UiyEWl6emovtOf+Wa9McfrzQBPEjxFVeVpSXzkgDA9OKAJIh++nAGAGB/EiqlsiI7seR0zUFkUowDt+8aQDJptuQgweme9bUIKctehhXqOEdOotmxIkBJNa4lJWsZ4Zt3uOmRHBLEg+tY0qkovQ1qwjJakEdsZFJDDg4rrnX5XZo5oUOZXTInXY2M5+laQmpq6MpwcHZjasgZJ91f8AfX+YpS2AnqDMKAGSSxxIWkdVUDJJOKLjSb0Rxms+KLF53EZW4j2mPAJGc9f8K4a9VSdkerhsHUSu9GcrrNxFLJHcqSUdMhOhjGTwfX9K5melQi0nFmpHrEN3pElpbWDJcNEiJJ5mfu4HT8DTuYOi4VFOUtNfxMnhrWIcee5G9QS2R/jn3pHR9p9iS1tkmnnLOIhEpOWyMtt46j1xQKcmkutzT8L3H2fxTChkDmVWUkHjkZ/pW+HdpnLjoc1Bu2x6XXoHghQA+xUlMkewrz5r3mexTfuL0LjcHpxUlkCGUb4wgAQ/Kc9RTARDcM5yI9w6daNALajCEnHX+tNiQ1jkZqRlWS9tYp/LkmRXHOCaLAV3be2a9KnTUFY8ypUc3ctWnyxlveubEv3kdOF+Fj2hDP8AMcqTxWcanIvdNJU1J+8PwsYwBgewrOUm3dmiioqyM0ALGihSuB0Nd2HXunFiX74Vuc4yT7q/76/zFKWwE9QZhQB5z4xmZrryrh3aBG+ZB0Ppz+Dda4MRJ81j28uiuXmjuc0lzAiSwQlwpfcJCT0AP8PTJrnPScJO0mV/MjYNkkgHjJ5Oc84pFWZd07U/sVwbxbfe0ZJx2AII/rTuZ1aXOuS+5HuNwkko2YRAzYIGB06UD+FpDGu3jRtjEKxzlTnOf/rUDUE3qaOnSCK+s7xIpZI0bcxRDhT3/Crpvlkmc9eLlCUOp6vb3MN1CksUisrjIwa9NNPVHzkouLsyWmSFgm4BiT8p/rWVaXLG3c7aEeaV30L2MnpXEdw2M/NIfwpgRwuXYMRjcM0uoFhTwVpiQhHFIZF5aO53xoW9SM8UAUgCxwBk16raSuzyUm3ZFm1OC0betcuISklJHVh3ytxY83aiJnWNmVWxnpx3Ncp1krNuXPrSAy0OUWvRor3EedXfvsdWpkMk+6v++v8AMUpbAT1BmQ3U/wBniLhSx9B2Hc0N2Kirs8n8U6h9s1icR4EUZ2ZH8RxjJH4H868ytLmmz6TA0uSkr7sw492TtZQADyeMisjsZFk7zk4B7mgo7zTPC2mL4UbVNSumj8wb0df+WagkAY7k1VtDyauLqe39nTRxI8pLm5QMWiXJRgMZ9Mg1J6mrin1JldfKMUgUKBvQgA5bA4z6Yz+NBDTvdFuy1N7ExvGynYd4iIIByCOT+R/GnczqUlO6Z3Xg+e3bQXNy6syHKkN+8554rSE5LY8jHU37X3UdVbsz26M4IYjnNekr21PMlvoRWmowwCRHWT5Tg4Qnv/8AXrGv7y9Dvw6a36lyPUoGkVAJCznA+Q1y2OssxLiLcf4iTQBW81be0WeTKxoOT14pPcAGq2W9MXCndwOvNOwiT7fbSkpDKHfoAKGhliKPYo3H5j1NAENvGFj3DktW1eo2+U56FNJcw14wEWPcQ0rHoO3es5S5reRpCPLckK7UYei96zLIoSdphkfc6nnr0PSmwIpohG3HQ9BXdQndWOHEQs+buRV0HOMk+6v++v8AMUpbAFzdR2yFnzwM8Dp9fSs20ldkxi5OyMbWZFax4vhDLJlQyvjJxkDI+nauOpWb0idmHp+9rG553daclvqHlXUhiDkAyqwPzBQTz+I/WsNG9T2IVJezvBX8inqOnPZXJjB8yJvuyAdfalKPKzajXVSN9n2I9Nlso9ShOpwvJZqcuq/ePt1qEaVVNwfs3qamtaxa6nBY2OnNLFaQxDMUnyqHA6jn0/zzTbOehQlTcp1NW2YcDPHKXjUBs9wG7DsaR1ySasy+EguoWnn2W4jiP+rQkM/Vcjtn+lMxvKL5Y66/gNgs5rieJFKrlFKlsAEHr14oHKaim2d/4Y8PXdvumvZnIfkqrnDc559a7KNBp3keJjMVCfuwR2HQYrrPMIbckKpHXP8AWm/h1No35lY1JDtjcjqFJFeaeqIAFQKM8DApMQyFWSPa7Bjjnjg0DJAilvux8d9opgSKqKwbaox0wKAGnggnpSAq20oCFSeQeK6sRBt3Rx4eatZlhIw0wmJPC7Qp7VzPTQ6hH+Zm/KpGNePgvGAHPUnvxWkOW/vEz5re6UWJZiWPNejFJLQ82TbfvbiVRIyT7q/76/zFKWwD5SExIei/e+lQQuxy/jG7uLSwgeKJPKWXeN46NjHTPQ7j+dcWJhb3kejl8Yzm030OGvb59Wuje3VvGu5sNGmVGQAPrXLuexTpqlHkixkWoz21tHGjk+WxZt6AjkDv1qlNpWFKhCcm2jPuULT+YBhXO7BOefepdnsbU21GzCK3lklWBIzucjanuaEm3YcpxScm9jRtNFmF1MYpUlNu4EiqD+h7jtmr9m9bdDCeJjyrmVr7HUaFpy3UNyk0UTIyMu125DE4GcdcYPp1q6VLnPPxVdwa5XqVh4WuZvEyWNzP/o6oJdwH3gOMCrVD37PYp46Koc0VrsejqoRQqjAAwBXceILQBHboREr4+Xd/WjmXw9ToUXpLoaUp/dOfVa849IgdmGVrJtiuSqSSeKsY58bPqaYxyPhcnoKpakvQas6TZQZ45rSdKUVdkQrRk7Ip2wzN+FdOI+A48P8AGW1PzFTwRXnnoCMyKdrOoJ5wT1p2APOjG4+YmAOeRQBWli3EuhBHUjNdVGtb3ZHLWo396JBXYcYyT7q/76/zFKWwE5GRg9KgzMHxJorarpvkI+1kO6NjztPofasqtPnjY68JiPY1OZnl9zFf2WbG4t2EvmEjC4yTxx2I4rzpRcXZn0UJU6nvxeho3umyQ6CqAoWkKTygOCVGCOg+opW0MadVSq39UZN5cvMqmZxIN2Rx3wB/ICkdEIJbHZ+Hj5vhq/LQj7Vax/upCOSu3K5+ldtL3oN9UePi4qNeNno9zlNJa9jkuJYIZJISCsrYwADnjPviuWMnG9j1K8acklJ69DT8NpMUurm4lcRwE74lbacnjt7kURk0c+LjFtRitWdR4e1a8vtYurMS/u7cELvG44Bx1rroVJTbTPOxVCFOnGXc6nfcp96JXH+w2D+R/wAa6dTgtF9QF3Hu2uHjb0dSB+fT9aLhyPpqXLUSfZoyoAC5OT3rhqP3mz1KStBEjOxRlcDJXIIqSxzouASOTUtBYVR87UDJguV5HeqAiJA4x9aL2DcpkNBKGXp2Nd8ZRqxsedKMqU7oW1YLOM9+KWIV4BQdplxxtye5Feed5WurOO5+Zo1dgDtLdquNuoO/Qyms5grIYbMBlwcqeuK2VBvVMxdeK0ZchSOCN0jQLv5JHeto0EmmYSruSaCug5xkn3V/31/mKUtgJ6gzCgCje6Ta32PNjUkdMjOKmUFLc1hVnD4WZGqeGmuYpGiaNm2kKu0qR6gdeDnpWNShzbHTQxfI9TzGayZLuSHHktHncshJIrgaadmfQxqJxUt7lu31e80zT7qytpI9spw7r3HtVxqOMXFGM8NCrUjOXQqx6ncfZ2tDkwnGRjjjP+JqLmzpRvzdSa21GWzhu4UXmfAJxkjBoJlSU2m+h33gWyiFnNqCyb3nYjk5I9c/Wu7DRSjzHh5jUbmqb6HXV0nnBQBZtuLOP6V58/iZ7FP4F6D34jGB14pIsl3BgAyDP5UAA2gkhefc0ADEnJzk0ARuBg8c4NIBkwUQkEdq1o351YyrW5Hcq2+PPTPrXZWdoM4aKvNFuZwz7e1ebvoejtqTAgqMelMCIjLAEAg9eKE2noNpPcrXPDhR0FdWGbbdzkxKSSsQV2HIMk+6v++v8xSlsBPUGYUAFABQBzHinwnHrSG5ttsV6q4zjhx6GsK1FT1W534PGug+WWsTyu6hktZJLa4jaOWM7GRuoNee007M+jpyU0pRd0ySMM0SIQpXr8vJPTrSE3rcjl+VeMru6cEZHSgaPVvAlsbfwxES27zXZwfbp/SvRw6tTR83mM+bEPyOlrc4QoAda3Ci2AYfdB/HFctWk17yPSo1U0osh/tuzkiRwZNrcnMZ4xg/17VjY6SddVtJJI4o5CXc/Kuw/wCHHQ0gLp6UgF9aYETSAFs8AdaIpydkTKSirspySl+O1d9KkoLzPPq1XP0EifZIGPSqqR5otE05cskx0z72+WsaFJx96RvXq83uxJYJ+iEfQ1NejvNDoVtoMmJcABQCR6mueHK37x0yckvdKkzMWG4YNdtCEVdxdzirzk7KSsRVuYDJPur/AL6/zFKWwE9QZhQBXvLuO0gaSRgoAySecClKSirsuEHN2RFpmpQapaC4t33pnGcY/SlGSkroqrSlSlyy3LtUZHm/jrTY7jURcxyRo5jct7hQP1ycV5+Js5nu5ZVcYOL2ONVm8piRtJfGQDg4HrXOeq0rku1BciIzNKu3amOmT0/nTJu+W9rHtOlWq2WlW1uvRIx+derBcsUj5OrNzm5PqXKozCgBtl8ybfqR+dY4iPuqR24eXvcpeEYddpUYIxxXGjuGRuGVS6gNkrn3FNgTkcUgDuRQBVuRjcfXH+f1rfD/ABmGJ+Aq9a7zzxyLuPsOSfQVE5qEbl04OcrEqX1ksRKPn/gJ9PpXnSqOWrZ3xhGK0KqTxu42Nk9ehrvjUhL3bnDKEo+8a8bq0SyetcE48smjvhLmimVp5o/NC7QcYzV0oTk/dJqThFe8V5CjPlF2j0rugpJe8zgm4t+6iGT7q/76/wAxVS2JJ6gzKWoatZabGWubhEbGQpPJ/CplOMd2a06M6jtFXPOde8Ry6rN5UGVhkGFz1I9/T6f41wVq3O7LY9zC4RUlzS3LvhDUJrQyQIWwrbZUfjbkEhvphaKNVw0MsfRU7SOkkv7ibU7e3MRZJV3MCOQobHGPwrWdZ2VupwRoxUZNvY5DxG4OqFN4CeSQRnjru/nisKvxs9PBK1K/mYWqqXOTIhgZjtKtjnAJ/mKyZ3UXb1IILTEkJnDIrKSrg9gM59+KaKlPR8p7Lp1rD9jt5I555FKKQxncg8ehNerFK1z5WpOXM00vuRoVRiFAEdq21VZTnBOfzqOaM04HUoSg1M0o3UNwwwa4LNOzPQTurkYKjfGWHDZHPqc02MmJBGc0gEbqTihgVrggofqP61vhvjOfE/AQQuEmVmGQDXZUTlFpHHTkoyTZeijEceB17+9cFSo5u5304KCsVzZqTkzTY5GN3FZl2IXtTAc+YWyOhPSuyjJOWhyVotR1G5OMZOK6HFPdHMpNbMSmklsJtvcKYDJPur/vr/MUpbAT1Bmcl4t0JbiGW/iDmcAHA5zjt9OK569JSV+p6GCxLhJQezOKubh3tYbWW0jja2LAOBhju555rgZ7MIpSck9yLSbme21GNpHwrODIQm/j6DmhFVoxlDQ6LTNW1Zr5pbfy5YIi0SSyIVDKcHGOSD3rSLcrI4K1GlGPvbvWxR1aCWS+kluHh80KVHksSGwMnt1zxUyd3dm2HajBKO3mUrDSv7elWL7QkMmJJSdm4hQQAO3PBNTa5vUrewV7XWiK2raP/Zcz2huBI0bFASu3OKGi6Nf2i57Ha+E/EKxWFpZXpCs6kRNnrgkYrtoVlZRZ4+Nwr55ThsdoDkZHSuo8sKAIo7S2MIZ1Ys/Jwx7HP4Vwyu52Xc9eDSppvsJa6dbFySrEDBALH/Patq8VCKsY0Jym3c0Ejjd3YIu3oOK5jqBooRgFQCfbFK4A8QydjFW6cHNMDMUzm42SuwRT949DwfyrWnNQdzKrT542LJgcDOM/SuuNaD6nFKhNdDQc/NXnHojJQBH780mBTnz5gz6CvQw9uTQ4MRfn1Iq3MAoAKAGSfdX/AH1/mKUtgJ6gzGuiyIyMAQRgg0DTseXeKNOaz1A7TlHIwCen+en4V5taHLM+hwVbnp67ou+Druzsbi4+0AmadVWLAzk8jHt1rNEY2E5pcuyJ9Mur2exe3UP+63XR6fOoOCPwFVB2dzOvTgnfvoZfiKU22rR+d5qEqoyp3Fex9u3aidk9DfBrmpaGXa301pctPaxyRSpGVdhk72Yk5Ofb+VQdM6cZxtJ3Q26up7yOO8vlV2digYgLzkk5x7n9aBwhGDcIEElzJFJbqpjzD/qzGAcc55I6/jQm07lciknfqelWOpzXNlBdrKyrDEhdB91vm2tn8OldvtX7rR89UoqEpQa7nTV1HENT/Ur/ALv9a5Kf8Y9Kf8D7h0SlmwOh6/StsTJKNjLDRblcug7WQdjxiuI7hzjdjI4HNAEbSABcjqcD60ANm2MjRtjJHpQBEHMBCjlOAR74oAtbgMlug70IREsyTfcYMB1xQ0wK87Zf6V34eNoHBiJJzsRVuYDsDZn864K1WpTnbodVOnCcRtdkG3FNnPJJOyGSfdX/AH1/mKqWxJPUGYUAebeOwYtYicFuUOcg4HJIx+dcOKXvJnu5Y702jI02IQ3EEk0whCSK24qWZhk5wPwrmR11XdNJXOi8OahFBq7wyxHE0TRyHpsGTyRj0FNHHiqblTunsR6xMZbiJLVVjZIh5++LncCCduev3T+dW/eQqEeW7ls3pr+ZVi8KHVtNudZs5QZGdtkWMDAODkD25xUWNnjPZTVGSMOBZTdCO4hYW4YhsDq2Djk8d+1I6pNct4vUjxE00jXMaRkkMqJ6+gGOlBWtlynonhXSDFpitcA4L7gmeDjpkV3UKS5bs8HG1+ao+U6iuk4Bq/8AHun0/rXLS/jfeejU/gL5Fm06MfYUsR8ZeG+AscHkc+hrA3Bj64/CmA3ZlgT26UgGy8EEYznHJpCImchyrLtbsw7UXAtFAylT0NUBXit4LUsIkCDqcDFF7gVzDJuPy/rXfGrBK1zz5Uqjd7DWRkOGGK0jJS1RnKEouzG9sVNSlGp8Q4VJQ2AcCrSsrEPUZJ91f99f5iiWwE9QZhQBxfjZ0SwEMzKJpJs7m6bcHGK4sSne7PUy34212OJ0q3aS7jjJA+bgn9P8+tcqPYrStFskupTJfPJDvi3k8FzlvrigUFaNnqbniG1lFtA9y32W5EAIjRsBdjYA+91wR6nimzkw0k21HVX/ADNfwbqX2x0hWQpcrkMfLO2VexJ6ZzmtI2l6mOKw6T12f4Gb4q0tV1Ke4t5GjbZv8qP5gWD7WH65/OokjbC1Go8kten4XRg2iyRyBxayTxRE+aSmSo6/h/8AWqTqnZq17Nnq2kSrNpUDKhTC7Cp6gjg/qK9Wm04po+ZqxcZtMu1RmRQZdUXPU4/Ws4Q5LzZ1ynz8sEaESKA47fd/z+tccpOTuzujFRVkUv7JsY3TbEw+bjEjcd/WpuUSx6dZ27oUjIZSSpLseenc0NiLavtlx2PH40XAqXySzzCP7KZIgMhlk2knoR+tAihPakTF2t5PnBOGl6ZB/wAcUDNt5AFAUglvegBoXC5Yg5I49qAFYZ4HShgMCBuGAP1pxm47MmUYy3KtxGEk4xz29K7qE3KOpxV4KMtCMAkZArWUlHcyjFy2GTAgAHrvX+YoburoTTWjJqkyCgDh/Gsd0t1BMDmJGDrjtjAxjvXHik7p9D1sucLNdTG0iJdZ8TIo2WZlRiPLBCoQvUe/Fcq1Z6Eo8lK17m7D8OIWYkaoruGJAAzx7+/Wq5CXiX2NabwxPLcwtcgXjiUtJIcKCpXBwCeo6/gKdjmi+VtR0VjY0vQLHSYZEtY8ysxcO2M9uPpx+tXTspCrOU4mT47iebR0eHna+XGOoI2/oSD+FTUi0XQnG6ucQdLuhNC1m+Z5YWlkiLYA2kjPT2rKxuq0bPn2TNrwn4l8syWGpSKuPmikPAPqP8+9dlCt9mRw43B2tOkvU7aKaOeMSRSK6HoynIrrTueU007MdYMqld3vj86ism4aHTQcVPUuJuAJGD8x4rgPRHgZGT+FAhCAxwelIBqRbX+Zi3cZoESFmMh2gAKOp70wKN7cEuqKDu/SkxosLZ28qgtEPpk1cvddiYu6uPa0gOV8vjGOCf8APelcY/AVQB0AxSGJIdkZbGSBQBnEljknJ9a9SCtFJHlzbcm2W7NQUc1y4p6pHVhVo2Vr4jzFGMEFST68iig3rqLEpW2FroOAKAM/WrRLzTJlfGVUkEjNRUipRszahUcJpo5XwhpUEuvsXAPkIWxjhtwIx+Gf0rzkrM9yc24ep6FFZW1uwaKFVYDGQOaq5gWR99frQgGEYNADhiRBuVWyO4zVCOP8Wxx2mlh4I1SR7jYXAyQNpPGen4VEtjSmrvU47S7KOLVLa6fEoyWMbqCCAOlSl1NqtR8lkem21vALJJbaCO3DLv2xqAPxx1renNxehxV6SmtdxLEeaseeM5NdspcsLnBCN5qJpR/xf7xrzz0yQKOnrzQAbRnHpzQAY6445oERnjIpAQW8YKGfPznj6c0Af//Z' width='200' height='133' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=718e55ece43846659f5e50969a4c67fd' target='_blank'><b>Seattle Bike Routes</b>\n",
+       "                        </a>\n",
+       "                        <br/>Designate Bike Routes for Commuting Professionals<img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by api_data_owner\n",
+       "                        <br/>Last Modified: April 23, 2019\n",
+       "                        <br/>0 comments, 13 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"Seattle Bike Routes\" type:Feature Layer Collection owner:api_data_owner>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=74bc5c3e4ac7420db8448e00c4d3b48a' target='_blank'>\n",
+       "                        <img src='http://static.arcgis.com/images/desktopapp.png' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=74bc5c3e4ac7420db8448e00c4d3b48a' target='_blank'><b>collisions</b>\n",
+       "                        </a>\n",
+       "                        <br/><img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/datafiles16.png' style=\"vertical-align:middle;\">Shapefile by api_data_owner\n",
+       "                        <br/>Last Modified: April 26, 2019\n",
+       "                        <br/>0 comments, 1 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"collisions\" type:Shapefile owner:api_data_owner>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "content_first_created = gis.content.advanced_search(query=qe, max_items=max_items, sort_field=\"created\", sort_order=\"asc\")\n",
+    "\n",
+    "for item in content_first_created['results']:\n",
+    "    display(item)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7dfc8fef",
+   "metadata": {},
+   "source": [
+    "## Querying Organization Content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "236b6872",
+   "metadata": {},
+   "source": [
+    "### Searching for Organization Members"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a61bcd8a",
+   "metadata": {},
+   "source": [
+    "We can search for a list of the members within the organization by using the [UserManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.server.html#arcgis.gis.server.UserManager) class within the GIS module. Here we access the UserManager by calling gis.users, and use the org_search() method to return a list of organization members. The org_search() method will return all users in the organization if no parameters are provided:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "15f84b4a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<UserManager @ https://geosaurus.maps.arcgis.com>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# View UserManager object\n",
+    "gis.users"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "22647b19",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "42 users found\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<User username:achapkowski_geosaurus>,\n",
+       " <User username:amani_geosaurus>,\n",
+       " <User username:andrew57>]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "org_users = gis.users.search()\n",
+    "print(f'{len(org_users)} users found')\n",
+    "org_users[:3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "5f92cefc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"9item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/user.html?user=amani_geosaurus' target='_blank'>\n",
+       "                        <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJYAAACVCAYAAAC6lQNMAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAALPWSURBVHhe7b13oCXZVd67Ts7n3Bz7du6Z6ckzGkmjNAojCWVkkJAEEsLG2Bhj+2E/+4FxGONn4wDGBgdwwJhnIzICSQiEpBmFkTQ59vR0jrf75nhyfN9v7VPdrTF+//j9yT63blXt2nGtb6+wa1dV7Cd/KzYYDMwspk2hYQM/jCsupgO2ZDxm+rN43GzQH/heyXzP9Sh4OQMiYtYb9IdxMUUNrNWK2+b2wFaX47Z8vm9XT5qtrwwsU4jZxMGBjSwkbHS+Z+XRhKWzSev3+172gIpUnjeSc+1juhCLxbUlFdHTnsYQN9w4pW4dDNQOlURB3rSu9j2VoV7oPGmdbs+Sibj1vfEhkOda3UTrmH/8qL/vNCCS+kILdcHPrycnLQf8ozZCyE/euPIlPL6vLZSTUJ649ZzWXpv2pNOfqYnefo5jOojBIEpUW70p1Br+PB//2CWGcYFuOhgeE0K8H1pfF53ziiAuiteRttB6gvc3ukiBHHo2HXj5oaHxrg67utrTns0BxbH2VBQbqOt9dbcPWLzqkP9PCaEeZYz3nRCkcxAKBKEFHFOmyqICThNsup5UHh3H1YCk0jqYdT2pBDExMgITP0jmbRjQel1T2lBX3BIqW8UotuvVxpLKoYueBjDqWkIV0Va1wlLKo6GlfmujfF1IxBPOfNKSjnj9pybRTPHiVox8SgM0KNdp5SPNK/dWepmUQSrKUX0J0caZp3h1S1sok8Y64NVfNgYDg5LhSeo+OZxkoQL/T3pV0KcdalNP8Ww3DhIhJuxBpOcTgId9c4ArP1tC1+MCaQIacV3lxUU7J8Aw+JH++XU6prLooB9DFy76oKQsNYIM3kgaxDV27GnkNYRqUyO9aeqwXyf6hsCp6oz64ETl3EemMjAiYaL/gkDzRsUTdBbJCNOH+Wim8lJQUpFJJfQ4dTgxRK0TBgLQkZhGroAWi7FBIMVTL2WJcmyRRKN+9hQSiER5oT5iB5SjX5SPNriE0aGqU5k6QGrBBJ07DXUw7JIfh3rCPgBQBCGxl0vpw1PlBWDRQAZAnEPEIHGJg+YMcNXgGZFzXPfsDqSoDaHQ0Cbfwkloh18O1/1YP/ji/BrGwZg4fVNd8b4GAq3yfLRvWIeHkDfQmcHI+ZAn8COkoeHq3DAPx2wQyhtNHKAaxgegDRsyDERx6puOnQHavDHaHAuU5Y0mfyAuQEpIoyWVIanjpCJBPMc01hsOqHxTHlpM41Ug10ifFPMpPy5pEAHAsaIexKUqh829tifAbG/DsO+EIK2RlpwFmFwnZCAw+6gtbB60pzzag7RzIKnQG+tgCyANIdQZ8gehQhoNBV1AeQfpRbnOWtcmdMrBoj4GEoZ6CV6fzj2OuoZ7D9oH8JEwpKVq+hsXOgMwAr1pogOfopSc4l1Cs+ka/IzqcjqQX5trCqWltYH3w0rpHPUhSei+X1SpA209uiop4KOEtDRwCDQGURQoy3/k84hhHK1Upr56QgN6XZ2HFOqMGJmUrSVwxQGY/gVRjdShMRBS4JDSjsUZQbJB+h2px7ZK6KgCpRGhyYEk8bo4903nqDU6o3MHG+dS7Spe9dD4ruJlZ6lu014XVS7tg8gwUnVCVOUPx7RagNUBthZqHWmKuoZBEJmWoG5RaG5DeRwh9JlyktQD6MVRBhp07Sldv0+5CeuqjR01ryuGKFrNiSku0L4vSeKMVnl9iTqO6DZlOGh0TtsQBn3VA39pDfHQExolJAEpN9piqs/bSRLlYaBzTHDJpTKSyu9ggi6K97qgS/TTOddoD9jx+jwhe22AjBHiGbWRkOtA1keXaqQg8nnlHGrvaRgGMNWZSEOU25E+3EQsSmTzUSKRE6QWkgLUY5+JGcONc1dzDoxAFBqdUAfYguhlo3Kuh7ZEm9eqSjkWGzydsukiCoY0nshDRJSoDh9ksZS6A9gzAklKcZDX0eVlosYpy8Hn5dIGeuc1e6LrdQzLJk4/6uPY03kQVZWXEHIIbAII0os9ZfVVyYBtOLChcQA9lzmO8oYWAHyOARcV6c/TDRP5MYPAz4n2MugI9KCNUZxfFA3EKyVkg5bB0UGKq64hXcHAkJQk1jlHXBxuNCK0J4wUOujGph8zcnzgX2vQsHfE+M47zDEjQUcQkXIU4yMNxiXTsp9SZmmkVQrpJeaLSQ4AOqIykGoOLpcA5Oac65StajWiIICEke+plaaEtii1JJ5LGW+Urg3zDht5fRsGJ6RqisuI7raoQA0UIyWbFKv2AjKN+GuqmkyqEA+Nc9rn9QEcKEya4R6mxdVQGM15aOb1up3OKtA3aK3ScZxQi/TJtQs1kFFtcRtMdKSISFqFPeAmvzfN6+UaDOM6JkkQHOE8tO1/pgP5o/Z5sZ5fcWz+jwTau0CB/sPBPhhKgUhXU71vw8wEGEEmGkPwjnEQynJiwExvQJRHe08uYkejECBxfQCoxGtsKyQSNhIGelaAyqjilAzwlPZJjgUWbJ6UM1HpFYekcxtM5ZIupXOEs3s0+iXFONLSSpH9Wjx/cTEpGW8EYKo5KTUk5T1ShNqW1C8lQLmtIJWUSZSsW0taJTdpSQEs0U+rP+SAqSpDZVO+ZJrTDPVG2U4htQ8YyGLysp3+Ohv0uy4lGO20AZ4zmEhNhE8hiOg+0LXHuQg01/kwULcDRGlD25WROqIk8DSiu+JcKLDXOcoea0AI8Gw0jLTXJM/1akKN4hH+ZowBqi0+3DvPh7ihtT7IaA/tp1GgLDRSCelI9OMq+byRAUwulrWnQTSU4MAbdsrTKzhYfe/t97z+jzQcDw8SUiUpqUG2jIgbgQiwuGHO5mACOEFduspUCS7FFB9teIOgV5eV3tnifXAjmCrpI5MrsYwOBRDsj0TH7Q0bNCQ2Zcdl24qrW1cVDwo1Sda4jY7O2PJG3TpMfWQyluhVBLKC8qUYmdbpda2X7FlXxAYkjiA26Ek79T9IXxoBPQK9vY2Kc9rSbiUgnSeTGGLvYONU6X1cOg3pk461IVW9EJ0Myet8IQpIB3BxTXuS6cwvch3AUKDq9oweTZs9lQcXFr7X5n3TRpXDYz/VRaZWOKYP8Czxhu8ZPBTQTHQAkgNMZ84QNurWOaOJzvgI08F1tFIg+ThRJeycaGqiIonvyeWsVgdW3Yrb7obZ+iqEjVl5zKwybVYa6VuxOLB0BhUUiO6ShmPqdCJBSDoSRlbECOK4Dikpkwq9B1H9ZPT2qmWAQ+UmEw3LpNOWj91s6d377I49H7a1YwmrnqtYZutVdufYh+3El1btpvR77cnPXrb4+rjldxds8QlJuO09Ut0Fy02krd7btlRG0koOSaKXk2eNF0rdigutcHrwP4CHs8A4zqNj2gSdIimj1l6j4bUBrrRIfw4dEE4f+gZNVIMYTnTEDPgUG6gdnj/QgsRelAKc8jYq/UBAdr5H7fB2hlR0h72XwSHXqU+b16uNc+eZZ9bxmz5qDzkhSK8UPmJIxTmdpCTOQ9S1oC55NMF3dCI6JnCRSrx98mjkwNXqcattDWxn3WxbG4QojcUErIGVRs2KBROzxXRlhZg0OKqEuSsHkXrie5Xr6oLOhBMnYCAOLr8MbUX7jDKgUkeYRIxnulZMFaxztWLP/G7CRtZfZ098+pw9/ZkXbfeMxvhq0taOb9sXf/NLtnsxZmdfOGvtzY51dhLWWBrYE39y3KYLMzaVOGwn/mTX7j34fnvhyQtWmBJIKttqG3WLOqo84V5sWufQkX7QRqec94njALQQvKvauO6H3nYOAgDpN3uiKIX+cuJ00t5B6elDXtJQaAQqskMHaDisIeTlKJwOt5CHE9+FKJUdQMnxjYOavduWsEERLsE8syrzimnUn4U/C/8/BKnC2EM9IKgAuLB5ABv/I1XokmuYxqUCh0gL7a+pQ+188JFRceRzzwfo6rjdHFhDZswOEmtN+w3pYommwrjZyERcEkvHhYFl0yEvLQgjgPzYVohdjTb9EL/ukTHiqZ54GsCGUa3/Pf2wf+L9lKKlDgo63p6w81/I2+O/1rdjn05ZerNiG2ubNj4zakkZ1O1mw7Y3t211ZcVyuYxdvXLJJicmrCsbKpvL2+Kly2pXz8bHR2zx3KLlk3k7+cxly27M2dvu/h576fFlG2yOuMdbnpBH2cMYqXmbII1LGTql4E1VQ/1cx9FUCpHsiYcKarr4ggol2fXruPtBLUKnQIdIjZKMtJG5IjboOvmgn67pnJRenRepazRVx/A2SL5QW2gS9QyP2WtzKaVSlC2cqw2hK4EXiTd8JC5VSETIBbOD6BqWQuD0xqCMzKKThKSkpFI276Cf858KvV3WbpuAlXD7amc9ZjubiGRpjwmpwgmzciVuhbxsLBnx2FYU4qJWh5Eexx4gPpxDqGA/BGLQA/1QReRzL8AsW5ShHUvapS+U7Gu/1LHz39q1Q9M3Wz4ne6q2KfD3bFdg2lhdt62dbWt32paW7ZVMJu3IkSN+jk9EqJTLskV6VpLOPn3qtE1NTNqjj3xd9uKiPfbFb9nSsartXFA/r0zb6um6zR6KWVNeSLLH7G/oD4Fd2ALTISLnTHw6g8KJH3ONAQ8TAo9wTrQnjjKHsURdY5SOidVlP3YmAU4l8mTstVGix5HeL4TkIQR7jj3leBqao2Oa5bzRCQM8lEF9wziEDozh7r5LAfx4cvpGoToYZvLOKgzx5I3iD+3vjaTtuIt+NQTl8vgw7RDifN5lWAjAChOkbEwRaK9W+14bDY68wKQfxy2tNkae4/VRKIaobGrGU0xnkhZvyJP71h57+TfH7Rv/smCXv1Kx7nbbDt2017bq65bISEJWSvLkJN3E0JHpCSsLOIBqcnLS2721taX9wLa3tu3l4ydsZXlZ24qtXF22Zr1hJ0+8bCywSOdLViyPWEX7bDJjtx6509706vfZt35FkquStGRG0JS9dV26Q5kQdDgEU9icVE7UIcCUEtp4GjIMg8MMWmJ089NF/MhrYFFdnp/CsNG8KFJqx3WdQz+kIX2M+OT1DzfSeDod03RMxTDVEyQkAHP6ax/OxTtpCeLceHfpQ5MUwfyQdh4Qt/LIg0qj0Z6ZxlMJjfSSyamd9ohz/bwWElOp4jVWrN6K285uX16h2e6aJNYGy2MGUoMDq4xrk1eY1XlGI5yOks/FLMWpTOrlB4gYOa4GPA40Q0y5++pYMlG0c1+etif/R8ea56fszBNXbLyyYK1Oy8rjFatKHzcECpbLVKt1AVQCXaqr0+pYt90RuEpOqG67a7s7Vd+8h2LO1sa2mJyyTqcqYHWdZ4B9pFxUg/pWb9a8rCWpzNVzW5aNFW33wrhaqLonC9ZsNdQ+1m6EWzI+cSsJmwQS3mcxbFgXtKPvHAfmM48kyisO+jKz5Q7LkEYJpXFP2bdAQzXWaeiD1PmG6gqmAiU4H1U/M/nMPQFUygNAEb195t4r0Z+XQR4AFgY7ZYfmhrYQQAH3cqnfVaCrGF2AsGTyGq6hnQJVMA3Whv1FQx3tukaFZPHxQyUqw0U5yf2qpxD9BQUR3wmnxkU3oJGWtAOAcpsk5puykEvF0ASKCyNbaSLiqcW0qycvcDRbsoufucWe/I2WbLUJSaK+QDsiILStVq3KZrpi/W7XpiSRIFqtVnUpBMPKpYKNT4x7maRduroom6umZnZ9lObSWaXJqy6BQe0ulDLai1ESn7vVXduQdAOsW5tbAm7d1taWbXdJQFzKWv/Ju636pVfZWH+/A8rp2AuMgzFQDXqEfeij21i6xmWYDC2DZCOXgu/14xqJPB1pAtFIFwVK5n/INwSqD0g4w17nKscTaHN+ig5el+JDO8Lm2oQ4fl6wAIlAoVpJoYHjZaiuvVJSiYCAy8snMfHeKU/kzYCXvpFO8TSIRvSUn0V0XKMBnkay1UGlE/WF0obxpBH4AA91DisNOJQkUCLqdt3qKkT5fXQj7IdtUf6o40RlMj178ndnbe14zBb2jFiv2ZKaaFi32xGTV72jC3sW1L+4QLPkzJ+amrR77rnTxsdGrCXD/bIkzeLlRWs2WrKfxmXvxS2TTlpKyMpnYwJW0sbG0jaSS9ncdMH2TJV1jT6IoOprR1IunUpZr9MVvSX9R/KWLlRsSc7A5skde/wX09Y7cbsGbVH5JDuQEPTVN8iPtKE/6hd7D+wZeNcB48ALowxChHj9wkD79gAlAz9IS0QY9GR1npOCPRHOT0VxPAw3Fkn5Dm7xD21GvqjYUB5x4Tjxlu+NP+SXiFQCRidl41F4Cs9G4JgtRF/veBQgyvDQEwz3imcmWHyWJDCrymjfWJZq3JUHmDMbnRbDZMAXigMrZFWvJGcEZPJHP/68A3h6GpWhtYh2gS2dsNa5g/bN35KtJXup2oyJwWnLy+Y5f/6Szc5My+Ms2Krso2araTlVPFKuWDGXkwRrudrbXN9U+2WfpZLW7XQEjraNlvNWkgNw08KkzZczdsvcmN17cM7mJ4t28/yUNWodS+fSlslnBaq2lYtZqfOstVttSbuOg7Xdbtr+/fvt4tVLdvr5U3bl+ardffMD1i1dtl6y62DyEQ5AGWXeUW6bqId0UcxzcmhDgXhQevfIFBc85SC1PI8SJxXnAxfAQh/yK1AOxwEAITI6jkCpbJ7mWqVRep252qM2EnHVLwO2kNYFAocKibd9bPAQCPZrSs/AoA7O0Vg0zYMSRROpXhuJh+Gau+ug5IDYkJM45EyrJdUjYO1uxGx7NSamDCxfkn0yKY9QXiHAKubUbEmJYJR7Ib6HYCw49E4DKh0gzBP9nA1kGLcuH7Tnfm+/Pf3ECatUxsTMmiUFkFOnTtrM7Iy80aq3a3N93WanJ90mqsrY26luW7fVtWZ1xyoFgS2ft8li3g5OjdnNCxW7c/+4venWfXbbbNnuOzhjR6cq2s/Za/fvsZtnyrZ3rixgdqyUL8pAz1i93raWxDZSK5vN2M5OzaXfyuqqHTx0UFIvb5cvX7TLZ9Zt39SrrF9ctXaiI4MfhkEl+hsxR2BzegIs0UBMCdMrnLOFaz7twnXtibsGNu1vpCH8IA1AGFbgwSWfQtAszuZrwTXSMCnRLq2IcxBS3vU6okAayor91Gf5Hy6yhicCFhuqTVIvaGEd4DUQuBZGVwh+b0r6LRh0NELlKD7M8EpFqICdnbgtXx3Y8tmBnXtRxvu6DPfpuO29bWBzh8xmJLnGyn1LZTGmqTU0kkBHABKlUS/r6flRcax1q33rl6fdU2vI+M7lxGxJm8nJMTkLO7a+tu52FVJkQ/bP3NS0JBRSK6k2d6woAO6drNjMaNnmRhKSUgWbqBQl4XKWS6Ysp45kEmk1RjaViAClOmJcXkCC4edXNuzU0qo9d37ZTi7v2mZdElMOQlWAKhZGXGWb6tjd2bQx2XZMX+ysbtnhm4/Y5F1JG3/Dy5Yt9K3bkz2n8pzxw75GzPZ4eDRkqEsx7YOU4hQWcqy44TEhkkKB2UpHHm0hnjL9sodwW4cyA+1Jgt2L1+l16OfrzjBLKIcEpKFZnkNpono5/kefw0wKDKQQDGlPKKh2dO7AUoQsHR1pXInpXGep7LUi/RKNkiGuEzroI0eNxXtpy1Dd2oqJ+QO7emZgF47FbHd7YOOzcVs4GrP5QwObnhnYqKRWKq0OhgZ4Q/1QHcaWoxpITiQ3ULOZCfvlvy1V2t1vtc6OOo0ubVtXepcBkpIHx4jb2dm17Y1Vmxkr200Tso3GipaQpJmsFGxBam1uvGxj+bSl87KZ0rKDBETpVxmk8td63bCJFj1GmBoHc1qiQ17qNZFO2anzZ606SNhpAevF8yt2elXGv6QVi+carZZVZMM1BbZYJmn5XEGgzDvgM4W83f6BlI3de9JSKQZUV04UHXYKq/9ipA4Dv0QLMSOyfTl3yR4uBV/P20Yaj/UQ1FM4v+79++m1eKKd1jrAFPo2QOrYQTQ8j/JTH3s0QVSHb6SgvJ/6XGhdiMJ9DgnZABVSCknW4ZgN8TSM9wL1cwQP8zGKwkoE9lSsvF0BSyoQiXXl9MAunYz5tMPUnoHtuSVue470bXYqbqUiwFZToaby8Ued3tghsQZi4KCfkGRr2eKxvfbpnxV4u0i6lBidlzeYVrbgyW1t7FizXbWpUtY+8Kqj9rajczZSzOlaxoHPIGq3G5KsSXl3KnegYRGq0UBS5TrpCmT0qSsgMaiazbZ7gqTr6ZzlPj2BfG1zx85dvmJLTbOvn1iV9FqxnZrAZJJsckAasuNGxsZtQg7D6taazc2N2oXjmzZ3W9He/MMZayWOWSouUPfbKtsprT2NYR8Y7FMCQyFwLSgNWiIm25JjQuBcOA1loEGUjwEKu0MylRn2hCjOD5TO1eYwMqZBRVK/Ma1MziPFBKkVyiMtbfT7tqpexrs9BDiCAUaBFDVMzKEzmWIUO4zzQrhGIM43v6K/cOVanDJ1JfKajZhVd5i/Gtj2SlzqSDbVqIz3KdlYY2alEp4dUo5yQp3DQoYb7QW42rxjZXvkP49ZU2XO7JmRdEnY9tamjYyUSGobqxsiZdvukU30lz/wOnv77bfb9PQey4yNWjKXtVyxYH11NiO7Jy6VF4sLVNqYMmC4sPQYQmbSWd/HJf1i2srlEZde+vP4nuwFBiMELshZWFxdsW1JpxF1qCHA7zJXpo5VRkZtWdfacgyYVd0WECfGKlLlKVu63LKRqTmBuSYaNJ0HYRwxQOkrJAhDGJCDLberfKO1JNVeGUkFD5xkESB1mXQhIfFhfyN4HBAK4f+fHrxur5NUUpEh2lUmhVISG9zz4rhPxdyGSwpvVNhIws5HtxKy0WFvvrwYL9nbFRWn/zrkyCUa5+qYBrbHw4y+pJevFVfNiH33AqW2aFwoKozKQEjO2evHfqh+kQDnjo3a0rmubKqcHX/hpO1sXbWbbjrsxNoUwFLpmL329sP2ofvvsrsO3W7Z6WnrVyoabZJWKqcnCZLyFRApSbuCb9l8QR5eXkDIyviXtyeVxZJgnl+Myc7KKA19KZTKli+WPS6WythAHen2mWpI2EGBfHYsZzOVvM1MTtiMJBSSLSMw45nSj821ZbN2365cWbIL58+braWtvTVpnYb6x0Soegk1kPZ+rH+A1xc7wgNogCTzLaSBniK10zwABhoSH7gD7blO8HTanKZsVDC8wDkhsm85jwBFgJ9gZaiyvGyPUwUhTeAdboZnoBwO8Si88Rz7Xs3X3huizSUbqo7fsNXBU6ByXVJZFEzRPDTRj0lVKB83ZNuOLF2jUaxn98nRQDSftGMWXGWGWz6QTYFGU7H2lM2DBj3L2slvtG1VUmlp+bLt2TcrgGYsIzB0600pn57deXjB3n3X7fbqe+6x4txeS1ZmVGZGEknlSeWkc5IWyZznE0LoqFSd6kHVqy9tpKwA0ZMUiwtgmULZEjmBriiJKIDEMznVl7OOHAGmFgpyGnhkakbq+BYZ6QURNN9vqi9tp2Gv3ZbDkHFH4sD+Q7ZbrwloeR9wzWbCLj6xKkBLegJW0RbSJlDRohMGNXcY1DqRAdpwAI1pa0RvBmiYtmDgqiO6JBoPkzNXGLRSGMSRYQ7imE8jB2DyOM8BUAKIIIkrw2FdXrzogsR3y0hx1/Lq3IGlzf9FAigKxHsigYibEOHeHGlAta4h4VQdcdcknO+JoA2gGVCoUfrHLDj1dsVYaRsnDBUisQAmm6oKhPOc7LT3/N4n7bGDdNTN2NL5nu2Zn3ZVtbR01fNeubJotdqOHZgbtwfvPWJ79kxaUippIKu7jwpSA1ylCYCtTlfAAsgqW6KYp2UAcCqTEgv7lgbxAkFM4Go36zpsqpyOipANpLJ8ObQqzSg9DOMGcpKb11KhU3ISKrmYjeYEkl7L713u7mzbzva21Wt1n5ydnZ21arUqYz5nUzMVa21Jem5NiZ4CbQIQwQ2ngoIaqc0ZhgRQtEuZG2jNLwoONLZrx0rDAGVwkm8YXHVSngfyh+shynNfLwuk6zoAcx74H8faUzapqciPvh1LXta1gqIoHTAd6feFVKODUJmp3Kv2EvUvKokyhASvXAFQIYG62vryDuX4aB/SASpuAVCWp6cy5WXMACbfVDAPFfiDBTExNCP7rC5G7EqbNBs2KvU2Oz0j4PRkqDdcyu6dnrScJM7kSEUFyMZrdVQd7edBCOGlUdVg6VlPHhu6rS+12Jak63fb1mrUraNyuW+I0dqUZGkLAO3NDWtvb1pzc92qGxuyFdclaerK3rWWOwCqirXs6sNILmMHJkdsLCc1K9r0+x3LS8VCJiZStzY2HWD0NyO1+8jDX7diOm+rpzMC4l7RSBSWhO8Pwl2IiFkuPUQ8+OMMJh6SRSPPQ0R79iE6MDzso+NrwdMqTnsHyHDzdCTlEjsaT/5rkUqnejkL9ZOKXYhHAEVx3nFFh59ywHAHuAMnzPYyqxvAxXVdJJ2Q4Oc69rKEbjccVTwpsRq4P4i7jlfpuPIMYXMoKbOrbl1wQOmYZgMyTCteA8CjT+1+xs4fS1i2P2nZQk7Sr2eXLl208qhUkUTh7OyEzcsLPHrokOwa2TRDydpv1WwgqdPY2VFhbVdhHcXFxPS0ys9IQtHVnq5xQxfQ9nD/pUKQYgPZT3HtmQj1GXpliuErw2zVCxBTqZQ6BvMGNpLP2L7xst1zYE5qx6zeaEpdZuW1pqzZ7QhYuzYxPu724IjU8tkTZ+3ic1vWr08qvRwL/w0Hle9FExGCjXk8bD2nk65x35YJ5DCIVb/UVFg1GzEEoGjHEYwfbkT5LTkYqJMIeA4qXaeHbENmKHBNB+o/0z0UCk48idfDsU7AzbUHEQKCSOOF+HUHiA78jx8NDKDCeMfNRUIMk4TAgVfKX+iAr6kXmhw4UmfeTk8nWy0qQLtATIcB8kT/gZyOlZ8fer3VyNjahYTVd5t25eoVa0tdjYxWrF5v2JikV0l9ObwwIy+spHqQhipbFderOwJS0xLZnBXKo6pO12Qod3ptX3Xg6kz1pKVaMdxL5ZKkiaw1ATfMx6kfkjZMvg6kCmMCk0wa2Vkp5RHwVEeXa95Rs2w2bbcsTNide6dtQgOgKkB3Bdqcjn2ZkoC8tSnJJbXIxpxbeqC+XZKEVDqM4X7f1z04iJisZoBi04RjtUck1CVt4ThK4xPIXBBdI7CFTXEKEbCQNE5XwKLgPHZmak80P+Xzd1k4FvyS02qYk0TOS3+uQIE4NrgaTvSPpBSoSBGdhGqyLjDiHICKAge+fkqpKMtVpCLdTvKyVYrKUDdUGb3ruqTiYYqujPlOR/GKdoarLG5eY+Bhg9E4COajSMcQLIwrMVagQoI0qzk79WxNkqpqe/fts/n5GY9nmkLmtt0hu+v2m+UdqtG+RIXGKJRka+VkfBMPI72plC5RgBPSbbWlropO7KwMc9pImJyc9vhSqSKw5FVGwb1CPEemKegHC//yTGFk5BSkZOyrTzldHxc4b9kzau9+9a02Vha4ak1f71WU7YXKZN5tdGTUEsp36epFu3L5qi2fbVhfgg+IdKX6w/o1cULtoU1hH0AR6Ko4STHohOPjD7g6LbFlGZZwEVrSY+113cGjY/57Wc4vnekv0CvQjDCEz7XgvFV+bDOnOeeeRf+0USZZBJcQqMtRyfG1DbSGo7DMlTRsGu3aHGTK6N1S6aEMbYr3Y8+LsKYIgYaOihBepy75EhKBFgzTWIBEcAmnY5dURKEClA/DNZVM2+Zy3Q7dtKC4nj377LNWyMu7U4HlbMre9ab7LS3wuOoVJwBkRLR2uyV7qqUyBFR5dHh6aQEA7wvQdWTQs+d+ZC5fEJhGpN6k+vAcU3lL5uUZkqdU1HHe8hWBVRIQqZVK8jCr1KakHd5fSaqw0e5bKZe0A6NZe+C+O6xSzkuq9ayosluy65CoHanFltqEhMwKnOdfqNugPafeV9Q/QAXjRTftedzeaSJGOJBEGq45vXSCV4tkglGoUBK4lLu2KYRo5xfMgkccBinml11KkYYAX9xj1y/ibxQcdJTn+bWR1uOH6UBXpDv9XAykQAjlW4C0A4t0ZAqLvAQsNRdwXXsWEGmmzdMmAYnK88qUWMdOLOoQoPA43SvUOSD1dzvomJjQhut1enukLnqtnBVTI7a6vmWnT5+xMY34lNQKdb7pzttlyE+oEWkncDqDhApShXt03DZJA8JMQSpR19JF6aySpQojspZSrp66Uo+SsZIWYo7ydlADgE9SLF0oWlxA6qYqAtiIFUbGlb1sybI2XUsKlHiYjc7ANnYkeWIY32ZjpYIdHknbPbcsSPU2rbpbd2nKrSYYmktnnCkZqcmFuQVrLKneJDPwqDeBSgfBFtKmYweLyqVwyie4c0Sk7wU8beFR3KT6Q3ruR2iw6fi6GoUhACfwm/oC3gL9aVugOzWQOhr6ITiw9Af/CEE6epEBWM5a/XkmFRTQe70Id0v5idhRA/yxd+VwtcixWoSHjnHv77dSvqSKCBINcDm0fJQSVKQ3OMykq25d9Mb4tXDg4PJcoe7egBu4bZ2nfInw9OSE7ZmT2767a7ce3Gt3Hb3JpRiz53hhrWYzrFlXlRkxHbrzuLol0iKsHAGhPp7KihhIMOwkXZfN5k8pU6caRr0wBe+vKy+yvVuVIyB7rVmzLQFjo9Hy+a14RlKvkPb1W5XRggCclLrkqemETY+N2MxIweYk4ebGRyyhEYh0hOL0EZpQJ2rywtmzVs5P+a0jGuT0dgqQfMgT9oBMo5HuBIoSwnWXcIr3l47oGLCEgP1FPDwmNb+QO9SjeB1HvCduWGQ49kCE8lCujjxam+9pr++Ei7d/X+whjxSjMVIBAqkoaFh+SDw8iCoI/8O531ZQBE0EEwCJc8CDSBZvZTzH/XbOzqrJhZc0ycZsbNZsdCZhlUpfNonUnDwt8jMqYWgAmDYHNGXF7cpzC3bqyWVJn6RNTUzY8vIVO3zkkM1UcvbWu49agel8SawOc02SBOTnZjE9wP6pbq1LHTb9cf6ejHkkLOeseECW4mW6Ryu7zeevmABt1AW4viTMlu3Km1ta3bBnTl20Lz59xr724ll75Nnjtlbv2Gq1YzU5J7sCxfTsnNthg6Q2EYZpjm3ZWJfXd6wmNdhRedh6xWJR/a/YrgbH/oP7rFGrWW6ma2P7W6J/U+2+HiJN4gN/SJqILwxBZ6za7udOs5A2kvj65zx1QaHjiG8hHUCJwBUYT32U5RPUHPjGYPCqhnmVLiT3ENWZePsnhsAikTLxdjggLrbKBlJlyuUqa3idTDBcsV4IkggRHU1BQEAqRrU5LjR0Ot24bW8PrLZlVl2WqtgdWHksLmD1bXRSx+J7KY9qRdKpLJwBHdMhCMYbXzr9jiTGqJ19tGxXjm+5VBiRO1/MVPylIg/eedQO7ZlxtUKr6C0TmtlMyhr1Hdva3bavP/OknVtashXmoXY35Uy0VBfrxHZkk7VtV+k6jYZLrZ6kXrPRtGatLo9uy1bXVu3M0rJdWN+2X/nys/bUmSv2+Inzdmpl3S5urttjL122R4+fsOPLO/bi4qodO3vV5vbss7GC+iswsj4Lr7HaT9jZq6uWlz0IiFsaAJlsMqhqAbHTGtjkgYQV9iwGpiHOdeATmXBTIdhFDMJgQIsFgZkABn4FrngeByHGPYPF9afUmcpzwGHIKEokUFqktOiNFoF8TkNJvKF5BD/QTgCa8nF4eLxO0dSk6/CMlKGMxNs/Hn/I7/tRp1dAoymYExpFoTrmOoG8nF7Ty4CM9Nq8YC6HH3Ed2VRyuGy3GrPddW5AxySxBlasACxJrHGW/MrUycR83T3EYvNOUv6wRF/b1S3Z+ccLdu7lJbvl6GGXSl0BYHq0aK+/9YDtm59SjwRu2VLYORfXNu2lS5ft9776nP3aHz5sxy5v2rHFHfvjx16yb768KCBcsE1JratrW9aSBOlsr/lEa1tGd0fKstmu25X1JTurcp66uGFfPbFkn3vmvF2WGm6JwllJm71H5tWWgzYzu9/e9uCDdustt9jyxo6dvLJkX3v2nO3ICB+TZG1K3Y3JON/drdnzFxZtQnHYOai8ymjZsvIQa7rGmvkD95atsm9DKjKsJI2IH0ksj4r2CvDIwRaBAGSw18k1tpHeaTo81xY0QpRiGOfpKIvUgowiIz57Gu3IFrgetmhGwNMhvnQsYNlD4mPI4Al0oBCA5Yce5wDjZNiy66tJQ3y0BbuIPGFjLVajOZCrHbNtgMX9V0n4EsCa4Skd3HUxKc2LQcJYc/Trx5SlrydXXRi7sW7Fzn+jJPuGF3WUbEVSZFJ21v6Jsn3kja8Rc8p2fr1lT59atN//+lP2X3/vi/bc+at2RYZ0TOoxK8Mb8zMm4Ekv2rbMnPM7Zi+vN+yPnz9rx1da1uzKI0ybVcXwpfVdu9rN2pfObNvnnz1t1fZAbc1bJVextICSkhStyF66e++Mve6OW+y1r91rV06/aPsnD9mBhYNyTHq2KNX3y1/+um2Wxy09NiezoGEbWyu2Xe/77ZyMnImabLeSjP/tjU05HBkb2de3udsFbXmM0a02h8pQAjmP2MKoF5VCHFoiSHquwwQkPnYiaYnCSyYbhYYyUIcOIKc10QzskN93/BsG5XKtQox2vqdhw+K1px1EKt2DH4+FpclKBrB4DU0YJdeNuuudUQGck5Y4HTnOuEZFQ9B5Iz09q0djVm/Jxto121mL2eZVeSeSYCVJqtHZgY3ywGpxINXA84LeEG8LJXnfOWNmWO3p1MbsiT9oWDaVs9XVFTFvj+rt2523HbVHX7pg//RX/sB++j//qm3L0GZuaWJ8wrqyk/LMmkusr8m+qu1UZWftBu9UIqNQTAnUGbvttlvt2dMX7KIGwUp20r51edfu+tj32vx999s3H3vWEtWmtWT/9FnP3tq1ulTmWKVgR3iKGmdBLa1dvWozxZJAUrG3fehD9sv/5T/53YAH73ud/T+f+oyt9pJq51P2obfda8+9cNoaMthZncrLfZmIZStXxm3/qzJWnNuUUdlxWjhNRU+3YQNRhoCDOtAJ/uDvBXoBuGEyj4EVnPj58CTwSCUM4xnQrv5Ui6e4ASTEcwhw4fOQzdeug1MC7CMOOz3xjk/aQ56Y1FGD9I+ORBuB/+EwnLtn60cKSu+SwDPrXJuPAyXA+ZHNKvuK5SJmm0vKq7jSuNSgq0JeBsJSXyYWAZF3+Vq9dItJ1rhcztZ2yU4/mrVMKuO3WUZGZGPlkvbkiXP2qS9/wy4vLtq/+vt/xzYunbdcTu6/PLdXS019+J1vtcMzYzYpr+vo4SN24eJZqzaqPg+FQV9I52zl0iUbHy9Zux63i5cv28tnT9qFc5esXCxbbe2CxTY3bHKsbB/90Af9QYupcsZunh2xo3vHbN/Cgi3s2Wu7m7v23PPP2PrqknWkPpmv4viAbL/FtQ1b3V23Tq5l2fyS7Z2atsVL3Gvsu9TihjSP8VdGinbLG/MiymW3WYNaC/QIL5DjDBCIuC424EIAgQsAeCDmuErTudtEkNLJqbQk96A0Khqt4KDSdbfRABRxDpJQL9qNegAwwdsilHN2XcuxB1TYXtq//fsFLBJ4BgoPBy4u/fB6RmKYK2GOiA7jhnsqWq8DsnCdSv1EeVpt2TuSWLJ/bWs1ZltLJDIrTyakCs0qklw8Wp9FqgyNdgzTqF7/JZgcUAd7M/bk5zr+PoWMvMhkLG3xUtWOX9q0ne2GfeLdb7Vcv2aLy8uyZzL24be/3m47vGDHnn1CCK86MDJywWcmR6RKC/a+d7/D3vX2N1pjddmm82k7PDthf/DcCzZf37Sf+Z7vsLlUy37tM1+1+2++yW7fOyrpYnbqxEvybld8vdWe2WkBcM1evLhiy7LHWGU7Wpi0qxvrdurUab/nOD83bb2GnIdO386cuWq1pU2rzEnV7VO6i9u+/KbNTfIhjZnsnL61beU9Vbf3/D6eCOYM1JEzV2kC4yP+hD1mCLeCrj0qRiL4oM2nfShAbQrTQ+Rjw0HTNehLQQrcclJCL4/CXSIqj3NU577XPy4TqIL2MUUcQCoF/Pbvl1fIRW9cABghVBoq8qDcFOibZxhuCn4DdHga7Rlb7DHca7wMZEPSal3gko3FhZJU4IiANSLvsChg5cQ1r09/wX5jFEadp2NxGf8Zu/rctNRXQVfb1tis2vTdOTshj2x3p20ffsf9No79JCa+7p7D1pMafOalF+zOo3e6zXTm4qLPeI9WijYuNfb0E9+0F596zOZGR2yukhGzD9hn//ARe/K//ws7Ml2wu7XtyjO8IrW3R14rK0Dz6awd2r9gi4tLdn6zZZ9/7rid3mza8Qsb9rt/9FVb2tq2qtpVLFdsc3tTEqlnNx/cZ8+cWbU33Fay733T6+w/f+ppS402tOWtv8NLbFlhWxdDkrKrNOBuqgt8u95vgijgv0hiQD+nFRwNJ2GnH8xxqaXAzl+Cy3USKIR5Rf2QLODG40hL+QzocAx8OOZ6gFI4dpxwpD8vPxx6HV4teZVIptIwkyJ84d6fhT8L/z+E6AEMRxqGOdgKCA97n3VWGtm6Lo1cEvUlsrWxBIZNnnpIo4077OEuO5aRhAebznmgQk6OylBeQTvGChMJF0Yluj3oT51rNIW5M66F67FByr3CUjnlcyS8QI2Z6/xIToZ6z7K1jk3LppqQ+8/KlfFK2o6fPG2//4UvqbyM/ZWf+jn7vr//7+w/f/WY/dsvPWU/+3uft68/86IVUll71ZGjUkUtyyST9s0nn7P3v+4ufzX47sqarW9u2psOTVhCHSnLa3vr/Xfa7ETBHn7kG1YcnbR//q/+hX3Pd3/IYpKCF6T6XnPPHfbDP/rDti2aPfrcMUuoMZfOX7KzlxZNvonNlkp27/6S/bX3vd5e/MqmFQppG2Toq8wAJI36OCYVXVL7edQKPRBUi9JAfXgkGmFvIjX8B/1EJ4QCXAvGPWmHGxTX3ucISafrJEHbwfyUjsOSZ1QiKzmUbVhn+FKF0lEuzFDl4dib4uHauS46r2ijIhMPfsJ8gpQOIBvZ0/gIXBxH+3ArIIDN700pUrhywBHYk873VKCTVidu1TqvLTKrrjHzrgxyacZm5BVOowpjUoVy3dWjMFWhH52ket8gqjiNju8n7NmvxK3b6Mrgr1g9uWYXllbs9aN77YNve40tbdetVV1zG+3F516y/OSE/dYfPWof+M4P2LGTp6xQGrXls+ftR374L9oP/eD328Of+6I9/cIxe9cD91sp1bP/8sXH7cc/9Dabk93TjcthUDmFQdfOLq/YoDxu+camLUwv2P333GLTpYxtLJ6xB+6+3W6aHbc33HXY/uL3vNcG66uWaHZseWVVg65lOTkM5fFZe+nkGb83+Mg3n7SJyohtbNZtdWXLJo8WbeV83boauWk5Ihvrm3bf+wuWzK0HZmIDQQb984GvY/45ELnM5hFcAKSoIeICk0U+dwLcSB8m870u+J0WRQCIcI0pHi/e88JLKuAczeZ2npc9VKW6ELXBAe1AIDXlDy+onQqe61rB0QZAqAQgATskk79vXA3zpRo6RzqxV/XKg1gZghCJpgu+MC2sDqYHFr3fHRCFBlIX0iqql8ZSa9gwSnNlueMTMnbl7bWaXdkhFdt6et3S+YT90Ze+YvV+2r72+DP29InjVtVQ+8rDT9iRuRm79eYj9tDf+3GbliT4Cz/w3XL3X2utU8fs+9/zFvtrn/yQlbMZO7vVtdrqhr3h/tdYM1WyJDepi+OWklH/0Tfda4898ZRNHDwqyZV2RyOndm4sXraXHvuyzWQ7dpsk2eaLT1n97DE7OJq2mw+N29TMqN192yG1L2vbsvEunb1kq/KQ//jx0z4ZunSpawPZoJkSCw95A07Tjt5+u3VjVfMnf7zv3nv/XeOLflx25gbGDemleAeLJKCu+duoFXd9H9MARkLJQPf0wzxRfgYxBwrRFJMDRMHtNh1zBlscvMNrBG+XCnKs6F/iHTLeI3SROXRBF3Xue1IOMxLhZ+pMTyUzxYD0orZwO4FyhnJL55TUbg+s1ozb1ppJYrFhqId7hKOTfRnSkgpZeYVZ6ieHPEDaMewYY41iIVZPXtK5Z4uWaIxaO9Gyun4rJ69aVgRZ26paZX6P3Xtwj11aWrKGpMNthw/Zj3zwHXbTeMWm+lV75x377N49Y7Z18Zw1drfl2o/Y/OycffPEafvJ//Bb9qt/72/Y/tvu0SDoSN3kLVnMWdNvdG75wPiRf/nrVpiZsNmRMRub0DZaknc55k/n9LsNgWXb6dAV5w7LYB9R+QfvvN9+7j/9hh2dydstB2dtQW05Mjeqgdi2y5d37Yq8xJteu8cWz23Y7NSCXVk9Z69994jF0xuibZh5hxNOA5aLQBd4wFoFqSpWhyBGAAcU5+WypMdI93zK6EvJlSwASNfQDmQTrzwPZQc2DvNwPQDO9+o7ABYnZIqgMknsSPC0UcD58L0Kj/30F/xWn6MN/UvBFA9TI1D5cgyl6clwAjYIZ1+gFy7TVy+MQMNDYNJvYNs1s1UB6vLpuC293LfFU9zOMdt/Z0JM7NmehbhNchNaRsiNr+CJ6iYgyZB0CdlPj//uUTv5ZYGr0rXLmxet+/K2vfbWKbvlpjl78UzVEtMT9qb5cQG2YP2Wytd+RFKmVpO6USEpobor26qVKtrnv/R1a4pgi5cv2IfefI997H3vs3q9JsnadPsIibp87rStrCxZK5axhx971lb7Of/0XkM23sj4tK1eueo2SpGnouNJm5mbF2Safttn5eqGzRQH9pZX32y5fttGSrIBZcvRhoQM0//+2HH7xd96zI6+aVoebMJajYRNL0zbm//KqmWLSxpiAg8EhwbafBZLdIEywTgWCNRIH4Qci07OBV0KfGCaQowV/yKAanc9ADJyKD85yREG8w1B5wnlv36NBnkFnocQ8cubpGvsY//0j90WBgcBycBGDbwuMVSUGELT3aby3JIeMvQ8hDquVeyND1d8ZnurJkCt9O3Kmbhdfmmg/cAqYwLWXXE7cGvfZufiNjUidcDrEYbAIkR1swPYtCmVidmTn73ZvvXbbSvPle2Zrz1tb77toP2DH/puK2Ty1qlu2G88/KI98sJxcUH2DUthNBp44142zQcKpAIkifKye24/vMdefdctNp6OydXftH560m4SUxfPvCzpmZVa7/sy5OX1FVtaXbJbjxy2nU7DHvn683ZwngnRGZuaKkti5FyS+KsJoJPqU05fPtNNSmJXG9aqSbpKzbVFEGREq8NTQFlb7jXsL/6zT9luo2dH7p6z6mbO9t2etrf8yIoE0nrEwmu8QIJFxL0GBCIkQaKnpBEmIShOYsgViIKvWtG1MP5DIURxxMvi/EQJAKKzOJx6dNKREs6HWb1Nrun8Eq4FByQI12L/9E9iDqxI9LmxOKwxfMhHidVoJR3aUCEzIIukFLEBUsqm9N5ZdRIJsbotibU6sEVJrEvHdH7WrDQZs333DASsmM3PxG28DCNUv4DlBFQ+ByntoEYVzGFcBvblF47aH/2ipN5kxR7+g2/a8//jp20K6SQ3s92pWj4lJve71lBjeeom3mqqD0l/TCslFeUMUWE8/lWtVaWit210/822//DNduyrX7YXT7xgNx293TZWFqXiBvbNl67aU2fP2I998C12977b7eTSWWs067ZZrdnm6pYGY9/ystF4ZynLkXm2EULWGnUxzPwFIbOz05Yvl2XcJEW3hG0rbzvBq7rN/sVnnrY/+pOn7ea7DvrixXd89A6744NPCdRdpeVDVIHGgb4s0dM5TBXth3zEMoFK3rfA7ABJp6GOAm/Jz0/Xhvmcfzrm1CUXQWUHJyHkd6kUiU0FL54M2vs1h38Ioa38l5R7UDYWLSSD42RYqaPfj8I13yiKPZ3S3l1cHbhXocTk947xx14tkIMkNcQEqewsDcSGgJYrJWxkTp7hdNwq5Zikjdxe2Sk3Sko2jm8MECWVKNjxr4/ZNq9eliT4mx9/n6vomCQET6ck8pIimZJlZBjkywWplKzl1JSGQLQmT23pyhVbunzZFi9ckAe5a+Pz+23fTbfZhWe+Yv/kl37N/v6nn7anjp+WHVSxl69s2i/+7jft0bOb9iffetnmp2OSanskift2y1GBcf8+m5fqm52ZtdGxcX/SmWXKCQGIKQHeCTE/P2dFgYpXAPDOByZoW/WmHBrsuIRd6aXs5TMXbWd3y2b2TNuB26dt6tAl9TTcJ4SuMDnsmTWHxjAPOoV4TBg+86JuCiBDXugMFoQJUXhBXKAiy18CAAN9OXTwUYCCq1R4jAolrwub4TUKJ5BX4nF45kE5vB7SJh78ROwhV4WkG6YKwGFDR1NwyOTXvTMcc13HuuYbcZ6HOPbULWC14v7ehq3Vvr9wrbEt411gGt1jNibJVSyYRnwgjtdCxmGgE6EdqljDkvHGPNWxb8XlkdVt/8yUfeSt94ncLMOV55POWL6I4Zu01u6OrZ0+b5vnF+X6X7XqbtXbhWThlsfc7KyVRipWyqZt69Lz9jf/9W/brz9z2ev92NvuszMX5fGdumgffv8bbVT5vnF+1R6RN/eq/WMaLD0bq4wHKVUsSUXnrVgqq7wxq4xPOchGRkZ9DVZaG2uumIFn/VVbthUrPJu9rlR12s7tNm1ps2NXzy1bVwPj9tcXbWzvqighECHTYpJsqh/yRLTQf9Er7Pk57SUembJxOkriQ7swPyjGaoPHyq4NMIS8AUwcKd5BFoSI73UeXtBCdq55quFx4E3E59CucExg77d0OOICItA7oH+ch86Eyrzx3pxhRv3jmDg8i9BAGk3ekAgJ2mjFrFo12141AStm9R0BSzaVr8VyYA0ksbg/Feyr640clsNsmx+gfnv+9rxzL3ZsUfbagbkJ++Dr7/Y3H0tPWlaqqNflIdSWxcXEnGyl0uSoGD1hk9OzNiamT8k+mpid9zXsPN61trJuzzz3ki2t7dgte/faT3zsXTZfSss4bwt0OZseSdn73nCfffId99lb7zhoX3nyKZcK+ySpfJC5JGJdPbExn99j8pYpFx5UpR+sG6MPzVZLfdBeKrqBASrJt91P2NLGVTu0Z87e+9632fSRhmVGeASsqbJ7Pi0AoSnHH9PTMXjxm706BjzOJ9Ub7UnEccT4a4NedYefFxk2T4fEuIHPXvYwr664IaRjNgJtIbfH6doQax6iNH5LJ0wZIA+IAWCcCxXEeTtpTIgLiCeljqlQ+2iSFGBiBQRUM3cVUnREQJYV9zpYCSpLRm1MFKM/3jARx58EUT62ACqvkWI80EZA2+zt2tFXV2xtQ8YtWBSx+EhSQkzkBi7r2QE0a9+9l7K9kil5YXIpB5IIbakiHvPnIYtOLy5t2rYTZy7Yu++/zX78o99h9x6at71799s73/yAve87HrD9B26yNXmU7XpdxvUVY33q1Pio/vetJVuLR/cBM2+RqfNWZK6oPf1Bx/dt3oXa7tigrZ4zSJwirElrW0f0LKVi9ra7brOPvPFWe//+sn0w8xb7YPvH7YP5f2ZjySM+yJFC/pY+aKCNbkdqCgXoP9Amgrpw4FhxkAMSBM5CV+XRudvUIYULCAx+jx/yIywYhB/aOA5Fh03pA7CGjBnWE+oK17gsYOq/IiU9vVAPJNLP92GnQGFRRq/e46MNVAcjEr8SIKhpqq0r/kpzaM96ciWgc6KMp+GfehM8TcqnvlC+H+vnN7iVkOUlXQGh347Z9G1Sa5JGmZxAJKrw7vdrBOuKqWImj1mlcvLY9Ou0dc57GFQmI7LXaflj9Ngq+XzBxqfnbM/Bo5YYH7evHT9lv/nFL9rp8xdkTG/bw9960o5fumrrAsLdr3q1/Y0f+LjddfMtImR4kLXZlHMwLJdlL03VwzOGPL6P2qLeQJ/AKN4siFrkIQtucBeyrAcz2zNRsrjU91OPfMW++F//mx371Bdsz+ZbNXgEH9XlEBJdXAVCI6SXNme8AwHKAzrtVSGAA4DQJKX00fSEU179jm6beRznOnL6UDZH7LUNmXodPBTuYAtCIAgCT+7pg1BRvax5d4ArXEsgIrH30QDHuOalhmMq4kONUQbhxoOXqXYDGNrTkYSqtxK2tS37Sqpw+6okRr1vFalAXhM5xsvW8rxYI+b3rFSYM4gQNZA48EdfecFZv5Ow1ETLrryUtVi9aB949a0Cbk8eXMrffuKPqjmzabuA2JIakvTg2J0DMZWXztLYjtLtyBN767veY/mpaVu+cskur204+UfHRmx1c0vMV34Z4YK1VFnNsvGeTcpB6IoZbpuKnRjhsJURk5Dd1K7t+nr7jkCFGmQNfVOAomlIdPqyult32mZkg7HAb7fWtr/70/+P/dE3zgjUS3b59ElrNdo287qm8ksyStXjZl5bCqNwXYL4qfMLKRa+2MFgg0kAT61TGjdrnL5h7/m9DDVdDAvqlfK9OMXrAnWRxs9DvEcpDhB6d7SPQOV5FKB2OPAK1TCdg3xGALPrrtqgiOKRLE4cyutq75JI2cR5Zqb9ZrPSY/O0VUJbjawrQVdg0IkkRVe0Vzl0SkhiAtB7JhXBOxvw6jBZaXnUWIeVDFimOjDSaWZ7t2sPfu+EXTx7RUBryQOU5JJUSjC5Wd20XruuusQMqSoerGW6AVXI+vhWJ0iYZHbECjMH7dDdr7Jap2FnTp2xx158USq1bQuyyzICU17q+t6b99ntB2Yl9bp2YWXLLm9VbUsMTqpcJkRR8015eajDQa/tW8tfQpIUjUQN1KHstZzEEl6hjEnbqDZ85r2D5NKA2FxZst/+1B/IZizb+9940LIJlWlFe/GR45aJTYoOMsSVno8doGpZ9+QfCoUiKoPXJ/HIHarMn1gX+GMx2iDPErbSYe3dGRI5HXyK4ylwzh1QiDfl7zl4KQPzRLxXNJkDcJw1Og7CI8wvBkDdCCrSX1voR6ARkcQgkM7r04Hq9EqAHCcALNhijqtrW1hLRQPVLdkyu1Vt2zF/7IvpBqQY3ycc5SY0q0dzjFruvNP4cPsGUFN56Bhg5libKmgPUlbpzNjyb03ZL/6dv2VbW5d9sVxWHhpPFfN+BlQcHw0In/SN+fN6/jiYjGw+uJTmsR4BLZlO+cqG4+fP2opsNl7J/fo777T7jhyynPo4ns/bXUcO25F5eZD5jDVlK529tGyrO1v+aFkuLemJvMYWGQ4+6gRcTG8wyYrUwsDnHRMM0jpLmwXwWpsX7GYtXxmz3/61z9vHv/Mt9lc+/DZ70z0HbGKibM8+/7IdPLhgk2/VYIjtBOJ7CDYPtCEE7QLRkPYCCPT3P+KBUOCfR/Kfa8PNpZNH3wgKrnF8/Rw+U96wSs9LcF4pzgGryAhc7B1YnLB5w6iE+qLMUYPo2TASY51KHEhsFObpsJeG8YpjkV+1IVBtxQSqgW0tUQ4fvgyL/Cqj5qtHuXfob+SlHG+o/unPz8mha6iaruJH2/vt3TJu09stq9eWLJPOa4TH5RHKrW+wHl5MbMgr1JDC7uN/IDYSlxhuwgpgGpnVRs1OXjxv33rqWTuysMfuv+te69RbtrazLRAprSTS1a1Nuyr1yAtApqdHXEI8e/GyXd3Y9Tk6rB8mWwuqfyBvrycVyKd5G6267exWHeANgR3HAnA1BKodOQKJDLeMElYcG7eTp6/YFz7zTQmzXRtnymK0IobV7HX33WWNw8vWSGwHswTxAkVCd5w+7AkOHo6hHwwkvX6+9AXwQcEwakMetYfzQOMACC5QTsQHj4MVQ2ARQvxwG8Z6Or82LEch8eCfjz3kdFekN4BCtPc2sHlcABigoaRIQPKfVQ10FwnFHtZRHqKyKYnFVAPA2llBaoVOjM4lZGPJ1hqRjZUTsDTyE5JWBGHbA/VSvjsAapO/L6qXtDevfsCe/Nw3bGm7aV949DF702vvs5jUEKswR8dG/f1WXQEGkZ6R8Z6WZJHPKAkjGwxgYfdI8mzKznrs5RO2tVmzqUrRJqfm7ctf/ZqAxlM9Tfvi48/ZUyfO2latZaurO3bq3KKdOPmyvMQFS0mdn7y4busC1KW1dduVNGz3WpK+GUuqjq7imyq/I0+Qb/igLhvttj9t3cZmEONxGjDguZc1W8zZ6WeP25H90zYzxWfsBsonicv979tWrZepWgpzQT8Y55t0FxIJhvi5fn7nwn+owiEARUX2cCs6DxLsOq2d1wAGikNr0BPl8+PA63CkoHiPJp8Swe8oMmpf4u2fjF1f806lXhmN038dh5GgDDr3wmD4sNCgDrVXGvStpwp/OpfHJAJJI7gq3JUq3Lwq6SEt5E8/z/RtdDQhYPFabV6JOFSDkkpevDckan2ou5yYsNFn5uwPPvtNe/SZF+2Wmw/avj1TuhxeP8Rj8EiUnY0NWqB8kl68tyrDC2opR+0Rwy7h7T15zC4srdvB6RkZ/jn77c992V68uuUPkx4/c9FfO1SVZFm6um7LSrdY3ba13bY989J5Gxkds5aMzFVJrarEVkoGOM9cpyWteIRtS3mZy0JK7eg4KUDxDlKo3BQIfSBLWgG0ZKFgo1l5pgWBQbZhqVy2YqkoFb/pKnxwZ1UDS6rQaaF88IO9UzvwhbhI+pDMnxMlXnGRBIoC0sy5q7YFyUZ+aSqYSTJFUWpAQAAZ6VxgkGRYFMckofzAef1uSBBKVggFhQ0euNgM7VMiatN/MdvXM3sn/AK8CmmGJV0rR3/isfZqlADGm2YIFMsT1iG9GqRBG0Q8+wBa6vEb37TTjXnSS7J1C/bMN2QPLW9bORO3W/dOWoYFRgJlsyYpJRurLiRj4/TF5Faz5gbtQAY7Uw5VGdknz1+yh2W/PHH6ogZG0s5cWbb/8jt/aM+fu2LLFxctG0vJiF6ww4eOWmFs3tbiOXt8cdOOnduyl7W/Um3ap//kCVvbqNmmjrfqXTt1dVNGfU1g61ut3hDAJalrddvd3ZE50LaavE88PyQmYOGNNjw/yDlPXG+sr9i73/UOm52dktOBKlW6bM5SUwnr5lhLERjmQIEH2mDo9Y1BLnkmgrukcmoqkCfsPF+IgsZKwzXyenwon81zD6/pwPeUTT0hIESG1/TzsnSGNCUuCom3fcIeomFBDdKAsI9c1AAm57ACF7wZqkz/tLHm5trxtSSK6zE6ZazWY7a9qZG7bFZdk0ejoT0yJ6mFAT8iGwOJxb01Hz00DqkZiBBK5Fhmr8pNNQp2+g9qkiYt++D7H7D777vTFpeXbGx8UqlkT8nGgTQo1Y5UECMRJmPLoDpW19ft+TPn7fjlZffG2mL41x5/3pZ3arYtYLbSJXv61Hl79vyiff34KXvpwqJtSdUVeRw+0bWrK7uSUjVbrzXt0uK6gNryAcNnWhLJgRXlvfKFCyiAOuxiyIuYpUrZX4tEO1BzEBajntUOfN32ptk5O3r4buvWt0XrjkyECQ2QjjXmdmx94bTIIptRA9t5q+zs2OAPjHUq6dj553QMPIh+IWMIATBhf/14WLboHqSPx14rmwggwHGkfq9tSBbK4jdM78f/5IvChtLilZEON5asAWAgW5ViMOkaV3x2W2nxeHjMHhuIe/CAC6HkYp5jAWuj2rf19bhdPjOwqy/F7OoJqayRge27x+zgUbOFPUmbGB1IHWYEBrwr6rsRWESFyVEaWRiM2Ys/Iilz8or93M/9XfvqV79oM/sP2N7Dh+WdiSga7YwsOYi2K3WIa57gJWeJnD92f/riFXvswhU7cXHZFlerdlbnvMKx3exbUW2fKpq9Rl7hwr45O7jvgM1PTtrCzKhtr161znbDrq5v2VWptq1a215aXbMvPHdMo7drc3Mlm5Z99/H7b7eb5kZ8agKpU5faZf3V9NyM7DyBqdmSId+xqiTrroAv6FtX1189u0cqfb+1N9ZscfGUpFnZnjl9yqrvPmmtypIGqaRWH1MBmsM6QrC3ovMAMvgmfjGN4BG6oN0rw/Uy4LF2OmVekkP46QDhVUiKYGAijcQGD55eAanldek8qoaJXIqmXboWrnhdFOjIII7jkCnk0rE6FnXGcQvwtGeiECnh8yger7QgTXvmuiiTF+3zSzK6XXuhWslNPWq4EvuPKGK9QSEvBXE7pJVq2r0PHhQoR60iwKhbUncazf5TOv1lZAyjdpzSqqON5BDgWq2W7cqg3pZ63BXDXz5/wXZ3GvbJd77dHvsf/8Ee/48/Y3/4f/8j+8l3PGgfX9hv75cRfZsA0D9xwWb6RUmiORspj9nh/Qdtcn7EXn/LrP3SX/1u+8kfeN/wZW4pSTa1QpKRd1oxacqrlCamp9TnlL9mUqPRJVibaRGpQD4uUJcHu1PdsMVLp21lfc2SxYItbW1ZdbZq7fENgQr4QSsMc2gLjf7nDXKxJ4RdoDf7QOOw3RgYvyFOW3Td98h9foGMHFAmW1REVBcmS5TXLxGtLfHg9wdVSELnhfZIO66HB0jpVmA7hToYKNT1nw6V1sFMYxTlOFDgEXYmveW5+xe/mGpo6jhdGKrCSbNKJSbi930y0jsQmuZ1Rg335vp5XAzjdknC5nYOWGlsxI4fO2aF8og8umnlJ71SY5/IA6TtfiuItmv0MRm5trtrx5c37OzZ8/bdD77R3nnPLXbnTQcsPTZp/fKMtVPqb7liprKrhZytawTw0YGqOHB8+aKdXLsipq/a5k7VyqWMgJaxW+dntI3bZCVrs6M5y/EAqkDETXW+SME7GVCJqDLU48butlUFxKakGvcpqwL8fK5gyysrtiEv8utPvWiPPPaSHfxzA2vmwyoHJ04MmYcnOCQwagFycQ59/DDwgPuKnkSREXBCMq4H2objYJNRVuAdcVCckyFfya2463lCuUElcg1hw1HIGy7K/HjwkwKWGh6SKQ5ponO/BcK50nrD+AXu+/07L0wbl0lJY/wVSCIg6314GUitE7fa7sC21+K2u9S3nc2YFUaH72wQsEpFqUGN8iw2kBqFfaCB6WWGQGcGlhIw2nEBpjknD+rVdqT0WttZWbaOUDsxNWq5kREbtOQRqhNIQwqgfdiYMJiJ0668t7qM+tX1TTs6N2fvfvXttneqbOViybZWl+3Ey8/Z6Uvn7aJU6NLmptTeilUlLS6sL9vppUVb3Fi3enVXLepbIRUzvhBWYlWqQDwxOmJlSVAW8e1Wa46DQRfbkVs9QcrzsMRmbceubO9YQ4NyqylQSYKlRafDs9NyAhq2JeDvVht2x+tus8Y9pyTh+AI+oAz05xh208+Y6nIeCBwMKuogsHMwOu3CBsMjtQVxAhgoE2LBedSeLjowQozHuTAKoLo+y+5J/LrXoXIRWi5Y9ItssNhPfzkIGYx3CIK7j2pzb0MJPA5OqcTgDNBsClA3PQL7SqpOhbNkRN30uHpzIELKrroysMsnY7b4/MDWF80m9sZt391923dLzOamYzY5ErOiDGkCZfpNTv3ReieICOirANr77Pba37Hmass2VlYtUV23dGvd8oW0pXgNEK9FlGTwqQsVlOT+nfIjPeq1hjWkMtfEPF7AMVsZt3wmazvyIJOpnC2tb9j5y4t2ZXPXvcMVeXQqRVJ3IK+u6VMI++fG7dYD8zZe4DN0E5ZnSY4kDZ4oL6ndrO/ahkDJGiyWNLM2ineRZqUOncAqa0OgW9qt26bsunU5DtwxqKST9oHXv05OTc6W5Shw//LsyAvWu/UZYWhTtE4rMwTBvtJuGPDOw6iP5ErgBQESEiJQvDIgyYnlNprnURokfVgMMCxFvAVs7p0Tp38IHM6CeRIAROqQS0Eg9zj9CT9cDJejBF6QNr/kJ9eyhkPPIuniCbBvACbSYghEdZi921mSYDxU4SaX4qT1ZH9oU3q8KYgTjWqvTHvKgzgyVwU07st1be/u99vayVU79eIJe+ncKbskzywzNmN33HWvrzCAwUg9Jj+ZQ2LGuyvPi9HZlOqptXgzH2/yg+GyzyTJRkYFsHTcH7efGssLQHH/NnReUog2sZx5Yrxse2enbGFs3MoC6x4Z6aNSk7zEZNDlNd7mNhMhm8vZVrUqb1j1q/3SdnZ1ec0uX1myDYH6kqTlar0p6bcl1ZywqgCfz+csIQcgLTU8KclXmZ20wb41kaKuNmBHigbql0tz0QYqOam0Oc2QEH7uYiNsSh+Bin3045qDyvMBHOFH15lO4Jxonao4AUh84ZpjSIFrFOHqkmvOt5A/lMw1tlBX4u0/wARpkE7kRVqxd4mlRGThv1fsaFGDifVDGq/rSkAaz8MFxbW7LGyL2c5OzLZXZGct6bzOy0DiJjvY3+Q3InurmAm3WAgU71VATipxmiH65dkdf52tr+7apaXLvg5qY3tXNlzDJiQVuv22La6v2pXlZX8QwlWHCujJyONV3VuSEqgZwFQZGZPrX3TQsF6KaQnAwRtkJiT5ZmU7ve7Ww3bnwTm7ZWHc7rtpr73qlr12s46P7Jm2UYAggAFcbir7dItaDIFZEtPpykhXgB4NOQ3c/2yJmYtbVVvarsrOa9ouX3XtdzQQk3bp5JINmlXRQv1oVa06qNrGwqPKv2uJAbebsYOGPBEAXItosNJmsdgHoNON60PwESJQOWfFE665Ue6FkTME5zoM1HWXA7oWJFfAgx+qMnYurbjiZYfroac69hP2aomuBWAp0kGhS0ieKLitpXgvCJDpz8+9gUEqUSBjxTuklpGdxskOlSQRqLYH/l6snauKawpYEwLVbMxGJgCWbK4UnqJkE3VRIMSgDspT4H9CLnn1xJydOrZqJ5au2LJc/wtLV+3tdx628TGWBqdtZXPHJyK3d3ZlV4kh8SC58AC7ahcL/CiH9ep8Lzot+4hXQTKVgcfo9QkUC3Mz/n72g7J7bt23V2DaY5My6CulooCZdI+vK1Aw0alWel8hAkwBVNQFqWEINNiRWt2qt+yqgLUugCPJfK2a2rfTb9qe1zbss7/+osXkIfKike2FFyy1d0OZpZr8YV4oQInQhEEWABIGNPHDAEO9RTA90JA96WlfOA/g4BzweNHaHHTinAOKdPr5okQSKA7p5MH5E9J7TX7Zue/88/ooizSehcJ0MMzujfEGKTJqfCiIlgzjZPv4Ek6fX/H2+RO3VEAzaR6bqOM2Z1/GLNnT3HCW8YuRTlm8DSV0l3KDYRqkpndVeVBnDUsdfdq+Ii/w8SdesG88/aItHEzZu9/2Btt3YI8d3n/Awc7Txu1kxi6sbtp6veOMZDVBrV5zKcNtFR504KYwKxU4Zt067eJzJXsXFmx+Zs4fjkgpLVKlKqObLjBbzjedc9miPNO8S0a/5aLW8yUJ1rMzxweZWR+GJKt3elaXOlypdW1lt2WdRNrqAnhL6au7SZs5krLXfGLd/sLvqa4HL1v/Ay9Z/rUXbKABwf3IZAyJxWBn/Tp0CjyINkAXrg3VpVJgKwU+KZ8ktHNB5/44G2dDAJDGV/Wqc13sKbQhnNOed3NcU3Ve1LBODhXc7gqw8EB1kYplT8LEO/EKPYsuqGUpOKtTEsP46L9Xwj+/4BevB0c03QpXkGasGm004z7dgMTa4k1+imNlA7PulXF5hDxIwQoWSQKA5CUzGlRc8FooVQmwH8rrdudbBzZ3JGHv+UtpaytN70xRRnzD6hsrtr5ds7VWzY6fvGDLG9vWlkfKlyK4ReKDZEjQTDanfsbdWwwv/09boVC0Il+XKFYsrnPu47ECNcEyZ7WCtVwd0QcV26lL6sgmYkUsDkFd0o7RsCsbimO+k8OyGIBb7/RtWQ7BWrUpByRhOzLeXZqLofXBjj37fNXmDiRtan7ZJm+u28is1KjMtW5XDPYByh0DaBtCAMSQzvBhyIYIKNE+0FL/dd1tIO255iVxMszjRrifckxcuEw6UruW8iTXyyaN1xGK8UB6gsSK77mk5pMIkQl9bkj9Z+HPwv9GiP3sI1IiDr8gsXDV/QIo5aF9BUcp534WQsAg/0D2dUCyyJ/5LNmptr4Vt4sXe3b5WMzOPCtRLIm1cGfc9t02sL0HzCbGWEwnkS81hKPgg1N5k1KzbsP5AKAN2ARDNalEPKiQSo/Zc78hyXBONlt/3DarHTt46722enrZLlxlYVzL7rlpjy2Mj4X5JHUiV5Dnl856q1n3hNxH7aLSUIv9nuyupqSKjHrmbZhNZwRjhzWafJm+KU82KduJV3fXXE20pGqZ7ETlskK10+NRL9pookHLNutt26jhlcqQlwGLh1+T1Js5kre//HMN21pr2vPfStuxZ6T+UgWbnEzYGz6wIWlX1fhH5VyXDtxRcOn7ioD6IZ7rLlVEaGRWTwx1LaNA//3YJRYSKqwODunhoccqV6iM64RQNyoOfrCP2qPrJCEf+f0QIwiVqON/9RVwQWJdUkRQi6Fgb4POgRRVIlaveR0U5fk4j8RkaBi6fKs6sPXNhF260LdLAtbZ5+iYAAWw7jAH1iTfhM4zicnjUyqb3CoHzxKQ+6oHb1YoWzsFGS39otrWskRacVJXfNWol2zY4Nysnfovc/K86rbTqKvsuN21d04ALimN1KDUHIMAYx9GYMTjNaZzBf8YeLMpYMgByAhk2DQQiakKwMQHpi6trVlV9s/27paDjg8TdFktKuOcOw2QAi+T5xu3tnfkDcoMELC2ag2pyL7linmry6PliekPfPwWe2n9GatuxOye17XttlcJ5Kr31LdGrTylQTBxRgxL+DsyApPZO8k9BMAFukTAcvuGa9o48jVyOony41iEFCG4KnQCD+lLMkU5DwKxPcB9L0JRDH4OPcLVMnVQqtKAIal5z/1vvhbSEbyhtGRYnwTMtXAt0Q0BqRVm6IVSnTMiycRDD0isja2EXTjTs0svxezc80qh0brnjr4dvDNpe/b1JTViNpbnwcgALCpx71QddleecocdBlz0AwMfCGKkQpBuUpKgKxtNafq5tK19acHOfk5GckOGd6dhN81M2DQvM+OrXZJWmLB9ialsPut2US+R9zfVNNTuq8tXrcwLZpmyEJh2qmGKgonP0clJX5bckN1UlfQaHxm1FhOukuq5LJOyPDAa83cywFBeQrLT7NjmjqSnysqkU+afr1O/eLfXh3/wjZY7+rBNz7fs7NmOnX+Bh3C7tndfwY4+sCYDn172JBWRWgxY9W8InAAo9qKDc5yNOKUV//gOUAAUeQIouOaLMj0v6ck1zA9rKFp7P4WnOqAeQuRBEo/aoSyu0Co8XI4oh4EExnyQ/ZuvYyeCPAoNUkV/Is71RnAckoSKCI5LlzKKVRoqDo/c4xX1bbeZsLXVuJ0/37VLz8ftwot9S2ZjNne3gHWHpNb8wMZGB1aRVEkM+Iq8ylPvKCN6ZwQrLvxFGFFQ2XHUMx6pUMpN8XD3XR1RGzty4fkyxfO/ddCWvqx86iXrmviEbj6fUV96YqqkndKzfCUmhq9KopxdXBHDE1aTpKO/BXkVvCSND5mjXpoy0lmlwONaGwJKNs/bmrM2kOpjkpSJYV6wlk4nXY0i/erK05X0gvBpAZVXI/mnfeWL7N8zYe/56HfYpx/9lDpUkzcat4N3JWzPQkyOwaYcD27TqI8ARYCFH+KEdUWnKIQ1bAwwJdMRfeOuB7wS55wuSCT3BkU3yTT1xS9eC6xOITCYqQNBMZAX7veLIbYDhjYAVCXQhifJcV/Ap2/+7jMey5NE1p/5d8CFYAErJmBRiPKBdjLrGMTDMBXrx6GaYSPYa+ODTGQFdLA6zG+ocI2s7Vrc1tYErLM9u/hCzM4LWLliXMAa2AEBa+9sz0ZHYzbCp04cWBBr4CpIvpA649ARkCgxADw0kw5Suzqt9LQNCcGvw7n2hZzZi79XsdOfH7ci6k6xcMDfI6/rSKOmbB5WDMhqsjNXVsJclqQTc2DcW6wUy1aVxPIlO6qDm9rcfCYvt7bxnntSk6Vsxh9gZeafSVPukTJ/pmpUlnxapjSUNpVOWD7Dh6Ja9pp7brP3/OC9tjL2RdFn3vYeSlpt69ck8fhal9oIgT2oj3BgyADW4EMCJJebLkrrH0hXQEtwW42kJPJbbDqJaIRxB+O9LC9XUWgJ9iJsHCnjpYc8PA1J2QDXAQuQBAymJtgDoLbi2NRt9ZkXGfPxKQFc12L/9lGnm4OJAybwvIFeBRKDirytHhmABcODcwmg/NWO2kNA9ujcLWmAtfWEnZMqvCA1eOHFgRVHBKx7+nbgtoTtnZMqFLBKOYAUXtiV4LU7+vmdHnUOWDNzrW4P7QiMcBqDkSq4yNgmYDex+QOxtF//SvmUXXohZw//fMJyiRHF90UAgUuSidHM8Gw2ZFQ3ZVzXmSJoe99ZGw/IWKrLcmnuNRKH8Y7Kpn6kSF9AKksaViqlMNJla7EUZsDNYSZQ5TDwpVb6MlYuWDIjQKrMqdGSvfbee23s1tvtQx/5a97+33hs0WKFn7Pd9s9YasB0SABzCKK2TmA+iwKhP7QIKxMkscQ4qN+RpEE0uXQSHeCf89GBBR+hKYRViSqPieJuJBV10fms9Dwl7pJIBbEmqyvVz7wcUskBpK3dAkwx0UnXWoAq7pPfvabUoa6Rzx+Q9U4MNxePEE+V0IDQEsCkvTOQKO1Jq0M6wqAhPqRXnE7UbTEKMal4oRmG8EwhaoMXqRJI7z/fi1nqIMW7+PUKaIs2xUJY/SkANupnMlbHGnVBLbQd6HiXCTG3KlU0eeeuPfiJgjrecqbTC6SRv6Cjze0WlQw2xZ2WrsOJNnaT9kycIi15EBZmlnmTjFCSSUrtKZ5vEJYEGFR1i6dwWCknYqTUprGRklR8zubHCnZYam9shG8sms1W8rZvcsTyub5lYLJCUo5EN9G08exPyBv+hGip+k1OhiMG0yL0X40MXrPoGGQ6D4dowKktkCjeZ3BiMylOR05h6MSxyuKOAXNsDCRsv51Wz6q7Ot7t2sZ2z1a2+7a02Ze9GbOV1YEtX+3ZlStdW7zSs8WLcbt0biB7uW8XTw/s0qmBXT5lduWE2eWXzS5JG12W4LiobfFFxb8gvvz8o7KQQKzaroHghh88ZRaZkU03fDkM7RyCwBmiNKg+aQ/F8XohuovNFdC+IYm1vKbGnJA39awqPcmtHBnvUoX7b+G9WAMbKVv46hcz+LKveAQMSZiALKrEX80DYcGYwKNLqosWQSynsh/TJpe4QkkYEDwqhqlqVlg/apc/vceefPakPDxGdFegkSep7KgsRnINIsuz25YnycvnmIVPMUkqRiAdut2ug5bZdjKmpC75wjx0IB3viRgIjHzplSeOWIc/JkmW98e7wwqJybExqcK0g64gB+HWd7zXXv+OT9i7/+KP2ff+1f/DZH7aaGHErtY+KtB/3oHNpGrKH0V1s1t9UyJ/qJdi4QWA8aHp0omnmXyvTjFO+HSdSxod821G+CKBJBtO/FWRvQ73c4nn3mfPV9L225LoUmltSSNpev88TUdmTQePWefNhupoSnDURWMdd9jkqLHCZ6B4nhtlQUbsFwCWjlEfMMW/LKqGiH+qECGrLsFRhQhYjOQALL/qDOfFqQx+DG86AbCWhHwH1nMAa2ATewUoB1bC5iZkY7FkhlcYoT400rk1QZk4BYAKkHp91OPqIahgVR0ABSAJiufrrN4HEZKR3aYsicp0Z8oKX36rXVyq27FTF+Wtym5S/1LJjAjfdUcDo5aZ8p7q5BuC1+aDRBDmuAg4KEFdIDFFL0k99thRAIl7j7xDopLlm88ZKxfzql+MUrqRYtEHXU7A42uwfHHinvf+Ofv4j/2s/egv/abNjJc0qEySTJJRTsaltY9ICj0qmlRE3rZL5YGAHI8jpagbAImhaidSi31TSOL2TEt9acnG6Qg0gIpbTU0BBrNP2PBnPfstXQdQAlGrof63VZ4GXVuqjA9gdbRvN5Rf6q2j610Bi0fR2jWlrQqcut4TOPtSgY5kJ5D+CqJrUTydFD5+/lFfj+AgEt18Uo20aoOkFsAKeps0zlH9CzJDvAZgHsmUQbC38OoYERvbMX9F5IWX5RE+07OlS7I1Fszm75RXdDRpc5O8Yypm+bTyIst5ckelIQXFJ5cc3P+DeVSHzRWBmsBxLIbk8UYJ3uFendtg2rAfBn28uazNf+OjEudNu7qybksbW7ZTa7nxjnyty4YCSACFFa88VUOJ0ZouVn36alSloZ+Ai3ax1p2XkgBzXhpX5G3KSj9dKvqaMJ4T4Ev2OdlnSdEzLTXKsuWGOMv1ZmbClg+9yw7f9zo5MHQjrrQ5gStjucyunVr+oAj8vPqbkXRhyHTVRjHbASUmq5FyPh0w7HtdXkHJQ8ID1UGauNXqkmgCRxt7COAAJkkdQIP06eq811BepenWidd+KJE6Hqf02jsY2MOIlCqWc5RQmzMCUaYkST4iT3osbsly3PLlnlUmlPIXBCyfHxHD8AK6SATl5QFQbCXnk9gW2Kmga8xnRJIEyRVGLmwiTp6WVMvWTtKuXpVOlh4+/3TfVq6YzRyWS31b3xZujtv0VM/G1ZBcUjYRpSs/Uo+fvz1GWHPQ6hLGe5AgACscB88oxFE/AcnDQxeOAeXHe+mnurbw5PutcXHC1na2bHlz29Z8JURbXp/smVjKJyH9np9qYm6L6QLeIcr7RF01S90hqZhZJ2BBslIipTQ5gSSfkVcrVT1ayFtFQCrJLWV9FTPgSKKSVF9V6rDfqNrM/B47ceGCpe/+qCVvebtNzxT8XalM1FIyH3aqFHuWj+fsm2ffIHV4EtZIQmStoYHiBrWSNiSVMJTVDUkkgQkpA2gEgJYAIrNP8QBF6XUNqQOQyNONpFJNnFXavoDUlRQbyLlhVQU0R0rEWDCQS1qi3LWceJWRAM0U5QxJ02QqHSsoLlvs+8uKc0W0QFxqXt5/Tjz5t1KFPokGsLR3G4u9StfORyjoAWTwmYBUQUK4+y6pFlQYbYHZrB7o2uZ2XMaf2cWXYnb+uZ5tLMt4vSVuC3cMbOGQ2dz0QARUwzScHVgq4BqwKAwhBmqJGSLnxn0EMvb8kCLCFdAO7RajUe2DZM8mTr7Jiqdus10ZA7vVpmy/DQFJalBAWd3a1rHUoCRGVV5iXRzBkAdUVIe9RZsACWrFb/+oljSPyNNmGeVpSaqy7CemHVi2jGnFqtNcJuNpdjc3/D2lYxNztr1ywepjN9uZOz5p8wtFm0hpyAc32PuCCV6QLVcWOEullv3hN7/L1hpPCKB8ZweJ2rdGvW81pJBA4wCSikLadNgAjyQS0qazy9sUpQaVpieJ1NeeDWdKGhbSBjpn9K8gtS9+AKC0bN/sqOzmEW1Sb4Vi0rIVSeYC84ACluzibHYg6RoWEQh74qPoIGmW1WBL4rUjsdQjl0yIWcxUOhjdZ0IFoArFOqwpvxb4y2QmeBBxnfQBCBjbNSnzTXkXV68KWMeSdu5ZeSHrAtadMdt3VNuRgc0KWKW8gJVSOW6UIhlUjhriAFV5EgoOIqYcIiCFaYeoHYEZBNJEbjUxPsPOsTpZWbrLZp57vbXlfdV3W7a5W5VErWsQaeQLMGfPX1GepJjFqxy7/kJaVqXyUAYB9cs8lb9mUlta+VDNgIt3NUyOjVhR4CqKqNMTZQcRzzjWZM+BmQkWF0prJ4WM5U7aXtz/vZYdn7TJPfOWkB5iGoH+QoM8klCDLS10lnNjAmve/tPvvMtOnvuGPEmMbTMJVXmvAo4A1NyV2qoLZFVJVIGHDYnVE3AGGNKSRE4REKstKfUV530ZZdmEowPLlLVVEpYt9y3PdyN1PVcScFBzBexCpUt1ZEfyTcnAkyyDRhoGhw3nJZ3A2dEATKQlFNT+eHroFdIpBZjEK1UZ6UwVuDvrFwKjSOfMhA0gUeTgWKaDcgkQYgBqs6FRsbY5sCuXZbjL9Tz/jEaORtkCt3Lu7NqBg3ERrG8jBYlX4Zq110HaqQwBM3iIIgA2HmpIFSMVvSk6AVh+rB9/vkAQ+4OEDjC1tSfvhn26bvnVm+3gC99pzc6O6pBk4uFUGSfbu3V/TxWG75pUZL0m13unKvXDm/4EPIEJIFFbXsZ5BOys1Bx2WTKVdC+PD5fvnRr1yVJmoH1aQnHTI0U35AEi4NlVvV/Ov91WCgu2/8C0f2i8AbF0nfeUMniZ3shkpU4F0oK8T+y4ucl5++e/8AH7yuc+52W3Gyl5YpK43IdqyKOT6QEdnFnQIiP+SJqkS6Kr1FJStmxqFFsIldXTXlJJwGHZUk6qLC+gpQsCi/rFi4YLanBKkl7VS2ILYKIHwEnIeUjLdEkKQKl41gGE6cM5r3TCCYNG/nTXv/66jHepjTC6hXjUhwCFNeGvehSz4Jccc8UwqIZMHUoOAqMXyeWTYgJKQ/p8dasvgzlml48N7NzTKkcV7LsrYfN39ERU2VhjfatIrKovogn/ZM+oDH6siUfdCOLCCdfCiA7SK2zkop1ccemlcwQfnhGAkwJwkNGPQn3G9j7+Ho1gETreFRP7bqTXZaDsNru2tLbuy4h36h0H1rakVZMXesjuokvYTKy7x/imIYkEKo7XIcVtcqQshsRsVGAYLeZs//y8jeaTAhnTBGqVpBSTrY3mrn2ze7v9YfWg7T84ZocO7XWbjbb77R/RM9zKkRrrd0Sbgk1WygKa7L1E0fYuzNrf+pEP2OO/83kooT81DBtIaildEjPzPcsAHG1x2UAFSZ+sJE9aKow7HlkBLCudldGWy3UlfTRABJJcmkEgYAlM9Mc/2KSyuckeAMMHowCSBhiDXoaXg4hFiKIHL3OBCwCMtnuAR//ma6ACVihSnRTNxUeApQ6KKzDO7zep4zApyktyl17qH0xFWsFSKqnKJV0TsC5flJ310sAuPgcgzQ7cHROwJLkWElIfA3lDarwYhmT0xXwqzMGl9uBh+lIaZaRtLg3Brc69CTSX1auKd0NeUT7LLGD1pf6YAWewpETI2oU77e4zr7e0IsYrWb8xvC0A+WI97MFqTZ5iw3Z3G7YmNbmuDXuLgcY9QvrJqlfvqRqBFIv1WjZaztl4IeOP1R+YnbCFmWmNbLVP9UItngzGw+ZFu4udEfuZs3M2e2CPTUzP2PTsqOyjpkqUOpNxSA/aAndXXh39qEvfjUuizUyVXI1yF2DfzLz9w5/8kD35wuf98bmcpBBgykqtZWVUpwsysnmOQNInLbWVyUilCnzB9hnaQWpfCo0gOjKfl0L6yHPOiF7cWQBMfLrEN2jte3gLgBhYzC3Sah3yT7EpxTmxJH7UdeVVvp/7ujv16hidk40VjXgnjgipAz9mU16Yy+0TL1n/+Mkpd3XEd1yoKKxs6NvS+YRdfqlnV4+rE/m+f+Zkn3+NwmxaRCnlaGQomz3zRl4ik6GKcJHq52HzOLWNY0VLPNHRcMxAIL+DDCGnXzJbtucf+XP2+79w0n7lh++WDSQVoBGXwd2XNOIZwHU1NrwMjfubVUkpljI3rM4NZDGTJ26YeOVDldibLHFmdn1mrGxTpbxNClzz0xNSUWKsRjxLcXgzIfcYoaBpxHdlMf/Mc7OWvuV+K0+N2cJ0SV5eQ7aeDA+1hUfnWyyQVz3+zgmp/91t1Se6IHP3zU5Jgkn1pCVlSjn7+nP/w7qdk9ZLPmv1/gl5alL3AlIOFSyz0JdhI32SbZlVrByRauMWkzzghPqfTCJ1MpZFyghMTGm4vSwg+fd6VCtchY4eHDRshDCIobAPcedd4A/g8L1C7Ge/nhhgZQ1vs1lXhUSTgH5rRkPOQaVr7CWsgaQz2VUQjQFYOqc5fD5jU4bk5qbZyoXwmZOVUxpB8jL235GwA0cHNj2pTYZjLguwgt0SAi1AOoUG+uajJhwzt4TV5/hV4JlDFw9KwyiP9bKiQUPtlEOQnLOv/N53Cjx32Gd/9V/ap//GG+3A3Lyra4ZRV0Y6GxKFR923d3dseXvH6eekUZtqtaY7Myzw4z1XOBfYVXtnx2y8VNQod1dHo5z3XTEHJcNG5cMgt8UkLrBJ/v2Zg7Yysd/OP/0te+mZx23/7ffYez7yfZYfK1prp6Y6mOjEzpLak0ptql7m6HhvaaPN+yj6NimPc8843zKs2KNPn7J+omB7Z/I2N7aq/L9lDfusxVMXVJ+kqfiGug5A4Rs/TPIGKYQ6x90ijiOcHnoMH6Ax0oOdg8S1AfQKAbLTFtK75AZauhjhAJUfpqKU4p9/Nc5Mw5ClzF8NTxS4Y04qVBWuPNN01z3DwGzPJdUDwzC8ez7yTcAaSGLFbFmgWjsn43dCwLrNbO8R3own20ReCG+ZoSEEynSZqXoAzzUwafSy5zqEwnJRhJ/7/JJO3f4TIznu+PKUSfvGZ37Illfytu/QUdu6csbe3f6mvfGe20V01cJgUXpebcR9PjVCIzdpdTzC3fDg6U6zppqoI+W3angNAKPePUX577wPghfYok74QFM2w/09nkXU6Fe7mHGv5NP2jd2D9umVkn3ml/+5Va+eUd/CIC3P3mLf+Zd+3O5+6xvFEDkQLalBtYs+sgaMzuxKPfN0Ne/UQnrPVwo2Mz9qv/mZL1t9myHetT3zB2SzHbTSSNfGSpJe2W9ZNnveYqlL4ofywU+XPgBIvHOeDfkt7eQmCD1V27mOG0W/uckPPQnihKcnhBeTaA/fhqDjmOvXgKXjxFs/OXiIgpyxqjS8+8h5NywMYEWNIZJjbSEqHCphBARGHh8NqDcGVt2SJ7SukSig5WULjM3EbXQKY1jnPE8okR0aT9Mx/ly4ak95IrAOaIfThDjaKYZh86Fq2m1tXYGj3dVxz2pyr+udkh372t+0zfU5qxSzVkh2bG1j244mVm3feNk9x/CxAoFLqo0+8aWvVFoAkT5hxhw7ZDRfsJFcXvusjUkNjcgwZ5M2lSSSXaI8eR7CEKggLECKYy+CcQG2kMvaM4mj9q8fXrE//E8PWXt3U4AvWww1pAHV3l21Z7/yGdve7Notr3qVPMS88jOdgN3FOOnbOO+TF4N5ZXdJ5WVlbLVbYn561Cqjoxqgk+pPwx55+Cu2srwhqTsrjr7ZWtW3CPwPiFb7BHKp7zSvHm+rLBF7SG/sV+zQYNtqUz3Q2leVkG4YfFB7XDhmYLInAm7RVv77Xv/AEv8FrNhDwbsScQQawOUAGhaC3cUfjPbcFEcarlOSQuA7Y1GqU8gCWLW6XPYt8/kr7kEV5OKOTcl7ktHJe0cLks7YIzTDAaR9tMTV78np56sQJCqZaebmJnYI7watM5fTkuEtQ5eJwqrqquKJ7ij/5s/b2tUJu3zmuLzRx+3lr/+JHX/uSXvTwQm7dc+kPzzKm/86srH4cgT1s7qTmXZUBV/xiqleqMCrj5BSrKnKSxJlpNr8hbTaRkdHrCTjOiemc99MVo3UUN4GMLJcsXPxV9t/fPiCfelTPy1AyTjOFlRfW4xmRIvCSCYN4kvHv2HHeJzt1tdKGmnU6VoDtSvg8tqjsgBOXKvbFKAFLtlkTz7xgjXqTavu7KotFQFsWuYFbzbs2enjp+zp51+25TVm8m+VE/A2a9ZfL5reLPzkVb/Ud2JD3MKmwx3TDtVpOfFTHRmgE2QnDq+5NHKpBucdCh7HkXuJEdB0Ht5GBFgErLf8QPIhLgZAhRASaiMRkToPoIuuqXAKVIRPMSguimd2mqmZILHMarK1es24lWRTjU8nrCxbq5hXN3xeCIkV9LhY7aoAI5ppGb9v14k5eOotwKqyVC4vy92t8R3EmIxfOQkbKVvf6tql5YHNFP6lLV+YtqWLlywpj6woN7q1s2KL516yO/bP2v1HD1hH4GVSj+YiudybHToJbUkaHhfrdtpOPF/pIJuFF+cCBJ91Vx5fYQFRFfjqRVmqMp0SYONVDZgRezH7Hfb3f+9h+9rv/TeBUQpLgMWwd1sSMmnHGGLyFh7tLJ+3Zx/9EytNH7Lb77zLnSA8RiZkuxpVSFPsNRYX4kA/9thzVswUrCf7qyZwtRttmR5bTr+p2Rmb3bsgwJXs4qVlO/7ySbtwkQ9u5jSg3iT6vl3e5z2ig0a42hBPi4iJmprVElDCQB/EZTNHYCAMcRA4HAXRTREMEr+gNGg9CEvWxAOfTDwENr2gYQGeQIFO++EQmUgy33TsSmuYLkgzriCxcOElrcR81KA0gN+rKkoVlkfjlisOfE0T0/6+TkiEY8kGUq7RkBrVJntWEkhbNWaim7aYbW3zVHVcai08pLG6LtvtasxWl/p26vjA7jjwf1tt/VW2ePa0xYRC3kXaqMtbkpG9snTRkhIr3/XAfdbhLixBbad+NwFQrxoQqCK8MmwnHBhUdalYUP80opMpAa/j0islMGFLAT6YySfgEnLZd9IL9vnOvfbQf/yUnfrS71mmkrMOUycqXxU4HX1FKnUpXqiWzaiyxdBWdcOe+8oXbXm3ZXfe+yorV0qiQVWSK+0A8hlutYG3LX/r608JyHJU9Avvqegar0/CNhuozdwo5qENFihWJio2IvtjtJK3558/bmfPrtqZ03JGGreJh2+zTvU7JBlvV/Mm5RDUNHCG0kwBvjpXh7yFDvTZhQh/2tT7oYZB46Dhwj72k19KhqXJEmN0EukRvvok8GhkUoATX5VhwPc1+thDFy57BT76uCZJVe/4dMP6StyWz/VtVYY772wYH4/Z9CGpwjltoz2fdU8k1Sjl7Uo6sQqR5RusB9ppMHsv6SWAct+lo2MefuUGak8AZG1Qu879sLitLPbsXR/9GzY2+gE799zz1lxf88Yxmqy5Y22JzDPHvmm9nUv23C//PWtscy+w5dKKd77zuJYvjVH6eF+GshqLalZvibK81I+PTJXJY2oQEHGD1OJd7321T9aRPbw1Yj//9JZ97YtfMNteFGakartSi8rszwZoADUFdLzKSNrBFlihFH7W64aVFhO3PWDf9cM/Zm944H5bWVmRLYg3SlskwcSb//off8dmJuYFOkl9xXH7KSP1XBrJ28TUuFRv0h2OrtQ97zpl4CB5iwUcC9lxEv07YtLq2qbl5GCMj0/Y7OS0CNCWbXhRcY/KnntCbVuWalfF6q/bVqKPqhdwgI+Sqx8OoiEQQVoklBJv+ET8IeUcSiyOtBMxHKWUokAcBlzYgoFOnL/HQJvfY1TnsYOQOLuSMNUtSa01SSFJrIaAxuiXB6waUakCkYAEeOpSaS6ZtqXeJIlWJIHWr8Rs6cLANq7Ibrrct5XLAurFvm1eHAioA1s7mbKNkwlbfq5rb/7OH7HZ/R+2S6fPyEnYEYsESBG6x80ybUiTdmPblq5esTfezusfx9XeIKG4jYKXx0MTSCBWd/BoGMznhSHE+/OGajYjlvuI0CSXLro3OGAJcKtu2+U5e+8//11bPP2CdXbWNGCktmT7lMpFtaFjndq2l8eb/RjtbNAfGvtKUQivgMRhkrK2dMaefuRLUmFLdvDm2yw9MWq1alWqUEZ8qWQnT1206Zk5y8vgHxkb00AdFbDS3n5GeFp9oL0MWm4ZhaVEgrBGMN/VAXTcipqfrdihA/sEtF174cVjtrK6LG1Rtnzu7erXGy2XHFWrjvskNuWGeVC1ncbS5CFeruMC6RXiEm/6ZMZfChISB0nFAAJSQVKBSI6ZiRfaJVXaHTGP2yICEmuvfPmG21UY7VJZW33b3YhLesS1l7TZkciXCOXhCyrG2OUGaqPat5pAuIv3uCoVJ0CtLsr+vhCz5ZMC0xnFnZYddVZC4KIM9EXl2UarSJXISH7rx/6y3fGGj9sl2VCbi1dtdGRE6lJMlK2E/YLVj4HcbmzY0vKilTM9e9u9d7o6SggY4WUkoTy8OnrN6MfWwr7i/mRMthESJol5K6CxAJEpCl7VzbvcR2b32d/9woo9+dhTYqwk8ZiAKyiOClTbq1ckNAGVQK6OQ0ekodPa/yNZA8gIDriYJITAHO/WbfH4E/aNL33ZtrZ2bd+hI/LucBAStnh1zdIy6lnRym2nnc1N0XxDEl5SUfYWcbwik4dq4SkLGnmNAR4/XwvhPJKUzPYXywVbWJi0gzNH1M66nbtw3s5eXFUzXmdTI++RJlIf4uelCNpqnwjm7aQ3NJpeXOuAY4Z97Me/JFNRoAFILuZEdAcShFAimRB+/9A3AZdzDT6pE6dVUI8yslkn1BHoGvLW6mJ+dSVh21dlwAsstWpPTJE3OBbuZbE8I59VHhWGzmYBWr0qcMqG2l6TbSQpV1tRe5iSyCsP635k9JdGU1YY7ZjsUnvg/p+UR/YRe+7Zl6169byk3ZrsuJIchYbslZo/lsWNYD77Vtu+ICBctqMyrj/2ujvtda97dWCowMQjZ9znwijnfabMWqP6WOCHREtKEgwkKbKjs5YojVnG3dqKKcIqU/P21Jkd+9hf/Qm7cuGkJdDpAlfKmra+fEF5i1YZn7TK7H5Ft6y5tWJrl05bTxICsKoFagOelI5BuEDLG2bUArGdGXBuC0kjZEesuPdWe/WD77d3v+tttri8aYtXxGypTl4g0sXTURk+NCSBpbFtZGJMQEzJUZL0lKTkky+1XdFGfSzK9iuV8lbKZyUs2kofwMLdg1wubelE2gqltF29tCTNU5MEzNott6+p2/9Z+Lgi5yLrgwdFHhvwoT1eGQ6CAJYA4sD6clJeIqNSHVLn1uRhIUYxmJhFxzjtoebYBJyObJyugMT66aACxRgRB7D5JqA1JaGqq5Jg6wKWvDW3ldSMVCEhUIhkWXlYWaTGwLKseUf10lAHu9qitjEIkjL0WVRWKoUbp2Xt04W2zVXeab/wf/ZUz6p979/8x3Zlcckun3zW7r7jbrt06aokScta8hwwwvGk2kLq//k3vsfunB2xc489bOMF2XlSB7APhnIfjpeA5ApFixUnLF6eFoAmLDMyadmxOakA2ZWhSfDaGv2Of5U+Kc/snZ/42/bC8dNW21iSGK5ZR1KiXd+xfIWFTBN206vfqkHIBCcPrEqStmUg67yxsy41tStGdS0rV297Y9W67aYlxOhWq6H2yMkQXZLlik3sO2zdZEEDpGajs/N2z2veLkJl3Rbmy2IsOOwKZCPjApPUIGvq3ZAWG3uSYLvbu952nrhpttu+YqI8WvIl1bwMOOdv4QnvC2PqJZuROhU4i6IRN8N5MufcmQs2PtKzm+940fqZTwUpDP36OdWDzanhMBAAqClIrDTaU6dh7ubEWVFOf9gPrOdhMT2L7ru+wB5Pi/IElKE+RY8DUtQIUg6B32ad9E7C6ps9E40FRnlPEnnZcfNlq7x8jWmHkqQXWzrDHXYxWJ2Js45XAY3gn5tL9WRIhvU/3EQtltP2ld/8qP36z3zB+s0l+8t//z9ZYny/JME5MWdFaiy8yY8PnfAYFnYFgyaXrNtP/b2/bocOHpIKyfvNYm+4iCDZ6HUCHs7Q1aw2QHq7h6jREl7tozipc7y8ojryj//tr9s/+4X/KAm0bcl+U8Z51dVFWoyKS6IdvOcNVo9jRAtMfQFFkhHm8lgY3yFEmuZzBfVpUuUjWTesJrXmL3UTqNJ8dl/92Fm9Kg970ZrLF23k5vvtzgc+7B5fsZB3VTYyNmJT85ShQSzbpMk74msCuE+2BknCdBHaAcEIYLEdU/IwsSexuVhiU1B5YR6POUYe8GXCt2u8i7+cm7BUrmUXLzWFhbP2+tc9Lxg8LBubT+jlRUZAFQXVhavKm3urTXWgDmn/LPxZ+N8PsT//G6lBSyMct5lZ7qWT2CWSMpIw3bakFnZnOympwxLXgbXqEn8ssZAkQbYgYuPpRDCWNdzTPMeESmQpLHNSW7KdtM+XEzZx08Cm95lNzMdsRA5HIStTRSrR1wLJ1vElHTgPUpGMLAksf2coLmtaIysZ79nY2P32F943apee/rra0JQRO26vefuH7Oa73mCTsmWqkh6XTx+ztSuXNDDVQqm4zqBlL58+a9/57jfZj/3577Jium9zczdZU4aqi22krf7z1S7uI9InekZ2v3fGKJfE5IBl05niiP2HX/uC/Z3/6yck2SRdrCUbsSopkPEVo91k1o5IWvXSMgZRbRq8PY3+rqQptgIPWfClsnJxXFJn1OrNcF+SNmRyvKurJPUktay2sUSHJ4k6stFY+MgXLvi4eUv9zEjlze/ZI1sqbZtyWpi3w27lZj0LBlnOwuOOCA/61Bef3RNVPag+7MdcQSYB/Yun/WUnfGOxXCmLdkoXH1hGNhrqsCLzZWyUZyKz9vQLp9y2/eG/+IDlSl+SSfB5i7c2RQWRaFh+7J3/IjGAAW3ZT72OPI7nUHtSgaRiET52lTy+rhyMaE019+4SZe7/yaguYQfIG5qQQV6EELKtZKy3t5OyO7oyGMUMVipOxnyh38JCzMbHpUr46pfAmZPKQ8Uhglnz7qKYd2/K1sKQZpGZjlQn9kDMThx/wP7W95+x7uYJTzeQ2ujSOCm/8tQ+m9x7wO57wzssK/WytbEl+0WekhjSECN3a3Wbku30gx96jd1304KVKiUBQ2CSPeLTAAISXg2GPSCJplvcz1Z7MjEZ87my/dpnvmzf90N/18YKIqJG3vb6mlR62QbpvNTgiO279T4b+PxReA0lthVGPaW5ZymmjskJ4O2AeGpMf/jrK5WH9zwAdkeC/pEfYOClMvD5AEOjUbMx2VOTU+rj1pbtbO/IQJeno2xMadD+jkDMMmEeFCGg1v1JI/WDdP4dbdShVCqTv6z/4oEOZvtzAlOpTF/UJjGHD3BmpTY311f9U3njckiefeYFO3P2kk1OTNrhA3X7ro8cV98uyJwQWHoFix35rtFBfpRluC2XUFcfF5g0kAFWj4cXZRN4SKlTOY3ffN8m9iStPNuxihwk2blWltdWHhFChFlWQmyt9f3V21cvyLuTrTU+27fJm8z23hT3hygmS30byRbkOqfdc8PtZ44GMLFJNom2rFJMadQEpooWlhNwf+NXHrB/9Q8+Z+m2RpckUUIEw7NhGfFb3nOXPfH4SavXyvaX/sHP2cTUTba+dtlWlpacOQWNPF7eX5dr/gMfuNO++52v0whTXbJNvAbV5QATwHUhMJigPXfQ4gLbp7/0uH33D/xVOzg9ZS0Z4qtrG2LwuDVkj1bmDtrC0XslAVjzxDN7NW8XUof3NrD6A28cW4ZVmJTrLxyR14VdSMCmiQBF8HX2zG9p35Bxz6qKffsXfL5rZXlVKQf+rnrKwr4K9yLFO/U3zRSDwBTWhpFEUlkN4FWZvoJCgSfDeSGKXDDZay21jZf3Jm1ictxXnKYk1a4uXrbNzR05UeMaEGWbEKh5CHf56rrbg61mTPyv2jvf97tWzJ6yWFfAmr7viAbWpkSgfHyNnrWzXRmewlFJEkgAKHAbptK3jCRTrqLjEYFC0qes68WimJ3FuEOlyUNR++uNuG3IaF9fStrZlzu2Kmdp75GYzd0Rs4MLZtNjCRstpK2SGROY5I2wzFUjRvjyhWjAKi5J5O8v0A/Wck+SeaZCedT++l/YZ9/4wh9bsimPKiYvC7Urb+wTf/vP26WzT9kjv6OOJST6+xn7jk/+qL3qTd+pdpy0xcsX7O577rGRfMm2Wmt2/syGfdc7Dtn3f/ANAoCYIFBFFiYM8JGt2jkWnRUS9lf+4b+3X/yFf2eVogCYUNuTvFtr3OJST7P7brWZfTeFtgqYPUkynB6Cv1hO3OZ2kK8+VRzeKFWghnAMAFaQKnhYSCYNL23MsXFekzHO+x/27tsrGlflVcoM0MD0+5ze3iCZfNqkjWcvdqIClZ86KZ9rHlQprxD3yW1tarK0UkcaQXwAxCwPEqDaUlWM61HZLShTnrDOiF+YDLPzM97+xXOLaqNUe7xrR/a27dWv/WWlvGyxm95812D5ygXbvrolgRO3Q+8XgKTmWPbKKoSivAWe4MjlpPakigr+4Uoe/WE9leyFTFgvnVIn8RqrYtLGdsKuLiXsxItdWz4/sIU7zI7cLVU4LdtGbnhFbng+PSrVx7RjRhsTlYGJQTaFlV+uD0RU1t7HWatev8k+/J1XrHHxtIi3Y/Ge3HLV+Ymf+Md24vFv2uNf+n2LSzLEZePE1PlOY8fG995r3/NDf9M/ZsBnem86Mm/JNBOd3Jus26sOVOzD735NGLmSXl6nglgsaah6BQZkyMd+9Kfst3/r141vt0wv3KR6kAxpK+6/VfQZs717Dsv1Z16MB1i5r9hWefLcGH0KLUnKrNtg3MQWk8RoBg7H9BaGopK5AZ2RBGPqx2/oKx/Sa2xsTJ5o0TbW1h2oeNGoPBFNFBt65OoTKg6kMG9F2dhc0JBAmbSNPFxrKy0f3OTWFim47cN78klD2UywHj16xErjBbWhYxvrm2FBaC9h+ULGxkZ44W/Wzpy+JDs62HO33nLZXvV6eepzhw4+lB8p2ciBlqX3NOze95vtudk0+gY2uz9hkzPaT2mb6Nm0bKMJSa9xbaNSSyPFtI3ImCtnJqyYKWvUMyo6XjkPLLCKdGeDsmI2u0dlSdqN5stWSAlUskcAFGDyX6CRw4oALfwugJ9o1Gcb9uKzh+3Tvyn7irU48g5Q03/uE3/dfuPf/6zffEalQBCM1r5UxcTeW2WDbdhXP/c7tmffQdtz8CYZyqwJz4oRUhuDtF3elN1VTElFj7lUZIKPujFikRDVTtze+KEftS/94e9YrLqkvGr/+IjSSOruOyzJPmqz0/NiTl/qids/AoocH16Ym5LdFIWs6ORMVqCPSCyY61MAUkXsub0EqAAYt49qsgsBCLdxSFsXo7mvyTvAKCXcc5R0FKA5Jo8DVYBE+gXwEoIdB4F9fos+0k76q6vEsYICO5Q+AKyVlWUHc65Y8LVik5PB1nVbXAOOWX7uhWLMY+zv4jz4mwun7cBCxRLFyYmHUqW0zd+bs72vrds9t6dl4LZshtUIUnfjpaSM1JRUSM4qEmVlGZylTEXSTB5NetzvJ2VknaeTvM5HlQ46EqF87l8e5pWY7awPbO7gwKZki03I2C2ly5ZJSaok5I2w0Exd0/gZSqoQIJIT3ffqTmJXoJmxX/2lKTv+xPPS4TXrt9r2o//4l2xNNsrFY9+Sg1AJ80wQVvwrTczY0bvfYgMZ0x2h6dgTf2Tnzp6w2+5+la+P4uX8jGAey3ryxfNW0iDZPyuRzxMkKoMXtj13csnue/fH7PSTj1iss2mFyowVp/fqsgbUvqMC1bhNT82pL0wq5jwvqwxKpbL3ARAwcJBGzORz7B86VwhA4rZSUI8cY481eUJbao83MkMbviCGPcTtG+4HMmjw+vx9VZJSqE6ABKj8TTpqO06Dq9WhbUU8TyWp0muA8+sCGFLRbzNBb0CusrdZoq3A/BjLiPgQw9jYqPo64i+f29zaFe00eB3QfR+oBdlDm9u7Vttu2PbOEUsUJkb8m9DpSt6O3lew+dkRK8sGQgLxSdlyriSDrCSRVxbRyjJC5QoLWJmkvIZU1rck9oaIyzhgWUpNaF7f7dui1KA8YJveH7eZKTVUqpVyABbeHvYIcKJDvtiQR6zct4cgGO0aQfG2vMaMXV29w372H5209tp5dbRqn/y//o0cgrusvbllzzz7RVer/o4DqeTZm2+3vQdfrfwqF/WWkmoQkHZWr9hTUpfVVt1uuf1V1o3nxXARPJa1J166oIHSs8P75pzRX3z8eXvDd3zE6suXLNarWWFsyjIVDaT8mI0fvsNSsvfG5GHmMkWnAaMctcfIx+5BXREiBsM4X2ojkLjN4/HQi8nYgYOJr7JyGw2VhCSoSFLxvlLUDfdaeYOgWO9l+TurJHEABsBC9jAJzTWcEQYrs/J89QyvlAHXaPFNoaaDzPMKNKyKcPDj+SoNG/dbp6Z57rFgGxtrtrq6actLa+658tja2sqa7DyJfngkYDPFwLQFCyeb1ToP3glYk2MPJXol26k2bOYmuZqSXnvGUpZPjkgSaSSlchplAlAyZyl/nk52AntGjiQO3puapW4wEmpWb2/btkbbynrfrlyIyzAeSBXG/QEKvkSBi52RdEsBLHVIf94fxCyqr59oO0gSib6YNWtLa6+2bzzxAfv8Zyfsma/8pvVrK/b2T/wdy08ctJXFq3b2hW/Y4omnVHfcCiMTNjV3s5yOGZudmfcnmrO5vL3+gffYA29+t1XG9wpkGcOm/OPP/KaNl7O2cPAW4+0sAOOJU1ds71jBHn3uhH3kB/4Pi9eWrNfcsJHZBTkts9ofsulDd3s9TBcUi2VJp4qkCctRgjqDUWEGvO1MdmNYQInWwgMCbgJH0sSljewaFj3y3vmRUlGgyulYYFI+lvcgRQJAtRcjfX28bEhApYu+h5aSXWGvtL7uS/WzR0LRHoYx/XTpx9QGUyJKQxwPpGY0KNbW1hxUo+Ojtr6+bhcvXrJGveHpagINoN+7d8HWdK3bDuvp1F0NlriNTYxaTU5FrS5vvTBRfsgfWG3HrbqT0DawA0fr8tyk2rj/ow5jhKKWEO/csEVtueICFRxL8qj5GkV830bAqrf9VdwXTklkyw2fOaBtMilg8ciXVGe8LIDyRIvLKy/XEnXLCFjxxLidubzPTpx+vz1+/B22tHS/LSzcaf/hn/wTay6esB/6qX9rB+57k331M79uLz/xWTv57CMCS8LGZw7Z5PxNVhmbdQnaVIdzsofukCe4b+9ef9/o2OSkA4snehs7q/bso39szz33jN117z1WkFQeHx2xX/r1P7B/83P/wporZ8TEts3sv8tyM0dtZOagBshRy4/I5S6PuA2VkROAGvEFg9BDgbcuc8JTO0gnwHaN2ZI4MMI9wmGcqznZVgDJlxbpPAy4oJ4ABkB0u0nS3EGpeMDE4gEWSYaysJrIgxBh9YlUmOKwGwEOgTm0SD3TDuKpj0Bd0arVkdFRl6SXLl6UWtt2WwsPNCXJvLm+bbNzk7re9CfH8eLd+Pd6e7Znz7StbW1aIlOsPMR7l3j6tbUVs/XFtuX3zdjMzJYVZQf1fL1Q5IirEyohGNV0g4AtRIcAltzg1o6A1bOlVbNLDiyzhcMxm5qI26g8S9RoOiFg8SoThyj4bArxaTt+8V77wqPvFZgetKWrk9ZWwxn93/rqn9jzMsDf8UM/ZpP3vMlefOJhe/w3fl4u+Iq81nmbP/AaqSqpsGzePSPaXBmdEmDuFSj3uY3AsOJJnKJc55HJadlQRVvdWLfdldP22Gd/y2559Zvt1MvP2xd+979ab+mclWb22d47H7DK/pt9FcOevTfZhPLxYAOTiuGpFtFB9ECKuNOg8nnQAuaEYay2AAhtPm+kzrqBz7kGLAyG2ZATe49Nkc5k9jCfYsKCxJ42QCZphcoXE6mfeS+fq9K1tk8W48MimVifJWmoOCaaUWO0C6D7ciG1h1UP1MUgYIUq7wZjTgw1vrG5YefPn3V+8wkYPvOCcMlKg62tL9vtt99mFy4uqj4BWmkAOq8hZ13/7Py0AJu0h5IZdVJuNWyOd5Iywno2d8fAxvIigKPH2e+/8Kd/ugAxw+jCEJRo7telflCFMtyXYnbxZRTkwPYcStg0H2UqyYuQR5hR4+KSWLF4R5Kkrbx32aULPygifFTp9vnrEzvtHatWqyYZbr//qf9ur3/3e+3IHa+1Z5/4lj3xyB95Z6b33mVj84ckdkflvS7Y3gMHbX7vATt89Dab33fIpQCBByKYlGSpSF5Shm8Ijk7O2sLeW2xLaujoPW+0y+dP2GN/9Kv2gx95l33o45+wnX7R4pMHbXRswubnD4j4siPVV5aURMMMJvEcX5ijklRXnKs7MRe6RNKE6QD3xoQSlhlDN9QORjbvngcEznCVEd7jKlAJMKyqAL68YgnGEQdQmX1HyrESoVKuqF9FGc95/5BUSYY0r0LioVxeBjc2MSknrOjXfMWEwAHAmHUHtbSbNu7uykHSMR4eL6G7eOmcra9dsdGKvF6ZFUg6+sbN8Z4/gS4JmE/b5kZV+aXJ4kH94jz4W3Y0jh6iQ76gjRlvqbTmutzkStqmD9SspBEa60gXCwQY1QANw9BBxYj1YzVSI7jd35bhXrVN4UHeqp1/UdZXZmALNwGsnpXVELzCbGLS7w3GEhN25uJftpOXHxSX9ltBQ3e7vmMb61KpPNrVkWre3pTIrdrtr7pf6vG0vfzM4zY3d8Dmj9xrh259jd1+z/12132vtj37DlixMmYj45NikGwIqTxsCQDBBykxqnm2jglBel0UoctiypE77rXFK1ftid//b/Z9n/iwTYzl5fXIWN1s25jstYo8PJ/N5naKqImkQjLh3bGHCjDG1ZpfDyPYXXnZRBgObj8JBGUZw4AAI58Z7oIAzhSDkrvtEpXjUxEAV/VCX9IxSABjqaAytLGygSkMGE48ktIN/rIcrUzcKgIIT3JX5altb2x5W5FGtJc/bv2gDagTScnUxqRMBSQit4yOH39B17t2+MARK4lOhKDWaRHPIuzYvoP7bH11w8twCS7bmDKRmolUJv0Q8xeFfFHgoUNM75stXzabvy1nkyM1y8rQ5t2d/kSOgsr2wsJe1cj9RmK12htWbdZMILYl5b/wkkZEPmZ7DmO883aZgZWz09ZPj9ryxtvsiSffYy+dmpDerlq8L09UYJ6sQHCkg+oSc3inQmVs2u9RXb182Q7ffJsdXDhot912l0aSRmOZr5yqI/r5BJ9sC5Z8ePu0oQqwgwi8GRmm73KzVnuM78/8wafl5SzbPe+VB7h01n7ge7/bPvCu77CNRsxWa2kHkMjir+f2W086j8oGERARgiORMJB1wRnFNMFIOUjJolzxEvcIaQf3QkVl1CcsYmPeC8YgEWi/B6WljUhDbs8gKaA8b+Ehrd9TFY242eyAV3m8Z547GFm1cWNzx5bXtmy7uuODye8LaqN2vrjm6lD2MsDEUwTE9IP2X726aGfOvGwH9u6TCTNjGdS110uzACOraOVR5lS3aL67I3qqdcxvkQ7JlUgLWCxMcBErXYurapImzK5ubLf92zcjMocEfoGLEUT31GEdskyVjtPQQb8hidWwWnPXNnZj/kKQyy+av0pw/808Ii47q3inxPGP2Ikz32/HXjpiVxab1hbyEwOJYo0sHinnBWiFbMLmZqdtTNb+pDyN2flZv61QKo1YXB4cd/XxjBgBPBSwtaWtWpMKr8oj4Y18zNu01EF5Q2KUZIyrEt6YgtopSHLyDivW6F9Z27Wjd91nc3sP2tKZC/bMc9+0x4+dtRNLCZuYmnEVgrfm6/uxbUTdGw1oddwlI5JntFLyd2UxMJAoABppBUf8iSSl9zdIi4J8f0f0FxhlP6mFzJjzxLMDzVUKqgV2BdBiX4WX9GOke5FeNlMGMJvXf6cFTNRZs8Xdj11b21x34PGUNi+ZQ4on8eZRaahEtY9pD+bMkMzY2nw94/SpYxZTXfsP3GR5SSsgDT6o18EtUHJSrzdtcnpGtN91FchNbJ/q6Alg0s0of4GG90iOyr5hkZrUBiJaBvZb/1Lc3vGONZtITlqPR7YpWqhMqWHo1iQdlJjtdXet2lq2pc1VO7Nk9vTjMXvqD2T4HTS76705u/fQP7NS6r0CbNbOn12y7e0Va8otzedgcs6ZhcHHcp10FskZt9MnT8pQXPNG12tNjYxdNyaZM+MmLJ/KJQ+dzomZUIARyIOkFdkZpZJsDanyQi7YGKzAdS9OgEsJnI987TFblQt9+003M9ysqX41xRDezwEeChlJJ6UHnKhDVlgyzZKXGsNdR3ox1YDEdJ9M+WEC4ItUI1IsUpEY4XjJmB58tNOZpXQY5ox8jG0CQPLpPKQE90JRq/QbiaxBwx4PMq0BjeGN5OI9XACHui6vrtvK2poGWd2vE8es/ZTMhIzoxn1AbkRj0LNiYl2GOsDiSySb22v2ja8/bHvn9mhA75XNNebSkkEBIAkuvbTnpviefXv946PbfMFW9QAspHysUMozvxV0O6KUx7nlUveF8pRUXHJP1773Jzp274JsCnUIQii/gIVKAFiMSom/btV2GldsSTbRSanBJ79l9uhvm73lfW+2B9/1D2zlsozcRMYadXmOjXVr7vC9wrykUtFGeC+32oBE4G0vvPSNhwb8jSnk8VloufJ4PU5kACK7Tg2nszCT10zzDlJmr7H/csyuJyXd1A+us2I0LfHqxjFLTyQtvvmt5yVlB26jABTRQ7ZKzuoNXhJSd7Cj0koyjEuFjAYBdxjkXksaIgmQLLQBaQSqr7WLM7UhSDjRVcdsDpAeUwZqo/qHLRUe3tC5jgEWcTAdIgMm1CQB/jDdQHmk1Z+DPaP25AUU6AjoafOZ5RVb1QY6x8cqytvzOamF+XmllxGuPHjODIOqJDweIuvdWOO/eOWiHTv2jB05dMTGxqdlaoxaU6YSAzYaLEhFwN8UsEqjI7JXy7Z49aoPFKDnUjGZST2EOhM2hEqNHl7sKiLHVRCflevWcj4ntP/Wro1JRfEYdaIvXa1MMBAXFFEsC0sN2/WRuLhqMsBn7WMf/Xd2251/1c6+tGlx0b7fxJaSYorJcC5m/V3olUpRLiwgCl4Mj0PxHsuSRmBeACjIy8nxsjDVDXNHZOuUUTWSFLwQjReL8M6FnKQLo7igeJjPM3f+dhiVoT+3PQChuirGSVWKYUlJyi2NNtakN7uSnklJNYFxCvU7PaVjbiepbTKKaR80gkl4ZEiyoB6QrWK4AMokIyM7AhKSEbXB5hjUj7aw0G8okJx+qDwf7YqjRFQc0pEcbh8CJqUTtDwufAwBFuqaaI8pEpypuH9sc31nx9doATz3jFV+vVbXAClJLUrCRtJHZfJYWYFpGjWwrfgz5864JBsfkxMkEGKvssCAQcKqB/oJ4GkvAwkwZlmOVKt5n7nGlE9CLutDdEiCJ1ygcyokJQYptwiRsLUrYuqegs3u3bBioqDuYeJDFLoCQSTJBnVVsmzbTTFi8JDtn/1ntrXLne8LAmRWDc17h1zKwTCVjV3gn3BT3TlG+pA5lItdAOFgHDaJe0qiK2DBdvJZemoXgegk0gMVQ8ecY/pzj0vxGQGWuMBsjTT1r9aQatVo5RlARiv9mJ0s2575KY1SJlFDGyUEvYcE3Ghmwv2rrdrTpqAi8IqpIpwTQl0BZEH9Un8YjA425SU9fXJPdcgspCd1AAC8WW7n+GpQ5cnoHFohfTHi3a5S27MahKgrvHPeDL0q6cTTOMzgUw4OAZKRc7ROkPJI1LAQERtRZLFau2Fnz5/zCWBWsdI+VD3TJtARMqCyQ5/UdvWTx8z4vhD0QOIi1Yh3YJGBE+UQEcUwRgsEkDphOTAPQi6tduzA7bxoLHhBgRX6eR7lim1bbVC2pQsP2eULb7C4cCn+W0MSgZeUUQGqii+9I7IRrZRDgIF4MipMxqgYo0Z2JFUYrPQH1rZ477QaKsXieza0BICCcMT7bDOS0ZlEp8K6JuBJXXhiTBbyikhuwAbViW2n/mibnsAdp/rQN1QXBAfa3HSlSMplYEAf1JKrK8AFTVQ2g4AAgfXf66U8sIPnxcSmX2MA6JoDU3sV56BSEgcOA46HHDgHHEjxfEZxYvRIuRQcEG3cS8wIeNRaazZsbXvLv1xGqwuyMwElc1QAC9uTOsJqCHMpg6qn/KY85nXlXdtYlxNSDgAXT+ATPKNvYfoDPobBA0AdSOoLXie0jOghzaQLiDf/QYwwqhpb2xqZciO76rR09fbplH3zSwNbqW/6EzMsZ+Yz/Yy8VJrJ0bvt6a/8Uzt94nY1oK3ObNvGypKNy7Pzt7kkuecou22IeDpH8C9BqP62VGBDDWsI1Kz2pFPCQbjmgAlA4MOUiF/e28lacjbeuocdhrh2kCkPcHcbR/2jDAeG2krHsdWY04IQSCNMAZaiIPqpo68+k5c8IIKRS0BCedk6pw9ch7gQnbK45ipGdQBCJBnpcM1pF4Y3A4I2MJCRaEF6yVGQ1EH1us4AePRbYBDyrmkHpLVPOygfKtslly7CSDxq6EK5EowOKMDBeeRA1GUrNZhsVZ8w1GkT7WXNF33a2tmW2cG8X7gxHYGGgEbjmId5kXJVqdyehAAaDQnO52oIlOdtlbp4KCzFdYWjS4hsOhgkTDondaIOAKIrlwc2f2vcZiYa/oJ7WXFq4JxdufDn7ItffItdWu7b/NSE4MmqBomrbswWpsadwDxc6XM3aiE2hC+6F5gwJplfUaXu+vK2GRqJHaHq3c3m4928rjE8VADQcN11TQRmxDMcCE4D9QUGMK/Da4eQTEGNslfHpXKZx8LOApx+71PxzDnl/ZZEmE9CPTElQHu4J4dahZFIH7YoHYCiWq9DeSAqDaE+/5injpGg0BXJz4eq6JcrcuWhbpUs8MuelTvaUn+YLqH/gIXC6wIGfac97FsafN5/eSwtT6uBBbBVS09pd2uyZdVZVDftA1isjMhLgjU1qJLqC4ONa0U5JG0JCVaoLm+sWkJ9yMoc8Qll9YXpGRwinCDK4elvllNj0DPgUaNuFzK4xI9ImsV99NBx/YWXgARbhK0t76gp446XkfV6Tevv9u3h38zYovaJfMaWl99hj3/tx+2J5++ynVbfxgrjYpAIKMb3RSRsGx/tys/MMPaAv3hffr+fC3BgGrcd0PndcqSPGsz6IuZsGIWAJ4AJYqBKhstNRFT/5o7ajspzRqndlIXngiojwLTwhDP2mRiqeln5EFO9MBqVkZUhDxEoB+I4gdQ2wM4e+4h5GgAR0Yfgy2RAhwJk5BjAOaBUf0TbaJbbAemACmVwuete5cB2RW8mqymZfAwMbq/w/oUtGeM74sWO1BpLVnZ3qy6BsHF4CNVtIOVxO3PYD/qs4l0NIjygGe0AgU3ZlzhpLjsV51JL9GV+izfVEKAz4LvenzCEOWZA+mCBnuoPq3PpC/USROsgmiNCeQGk0DnNqqkDPWXSoHKVeOG5nj32jVl76tkP2cWT3ys9rRG2XbeyJNjUiKQRL8fVSNrdqsomkAEuJiP/mD3Gq4CA2DNBAvCEcy4QRR2CCLjrSAg13UejYvw8UnMAzVdKKj2jJYz6IBkIECHqE4GOc44KJgAsymbt0/bWlhPP7TTKVDtDXlz7IA1YPOi2keJ44jgAjIEmoCuPe2uUqfTRxjVsE1pAPmhJv/2pI9oRSH0tPXU1JElUmKeN4lH79BMsIGGQsGx4srQfdcT0DFqAOiMeYgaEfstOVLxPZ+jYH8WXBEZQ8CgYS3zoA6ZBXeCDH3yXkfcyUNI12io9dtqOvE14gIbh3iT2GeU7rYQRygGo8CAhHf8QDaIAD0rkzfPCFSeG8t7xjApR2wQcs8snctYZvEYey5gKZRR0bGK8YjlVyBzJ6sa2dyyf4TYGmVSSKiP4AwWK6kmsB0Bwpx+ChsVrDCeYTYgA48TX6Eet4RK7kctcCeUqDR2B+rjJvmZbkogSAAu3H0gn0nu/qILXMWZl9AJY6mMGmk/v5qT26R/32PjUHN4Q9eBY8LwjfaJsQAKBvX0qEIZA/GjtFPsgQSgeKuLtoXKBtKK5Bt50zIQvL1jBXmFBXtRnAje9WXXAxCqJB0ht1cskJFMkqB6kOXvaRtnwEo+wLZ4w8by1tSnV23WbDJDrstOXgYYTgq2Fw4TqXd9aEf0kyXhzYI6l1didKZ9XwyEANGldy/AuLtHI2y/a+dwetBYd4IN7v3QgQrqnHO6dobqKPdGuS6dSsBrA6O02duzMU39iVzeX1aC41F9FDWo70VFNzClhDDO/hfjFDRW9vEwQzojn/QHMNfmXJ4RYXgPpUsntEAFFbQIYPiJENB+BahqTgYCVOS8ARYcceNpgdgBhkCioQ67DYVSezw/BVHUbUCHxWGPuHirtcMKFdxig9mgnjI7sNFevtF9luqqhUwqo3CDpwiCIwO7SU8cQP0CFcRr642qK9PqhujkmPXvKoj9RHp/lV91IGJfwimOooOKCpMC5QXUHBpIeO4h4FvOxUI8ysY92d3fcsbqmstQ+gIsqA7CoX58M5ZG6noz0mqSj8nBjmnZj3IdqcIqgi6R4PCVeoTbhA30VrSNQRUTxY5qteD9XQkZOU6rN32zSl5GoAjbXLtiZF78sEbrjIxb8Mgr4skGYDRbIVDSNoRx/d5MChKYzQFpwYeBKvWGoc6wMiO+hdOIURpDfGSnCUxdzOrAUYhLnjLqBKQTOITwSkhFKnQACewUAc48u9HcourUBPKQUwZnrgAkgoVivjz6KyeEZwZCXtFG9Ed0iwIdz9UPn5A91hrIIIR1UCJKExF73MC1tJlBPuIWE1yYPW2YGAKIcwAUNXIqqXdCKthPwvrmGOoSuDdlPNRn3TmrVw+ChXja8XCR5VSqvLkDtStqtLS/52izq4baZ91JpW9BRwsSf65RE8+8rdJo6l0SVSnSvkLRRh6mMbXgS9gQ1UJS3uDrEwwNIssbuhpUn99nI6IRlpYYyCBr3cFjHJUaKaSxvJi3nwpx7a0gFOoQup8MEN/KVm7w8F0eAIIweVAvEoo3c6qFZtAwgRkyAqKTxEThkKlKBtGnaLYmFNKw35WIjyXoigOKpl3tuPFOHuiADTkO91nAQX/sopxrvkoh+YQQLDDCCNiJdosA9zGiKBO8UhrEIUtAQNST91FYkGCBmxHt+9YOb0Dy17PalaAPz3EaiowqoO1Xodp6yatAykSzvGWmjutiQtExfcCN/Z4fXD/HSEN5PuhEmSgWEqmxmaDM5NaW6oaNAhceuNrZbNRvIZhvItosLIP7KA7FlXIDaPzdtk+WiTVayVsqYjRbTNjeat8lS2mZHcjZTztjcSNrmR7I2pzSxAg8KDgMVujTxE/VteEjgsK2WVGan5a7KdhLAAMz4wbvsbW/5mI2NTNpoQUxpx62mTvJJEW6ZQFRuSqKHCdgX1AMxIQb1cc7DFL4igdGriv3hSTEawmOluFgXyJTQ8zCCXH153jDKHWTD8tmw25BYeYGeVyZ1ujHZfztOUNQ84PaZayYfpWIxEVjDz5zYzk7Dex2L84gTX6p0eeqMCyNc9XCuNrhDoPpoezYpt1zA9vfHq16awTW+/MXkKEtbhB215Xo71TU3Gdh6qBUaqIFMXeRBWjFYGAg4PrSFQYz6avfbfjMf7GJLcl+TNzlvbq357bB+h6mBulWKsotULtoHus3PzfvAY/kNfbFB02cBMOyFNAmEcNsKLeR3HMRD+G0J1skHWkPTpDbaRz8VGwSI0v1PwCJE4KJCjn2vxKKnDVTI6MysDUQgvgwVT+Xsntd+wO669602NVawxCBlu2IM36jhiWA8QgxaOkTpqJJ6reZMdULpPNgI0FJ5BAZuICur6lQe+qxSmEtBBRGcicpAhwiRWonUZVANSCxmyZNWFCATaqt/93mnZWvyBpnL8cVzSp/RsOQ96jyNhorE3kNqQg7uNLHKEwYHgxdDNagpt50gitqK28/NaF5eFhnVvDsUyeYAlsFLO5EMPtMuZEeSvS17xu01PLaYJKmGHXUi82kbNBP5XIIALN6lkEwIeGpvoC2Sj6kXjuNyolg5y1wXzoDYrbbyKgMkqDNfZWBLKakDRCJSdOd2GLQWr8UD/Tkt4b8b6qRTXg0jp7UHOTZw2AFHMaa2ezqG5A0hivyz8GfhfzfE8vksguTbAgBjQ1L5MXBEOEh6sDYqVSpZcXxMoxn7JGP5sVl747u+z245fLtldL0qPc1n2XxFqspglGOvMHIxRhmpfptF8UgX8Ixxn8uHN9ExDpA2boMonslRXFjEMS450w20DRtHysSlWRhVjK6gWploVWutUCxaTm1npr9ab9radsM2tnfUDkkFifgRlgvzBQupQp/JVzxvMGwhcXWelMTg5WSMwGjcMZrddR+OcMrmIQn6hT3nNpfSJhG3SkG7+KI9ZgGz8WqhFaXqaXtod8s9XegsoeIVYKirJO0DP5TUDWTyk8adIKXj2FUP5ag+SpHaUPpQHi1AV/B9Ii6hhpFiNJGFfdDVNZL3UKl1nUCd8M5xQNZh592pGoZr2HBCUAtl6JhruVxGNnTI5IVRo0LEIIJnVsO8yGElxalxS8v1ZZ4oLhW156432ANv/LDtnZyQ5yUjUQCQjHQRz60h5C5GKQYkIha3FHWBXQCT/HU6SoPLy8w8nQHE3GdDrWHLeEfUCVSROwB9dDtej0CkPrmKURr3+mS0cnMWRhSlVphjWVnf8jmqNe0R4ZRbzKVsanJUoGUgqZw+4h6PEhddbRHTVKxsRFQSToSApnax5zWUapbTCbC4RqD94jZgTIlmUNa/PBvHrAhmAbSVpeWqnut+3xVw+A+a0082+hSOCTrU1XBOOTIIQjz1DuMILH+KPM3rIVwjcBQ4ez24avckIV3g/fWUlB/SvPL6dTBdD2pjBKxvzxAKiuI8n/IzEolzaZHNWHl8XAa67CGZPv3UiL3+bR+y+1/7dqvJI3ECiIkQ0eejlIe1XpxTMZILQ9aNUZWJ9GJyk0ViOvR04DF8bT4QjbklCE1Z3GTlPh5GLdINmwVA0DZstQS3k0RcjNAstpnajnfkxrPiARVx2FalspwRjXKeiVFJqlubjt0mUfMAhs+jO9DUpwTSMkiMIMskTYb98NGrtJSB4PDJQkUjKUgK/ZAOwpLKJgG5qTUEp5t+ER/8fhVXda7avQpC8KIDgELcdWDd6KUSoMkrA+24kdcc33hO4Dw6jsK3X6MN189vDN8msV4ZAggUyKNDmkdK0jM/kh8btWy5zLCSWilYcc9ee+Ctn7TpsRlPIxb4lENN3gZPrKDKABkqzF+sqg05iFrkq/lItAJzNP4uDXmX9Ya1uqocaefEkYpQO7wPKp8lPTAN8czCP4BE2dxa4M04gBaPBmnT49EnAc5Fv36AF081rVGRSjH7riITAJAyde6GKfUADPVF5VK/14eU1p7e8UEFB6PSUTK4QpJwvefXaLdU+UAVQkRdhTKhDxHDOQkh6huMol7Kg5a+AsVBBmjJT1lBYtEn0mCkkzfiE4FyANYrGQ9viYvivY7heXTsZQ6PozRsIRBHG8I5ddx4/du8whsLIdxYIEeQLgIblxj0lbkZqbGMiChplMnbkXveYvfd+36bmxyx3RpemFxYEYK0+MSsYmSBWpgADbO+FJ5GUmmI8yACtgkNZUFfqBMQcXsD+0LgkYvLR4R8ZYLaxtwWn1Dh2TZfyiNJg01BW1Exqs3bTD+AsrgkYDFjTD+YV0L60HdPpnMRKOK5Am0ItAllEBOdh8BBIOh1xpDWoxRCnleGUFbIQ4jOCdf48IqsESCu8yHKez1RVE7EbNKwRcVHRRNuTHutTgXKJy46JkRlhcBAI9xQ2A3h24z3b894vVICsRGBnemkAxvMBFcq/ra/WDItu2vMXv+G99uRm15jvTi3BmQQdzrG830TRewoFrSxZhqXnYaHe03My6STfcvmxGSV70RRhwACTHcbxgGkHOqnvz5cdpNa7BuDx/ccKkFoOiOIS95yIhw0ND0QmsIgqF/yQBTnN/DJQ0Qb9tHxK+MJr6TfjWmjQFKiXpknOif8aeVH++g4uk6A98Ooa3GK8biQbxj1beHG69/eD0IELALxYRtGDIHlfBrmvTG4KvQDZYiuMd9CQjYyugGOmhEAQG9aaoenifMpgapUttGpaRsZLwg8rBkv2cjUnO3jsfdcxpKydXKya/iodVqocGMUQEl6oV3Q0xjIqCs3Xx1sGLpIGyWgUWqDP5MnbtNEYEb/UASoLXVLOYZEB+xKi3MQAvHD0e3HocgbCRgRJSKe1+EiNgTaEtHjWpob8vxpx4Qb00Z5o/j/nfDt9VBH1MZhzA3F39ieVwY3C4bgidJFbSa8EjTXr3EegBVdu7EeT6e9f8UCj4y1PMyosz6Jp29LZYGkMuI3PnmSBtedxWJl2VXcvOW+VdpvWmYsX+BVRiw5zlGY8pStlOfl8oBA0sbbOjQw9QerXeXomDY504nVcZTGO638nIdO0ljK8ZJ0HEBFJs9LAgHCO09aFUzyaxgjeP//Z1VyY/D85CXjMK+XQVpdC7D+XwevV+mifRQXAfSV124Mf1pcxPzo2rfnD+3nOFzmX5DYpAlaIQCbawyyqBzMAALlR+VFdCGE/NfpE+W7FiLCDpN4DYoCVrF3vftdA3+2vzLqC+izJYFKgGGtDYv3o7vdvoRWUoVlE0wxhHO8PvYYpsKTTwlgB7kl4+FGpgaG3NjQIXMdQLoWdeJaB+hYGI3R6PHYIRFw4elGFBeFVxLgfyKIwo1lEW5M4+VrD4H8uk7k4XDBrzMI/7RA2hvbeuM5+1e2I0r3yvgoeDuG5UR7QpQ+7ANwvJH893TXj8PN6JCPNMHw5xrlh7sLlIuWIv0r2xnVGYUbr1EslLoxjvyE2H/91V8Z+LIM3nklYPD9FZYGo/78pbNSU6FCZdKxT7xREPUNy8MLIi4iQLg4DH30XTiMGkC6qAGvbDghiiM9Ljk/RfIncDIDNAwy2G8sk3Djuecfnv9/hT+tjFfaWBKbvqMtvtJ2GEj7SoBEdRNuHBDR/v8rQJeoHQSOibuxnCguJIMG7AMoPC8e47Wqrku7qF3RMYF9tBG4FpXDFpysG9rfgwKUQ17KuV4GgXZSeezhr3xFl5XAG4b/pCOloaioM+TBWCbS37gn4IX5k1Bh6BwXafQwKgp9xamhw0KGkRyG46hB7ENd4TwKkXCI4tVK33ugTey83uvlReXcuL8xRPHRcRRujPs2YCkJWIJOfhpdG8ZF+QivrEsXRVFPeu1/CLRr2BdFR2XgeATaQufrQCPOr3lphKjPwfkgDWkJzGPBOy/TkwfGM80StIZidJ00fgOdfU/nN/A0yu9pFM9xRBeO2Zgm8uVOpMMuH5ZLiD3yla951eK/gwobJeo/71SgAIIXegPROI6uEaIRdA2A2vyqv/Im5Lsx/Y0hKivaR8fhPKRxwkI4SalvK8XrZBsSVR2L8v6vwiuvRfX9r0J0LWp/dM7ejxR9Y71RSTy4ea0vxEadUfA0ivf+cky64QCMmMMVmEd+0rV7LTFwCBhdo0zq9TxD5jPfBYWidExEuzpUGazfx5tnvtAfQ+sGcJGX13P7rTZ33AIWfOFlO7xW0ssd7sMSHW5/dX0Liwi4TRfinBYPP/JVnyD1xgiOiHlvuOLiEnsY2DeGqJOEaIRwTjyBHQj2ax4f0hCifIQobxScQDcEZ8awTELIC6mHANORi/xwNPwfjq635Xpbo/Kitt7Y5hvbRYjiCTceh6B81+ZwFJTXJYwOGZO0z6P9ks6ccTAFqRCMZWdedF3H5CCOYwLMwWHxhx/4KR1xLBGOjnnzDy+XpRzWh/HhT+LZWi0WMrbFcJ13eEcEa7bCbTZWeTL940tuFMczg9yv7fV5PC2UwYtzuQ3niwOVlzivV+U5uHQMmHzSlnbDO9qjfTTr7xLLRaEowwiLQx0Iz0UhGyZSUBSi8xuZcmMajrldEl2P+BKdU3kAxreHP61MAumJZ/Nj2VwhnerrB6fBg0tKmBi14Xo9N5YXheh6VD77KJCeLYrj2EfkkIh8dyioG0Y9Iz2MWuJQDS4llJb1+aSHMf7Cfu3ZPO0w3q/p3NdjiZEwj2f3WP3K5DHrunz5MfmbLX8xCnmoh71fUz4+FkD9QXro+rBul2rcG3tFGFLw20KgPjnClXBOuOFItIIefidC0aTknOD01HHMzP5fU/Ws64mHK6wAAAAASUVORK5CYII=' width='200' height='133' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\" style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/user.html?user=amani_geosaurus' target='_blank'><b>Atma Mani</b>\n",
+       "                        </a>\n",
+       "                        <br/><br/><b>Bio</b>: Product Engineering lead for the ArcGIS Python API development team\n",
+       "                        <br/><b>First Name</b>: Atma\n",
+       "                        <br/><b>Last Name</b>: Mani\n",
+       "                        <br/><b>Username</b>: amani_geosaurus\n",
+       "                        <br/><b>Joined</b>: December 21, 2016\n",
+       "\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<User username:amani_geosaurus>"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Display a misc member\n",
+    "org_member = org_users[1]\n",
+    "org_member"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8be185fe",
+   "metadata": {},
+   "source": [
+    "### Getting Member Content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c56cda2",
+   "metadata": {},
+   "source": [
+    "Similarly to above, we can set return_count=True and see how many items this user has:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "f9f2265f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Org member has 24 items\n"
+     ]
+    }
+   ],
+   "source": [
+    "# See the number of member items\n",
+    "qe = \"owner: \" + org_member.username\n",
+    "member_content_count = gis.content.advanced_search(\n",
+    "    query=qe, max_items=-1, return_count=True)\n",
+    "print(f\"Org member has {member_content_count} items\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "c0f9764a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<Item title:\"Demo Initiative1\" type:Hub Site Application owner:amani_geosaurus>,\n",
+       " <Item title:\"Demo Initiative1\" type:Hub Initiative owner:amani_geosaurus>,\n",
+       " <Item title:\"geotaggedphotos1\" type:Feature Layer Collection owner:amani_geosaurus>]"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Return <max_items> items from member\n",
+    "max_items = 3\n",
+    "\n",
+    "member_content = gis.content.advanced_search(query=qe, max_items=max_items)\n",
+    "member_content['results']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86731e14",
+   "metadata": {},
+   "source": [
+    "### Compiling Organization Content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4601003",
+   "metadata": {},
+   "source": [
+    "If we return all items for each user in the organization, we can compile those items into a single list representing all of the organizations content.\n",
+    "\n",
+    "We can remove the item limit for each query by setting max_items=-1 in the advanced_search() function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "32189e72",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1845 items found in org\n"
+     ]
+    }
+   ],
+   "source": [
+    "# return content for each user in org, compile into a single list\n",
+    "\n",
+    "org_content = []\n",
+    "\n",
+    "for user in org_users:\n",
+    "    qe = f\"owner: {user.username}\"\n",
+    "    user_content = gis.content.advanced_search(query=qe, max_items=-1)['results']\n",
+    "    org_content += user_content\n",
+    "    \n",
+    "print(f\"{len(org_content)} items found in org\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "417fa4d6",
+   "metadata": {},
+   "source": [
+    "## Analyzing Organization Content with Pandas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c232bb8",
+   "metadata": {},
+   "source": [
+    "Let's put our compiled list into a pandas [DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) to easily view and filter our data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "c97071ad",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>owner</th>\n",
+       "      <th>created</th>\n",
+       "      <th>isOrgItem</th>\n",
+       "      <th>modified</th>\n",
+       "      <th>guid</th>\n",
+       "      <th>name</th>\n",
+       "      <th>title</th>\n",
+       "      <th>type</th>\n",
+       "      <th>typeKeywords</th>\n",
+       "      <th>...</th>\n",
+       "      <th>size</th>\n",
+       "      <th>ownerFolder</th>\n",
+       "      <th>commentsEnabled</th>\n",
+       "      <th>itemControl</th>\n",
+       "      <th>layers</th>\n",
+       "      <th>tables</th>\n",
+       "      <th>appProxies</th>\n",
+       "      <th>protected</th>\n",
+       "      <th>contentStatus</th>\n",
+       "      <th>sourceUrl</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>8ec563a6886f474c8d991e7748ab4c03</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>1558567624000</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1558567631000</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Demo Initiative1</td>\n",
+       "      <td>Hub Site Application</td>\n",
+       "      <td>[Hub, hubSite, hubSolution, JavaScript, Map, M...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>95654.0</td>\n",
+       "      <td>None</td>\n",
+       "      <td>True</td>\n",
+       "      <td>update</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>d1d2876870ab422488e425db4c400361</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>1558567621000</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1558567632000</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Demo Initiative1</td>\n",
+       "      <td>Hub Initiative</td>\n",
+       "      <td>[Hub, hubInitiative, OpenData]</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>72567bd147fd478da9563bc56b434870</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>1634162116000</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1634162156000</td>\n",
+       "      <td>None</td>\n",
+       "      <td>geotaggedphotos1</td>\n",
+       "      <td>geotaggedphotos1</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>[ArcGIS Server, Data, Feature Access, Feature ...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>6fd3252f1ad044869dd4f949ea4b20cc</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>1555049137000</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1555049257000</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>hu_indy_18p</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>[ArcGIS Server, Data, Feature Access, Feature ...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1d3614ec5cc24382878533f8454c24a3</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>1630112960000</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1630112990000</td>\n",
+       "      <td>None</td>\n",
+       "      <td>1d3614ec5cc24382878533f8454c24a3.ipynb</td>\n",
+       "      <td>intro to notebooks</td>\n",
+       "      <td>Notebook</td>\n",
+       "      <td>[Notebook, Python]</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 51 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 id            owner        created  \\\n",
+       "0  8ec563a6886f474c8d991e7748ab4c03  amani_geosaurus  1558567624000   \n",
+       "1  d1d2876870ab422488e425db4c400361  amani_geosaurus  1558567621000   \n",
+       "2  72567bd147fd478da9563bc56b434870  amani_geosaurus  1634162116000   \n",
+       "3  6fd3252f1ad044869dd4f949ea4b20cc  amani_geosaurus  1555049137000   \n",
+       "4  1d3614ec5cc24382878533f8454c24a3  amani_geosaurus  1630112960000   \n",
+       "\n",
+       "   isOrgItem       modified  guid                                    name  \\\n",
+       "0       True  1558567631000  None                                    None   \n",
+       "1       True  1558567632000  None                                    None   \n",
+       "2       True  1634162156000  None                        geotaggedphotos1   \n",
+       "3       True  1555049257000  None                                    None   \n",
+       "4       True  1630112990000  None  1d3614ec5cc24382878533f8454c24a3.ipynb   \n",
+       "\n",
+       "                title                  type  \\\n",
+       "0    Demo Initiative1  Hub Site Application   \n",
+       "1    Demo Initiative1        Hub Initiative   \n",
+       "2    geotaggedphotos1       Feature Service   \n",
+       "3         hu_indy_18p       Feature Service   \n",
+       "4  intro to notebooks              Notebook   \n",
+       "\n",
+       "                                        typeKeywords  ...     size  \\\n",
+       "0  [Hub, hubSite, hubSolution, JavaScript, Map, M...  ...  95654.0   \n",
+       "1                     [Hub, hubInitiative, OpenData]  ...      NaN   \n",
+       "2  [ArcGIS Server, Data, Feature Access, Feature ...  ...      NaN   \n",
+       "3  [ArcGIS Server, Data, Feature Access, Feature ...  ...      NaN   \n",
+       "4                                 [Notebook, Python]  ...      NaN   \n",
+       "\n",
+       "  ownerFolder commentsEnabled itemControl layers tables appProxies protected  \\\n",
+       "0        None            True      update    NaN    NaN        NaN       NaN   \n",
+       "1         NaN             NaN         NaN    NaN    NaN        NaN       NaN   \n",
+       "2         NaN             NaN         NaN    NaN    NaN        NaN       NaN   \n",
+       "3         NaN             NaN         NaN    NaN    NaN        NaN       NaN   \n",
+       "4         NaN             NaN         NaN    NaN    NaN        NaN       NaN   \n",
+       "\n",
+       "  contentStatus sourceUrl  \n",
+       "0           NaN       NaN  \n",
+       "1           NaN       NaN  \n",
+       "2           NaN       NaN  \n",
+       "3           NaN       NaN  \n",
+       "4           NaN       NaN  \n",
+       "\n",
+       "[5 rows x 51 columns]"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create DataFrame\n",
+    "\n",
+    "content_df = pd.DataFrame(org_content)\n",
+    "content_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63914c58",
+   "metadata": {},
+   "source": [
+    "We can use the pandas function [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) to see how many occurrences there are of each value for a particular column. Here we return the top 10 most frequently occurring item types and the number of instances they have:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "4b6a60e8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Feature Service          434\n",
+       "Feature Collection       427\n",
+       "Notebook                 342\n",
+       "Shapefile                129\n",
+       "StoryMap                  98\n",
+       "Service Definition        76\n",
+       "Image Collection          65\n",
+       "File Geodatabase          43\n",
+       "Deep Learning Package     43\n",
+       "Web Map                   33\n",
+       "Name: type, dtype: int64"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# use value_counts() to see how many items you have with a particular key:value pair\n",
+    "content_df.type.value_counts().head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ed08c50",
+   "metadata": {},
+   "source": [
+    "Another [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) example where we see the distribution of access levels for each of the items in the organization:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "f9a95a80",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "private    815\n",
+       "org        516\n",
+       "public     512\n",
+       "shared       2\n",
+       "Name: access, dtype: int64"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "content_df.access.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "870d2fbd",
+   "metadata": {},
+   "source": [
+    "Using the [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) function in conjunction with the [groupby()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.groupby.html) operation allows for an additional level of analysis. Here we see the breakdown of item types that each user has created:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "1261d700",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "owner                type                \n",
+       "ArcGISPyAPIBot       Notebook                31\n",
+       "                     Feature Service          4\n",
+       "                     CSV                      1\n",
+       "                     StoryMap                 1\n",
+       "                     Web Map                  1\n",
+       "DavidJVitale         Feature Service          1\n",
+       "                     Web Map                  1\n",
+       "MMajumdar_geosaurus  Hub Site Application     1\n",
+       "amani_geosaurus      Feature Service          6\n",
+       "                     Notebook                 4\n",
+       "Name: type, dtype: int64"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "content_df.groupby('owner').type.value_counts().head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "795cee96",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "type             access \n",
+       "API Key          private    1\n",
+       "Application      public     1\n",
+       "CSV              public     9\n",
+       "                 private    8\n",
+       "CSV Collection   private    2\n",
+       "                 public     1\n",
+       "Code Attachment  public     2\n",
+       "Code Sample      public     6\n",
+       "Dashboard        public     5\n",
+       "                 org        2\n",
+       "Name: access, dtype: int64"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Viewing the number item types per access level within the org\n",
+    "content_df.groupby('type').access.value_counts().head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79e1bc15",
+   "metadata": {},
+   "source": [
+    "### Filtering the Dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3dea15fe",
+   "metadata": {},
+   "source": [
+    "We can choose which columns we'd like to view, and the order we'd like to view them in, by providing the DataFrame with a list of strings matching column names:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "1c99e62d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>title</th>\n",
+       "      <th>owner</th>\n",
+       "      <th>type</th>\n",
+       "      <th>access</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>8ec563a6886f474c8d991e7748ab4c03</td>\n",
+       "      <td>Demo Initiative1</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Hub Site Application</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>d1d2876870ab422488e425db4c400361</td>\n",
+       "      <td>Demo Initiative1</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Hub Initiative</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>72567bd147fd478da9563bc56b434870</td>\n",
+       "      <td>geotaggedphotos1</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>6fd3252f1ad044869dd4f949ea4b20cc</td>\n",
+       "      <td>hu_indy_18p</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1d3614ec5cc24382878533f8454c24a3</td>\n",
+       "      <td>intro to notebooks</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Notebook</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 id               title            owner  \\\n",
+       "0  8ec563a6886f474c8d991e7748ab4c03    Demo Initiative1  amani_geosaurus   \n",
+       "1  d1d2876870ab422488e425db4c400361    Demo Initiative1  amani_geosaurus   \n",
+       "2  72567bd147fd478da9563bc56b434870    geotaggedphotos1  amani_geosaurus   \n",
+       "3  6fd3252f1ad044869dd4f949ea4b20cc         hu_indy_18p  amani_geosaurus   \n",
+       "4  1d3614ec5cc24382878533f8454c24a3  intro to notebooks  amani_geosaurus   \n",
+       "\n",
+       "                   type  access  \n",
+       "0  Hub Site Application     org  \n",
+       "1        Hub Initiative     org  \n",
+       "2       Feature Service     org  \n",
+       "3       Feature Service  public  \n",
+       "4              Notebook  public  "
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "view_columns = ['id','title','owner','type','access']\n",
+    "content_df[view_columns].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db990804",
+   "metadata": {},
+   "source": [
+    "Creating and applying Boolean masks is a very efficient way to the filter the rows of a DataFrame. By using standard operators such as <, >, == and != on pandas Series objects (e.g. the columns of our DataFrame), we can create a new Series of True and False values, called a mask. When this mask is applied to the original DataFrame, a new DataFrame will be returned with only the rows corresponding to where the mask had a True value.\n",
+    "\n",
+    "Let's create a mask to represent all items with public level access:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "2b57a301",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    False\n",
+       "1    False\n",
+       "2    False\n",
+       "3     True\n",
+       "4     True\n",
+       "Name: access, dtype: bool"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "filter_value = 'public'\n",
+    "filter_column = 'access'\n",
+    "row_filter = content_df[filter_column]==filter_value\n",
+    "row_filter.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b4de2cf",
+   "metadata": {},
+   "source": [
+    "Applying this mask to our DataFrame, we return all fields for objects which have access=='public':"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "c2dfcf3d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "512 objects in filtered DataFrame\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>owner</th>\n",
+       "      <th>created</th>\n",
+       "      <th>isOrgItem</th>\n",
+       "      <th>modified</th>\n",
+       "      <th>guid</th>\n",
+       "      <th>name</th>\n",
+       "      <th>title</th>\n",
+       "      <th>type</th>\n",
+       "      <th>typeKeywords</th>\n",
+       "      <th>...</th>\n",
+       "      <th>size</th>\n",
+       "      <th>ownerFolder</th>\n",
+       "      <th>commentsEnabled</th>\n",
+       "      <th>itemControl</th>\n",
+       "      <th>layers</th>\n",
+       "      <th>tables</th>\n",
+       "      <th>appProxies</th>\n",
+       "      <th>protected</th>\n",
+       "      <th>contentStatus</th>\n",
+       "      <th>sourceUrl</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>6fd3252f1ad044869dd4f949ea4b20cc</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>1555049137000</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1555049257000</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>hu_indy_18p</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>[ArcGIS Server, Data, Feature Access, Feature ...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1d3614ec5cc24382878533f8454c24a3</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>1630112960000</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1630112990000</td>\n",
+       "      <td>None</td>\n",
+       "      <td>1d3614ec5cc24382878533f8454c24a3.ipynb</td>\n",
+       "      <td>intro to notebooks</td>\n",
+       "      <td>Notebook</td>\n",
+       "      <td>[Notebook, Python]</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>67ec03dba0d44bb1924cd8b3aebf2db4</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>1613548980000</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1613548981000</td>\n",
+       "      <td>None</td>\n",
+       "      <td>KMZ_ContentType_Region_UnitedNations-3.zip</td>\n",
+       "      <td>KMZ_ContentType_Region_UnitedNations-3</td>\n",
+       "      <td>KML Collection</td>\n",
+       "      <td>[KML Collection]</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>8df836df4d544067b715c296608beea4</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>1591834702000</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1591860089000</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Lambda requests on a map</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>[ArcGIS Online, Explorer Web Map, Map, Online ...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>8443e3c2473549f0b464a6a3f295acf9</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>1591655624000</td>\n",
+       "      <td>True</td>\n",
+       "      <td>1591655626000</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>lambda-credit-counter</td>\n",
+       "      <td>Application</td>\n",
+       "      <td>[Application, Registered App]</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 51 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 id            owner        created  \\\n",
+       "3  6fd3252f1ad044869dd4f949ea4b20cc  amani_geosaurus  1555049137000   \n",
+       "4  1d3614ec5cc24382878533f8454c24a3  amani_geosaurus  1630112960000   \n",
+       "5  67ec03dba0d44bb1924cd8b3aebf2db4  amani_geosaurus  1613548980000   \n",
+       "6  8df836df4d544067b715c296608beea4  amani_geosaurus  1591834702000   \n",
+       "7  8443e3c2473549f0b464a6a3f295acf9  amani_geosaurus  1591655624000   \n",
+       "\n",
+       "   isOrgItem       modified  guid                                        name  \\\n",
+       "3       True  1555049257000  None                                        None   \n",
+       "4       True  1630112990000  None      1d3614ec5cc24382878533f8454c24a3.ipynb   \n",
+       "5       True  1613548981000  None  KMZ_ContentType_Region_UnitedNations-3.zip   \n",
+       "6       True  1591860089000  None                                        None   \n",
+       "7       True  1591655626000  None                                        None   \n",
+       "\n",
+       "                                    title             type  \\\n",
+       "3                             hu_indy_18p  Feature Service   \n",
+       "4                      intro to notebooks         Notebook   \n",
+       "5  KMZ_ContentType_Region_UnitedNations-3   KML Collection   \n",
+       "6                Lambda requests on a map          Web Map   \n",
+       "7                   lambda-credit-counter      Application   \n",
+       "\n",
+       "                                        typeKeywords  ... size ownerFolder  \\\n",
+       "3  [ArcGIS Server, Data, Feature Access, Feature ...  ...  NaN         NaN   \n",
+       "4                                 [Notebook, Python]  ...  NaN         NaN   \n",
+       "5                                   [KML Collection]  ...  NaN         NaN   \n",
+       "6  [ArcGIS Online, Explorer Web Map, Map, Online ...  ...  NaN         NaN   \n",
+       "7                      [Application, Registered App]  ...  NaN         NaN   \n",
+       "\n",
+       "  commentsEnabled itemControl layers tables appProxies protected  \\\n",
+       "3             NaN         NaN    NaN    NaN        NaN       NaN   \n",
+       "4             NaN         NaN    NaN    NaN        NaN       NaN   \n",
+       "5             NaN         NaN    NaN    NaN        NaN       NaN   \n",
+       "6             NaN         NaN    NaN    NaN        NaN       NaN   \n",
+       "7             NaN         NaN    NaN    NaN        NaN       NaN   \n",
+       "\n",
+       "  contentStatus sourceUrl  \n",
+       "3           NaN       NaN  \n",
+       "4           NaN       NaN  \n",
+       "5           NaN       NaN  \n",
+       "6           NaN       NaN  \n",
+       "7           NaN       NaN  \n",
+       "\n",
+       "[5 rows x 51 columns]"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(len(content_df[row_filter]), 'objects in filtered DataFrame')\n",
+    "content_df[row_filter].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dc62302",
+   "metadata": {},
+   "source": [
+    "We can apply both the column filter and Boolean mask at the same time to reduce the amount of information displayed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "64b6f2a7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>title</th>\n",
+       "      <th>owner</th>\n",
+       "      <th>type</th>\n",
+       "      <th>access</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>6fd3252f1ad044869dd4f949ea4b20cc</td>\n",
+       "      <td>hu_indy_18p</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1d3614ec5cc24382878533f8454c24a3</td>\n",
+       "      <td>intro to notebooks</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Notebook</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>67ec03dba0d44bb1924cd8b3aebf2db4</td>\n",
+       "      <td>KMZ_ContentType_Region_UnitedNations-3</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>KML Collection</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>8df836df4d544067b715c296608beea4</td>\n",
+       "      <td>Lambda requests on a map</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>8443e3c2473549f0b464a6a3f295acf9</td>\n",
+       "      <td>lambda-credit-counter</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Application</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 id                                   title  \\\n",
+       "3  6fd3252f1ad044869dd4f949ea4b20cc                             hu_indy_18p   \n",
+       "4  1d3614ec5cc24382878533f8454c24a3                      intro to notebooks   \n",
+       "5  67ec03dba0d44bb1924cd8b3aebf2db4  KMZ_ContentType_Region_UnitedNations-3   \n",
+       "6  8df836df4d544067b715c296608beea4                Lambda requests on a map   \n",
+       "7  8443e3c2473549f0b464a6a3f295acf9                   lambda-credit-counter   \n",
+       "\n",
+       "             owner             type  access  \n",
+       "3  amani_geosaurus  Feature Service  public  \n",
+       "4  amani_geosaurus         Notebook  public  \n",
+       "5  amani_geosaurus   KML Collection  public  \n",
+       "6  amani_geosaurus          Web Map  public  \n",
+       "7  amani_geosaurus      Application  public  "
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "content_df[row_filter][view_columns].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2bce8bf",
+   "metadata": {},
+   "source": [
+    "Another example where we create a Boolean mask for all objects of type 'Web Map':"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "99511b85",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>title</th>\n",
+       "      <th>owner</th>\n",
+       "      <th>type</th>\n",
+       "      <th>access</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>8df836df4d544067b715c296608beea4</td>\n",
+       "      <td>Lambda requests on a map</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>5776d859b5a84b1b96d5c5bbfcc0d3d3</td>\n",
+       "      <td>WebMap for Landfall Spotlight Article</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>36</th>\n",
+       "      <td>81ef30218b3f41e89019160faa4de099</td>\n",
+       "      <td>Headless WebMap about Parks</td>\n",
+       "      <td>andrew57</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38</th>\n",
+       "      <td>54fd67f260fe413da84ed4f2d9e1dac2</td>\n",
+       "      <td>National Levee Database Map</td>\n",
+       "      <td>andrew57</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>44</th>\n",
+       "      <td>a478d4172870462dae95d0b26561e3ac</td>\n",
+       "      <td>SarahAWebMapSample</td>\n",
+       "      <td>andrew57</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>46</th>\n",
+       "      <td>ac02f94f0b8d42e59c74fdf9fb249a06</td>\n",
+       "      <td>VectorTileFromOtherSiteLayerandBasemap</td>\n",
+       "      <td>andrew57</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>191</th>\n",
+       "      <td>7d76c6397380497f9879df74f80f0214</td>\n",
+       "      <td>Brick Kilns around Jaipur 2019</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>192</th>\n",
+       "      <td>e91b9226ef224e7da4f32cb034c8b94d</td>\n",
+       "      <td>Brick Klinks around Delhi 2014</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>193</th>\n",
+       "      <td>711b1725f6334aeca2151734b37d3c50</td>\n",
+       "      <td>Brick Klinks around Delhi 2019</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>506</th>\n",
+       "      <td>6527ca7eea2a4cad826e11f298d09500</td>\n",
+       "      <td>Coastline_India</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>507</th>\n",
+       "      <td>a3e8eda445c34e95bdef7aa75bdd8a77</td>\n",
+       "      <td>Coastline_India_l8</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>583</th>\n",
+       "      <td>7d4f5249de15493a9916c03e509b831c</td>\n",
+       "      <td>slums_2004</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>584</th>\n",
+       "      <td>f3f7d8c728e74230baeed747a5322ba5</td>\n",
+       "      <td>slums_2014</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>642</th>\n",
+       "      <td>2fecd25df8624a41b15dfc97ed4c8f98</td>\n",
+       "      <td>Superresolution Inferenced Map</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>657</th>\n",
+       "      <td>2051a50d9370428297dc08a87db4a43f</td>\n",
+       "      <td>oma-test-map</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>658</th>\n",
+       "      <td>7cb38a3325564607a81c0da5733bfbfc</td>\n",
+       "      <td>oma-test-map-updates</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>private</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>659</th>\n",
+       "      <td>966cba4a3bfe487692b305d923fe2777</td>\n",
+       "      <td>oma-test-map-updates-052220</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>private</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>673</th>\n",
+       "      <td>6b43fb3f165245e3b72eba2ff2357d98</td>\n",
+       "      <td>Parcel_extraction_results_e02</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>private</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>783</th>\n",
+       "      <td>7fe016b30663401baf415f4dd1078d36</td>\n",
+       "      <td>Extracted land parcels</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>996</th>\n",
+       "      <td>127a87ebeede4e6c919d43b600763a3b</td>\n",
+       "      <td>Addresses Geocoded</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>private</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1070</th>\n",
+       "      <td>66db719c5a7844a0b681876f7cd4c269</td>\n",
+       "      <td>wm-test-n-layers</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1071</th>\n",
+       "      <td>d0772d26a75141f9ac11998c16b06eed</td>\n",
+       "      <td>wm-test-n-layers-dgray</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1263</th>\n",
+       "      <td>2303b34ac97b4689bd5ff851d5982a96</td>\n",
+       "      <td>USA_coastline</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1311</th>\n",
+       "      <td>6d8e89f6fb0a4c8a8bb5e059846425d9</td>\n",
+       "      <td>Giraffes</td>\n",
+       "      <td>ArcGISPyAPIBot</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1438</th>\n",
+       "      <td>b270d508a6354c6c84510e83f94ebf19</td>\n",
+       "      <td>API_downloads_across_globe</td>\n",
+       "      <td>arcgis_python</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1476</th>\n",
+       "      <td>ebc72a274dff4315b703e5de0a894831</td>\n",
+       "      <td>Location Allocation example of Pizza Stores in...</td>\n",
+       "      <td>arcgis_python</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1478</th>\n",
+       "      <td>27a956e9da094da98ebba3312a456078</td>\n",
+       "      <td>Map_View_Google Drive Image</td>\n",
+       "      <td>arcgis_python</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1480</th>\n",
+       "      <td>e66622a75ac14fffaf2e8223025479a0</td>\n",
+       "      <td>Mobiliario Madrid</td>\n",
+       "      <td>arcgis_python</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1800</th>\n",
+       "      <td>c0da3fa83cd34379b49c56a33247910b</td>\n",
+       "      <td>wMap5_withCharts</td>\n",
+       "      <td>arcgis_python</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1801</th>\n",
+       "      <td>393e05923b7c4d289d305273b30a1ea3</td>\n",
+       "      <td>testing</td>\n",
+       "      <td>DavidJVitale</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1806</th>\n",
+       "      <td>3c9ab685601748b9b55f06c6a529d070</td>\n",
+       "      <td>Chicago Libraries 2012</td>\n",
+       "      <td>jyaist_geosaurus</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1809</th>\n",
+       "      <td>4aeed784e57043e49895293e576f732a</td>\n",
+       "      <td>Guinea Power Plants</td>\n",
+       "      <td>jyaist_geosaurus</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>shared</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1832</th>\n",
+       "      <td>0c4170b6934245269ffc3f41acbb4a87</td>\n",
+       "      <td>LeafPickupMap</td>\n",
+       "      <td>naubry_geosaurus</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                    id  \\\n",
+       "6     8df836df4d544067b715c296608beea4   \n",
+       "23    5776d859b5a84b1b96d5c5bbfcc0d3d3   \n",
+       "36    81ef30218b3f41e89019160faa4de099   \n",
+       "38    54fd67f260fe413da84ed4f2d9e1dac2   \n",
+       "44    a478d4172870462dae95d0b26561e3ac   \n",
+       "46    ac02f94f0b8d42e59c74fdf9fb249a06   \n",
+       "191   7d76c6397380497f9879df74f80f0214   \n",
+       "192   e91b9226ef224e7da4f32cb034c8b94d   \n",
+       "193   711b1725f6334aeca2151734b37d3c50   \n",
+       "506   6527ca7eea2a4cad826e11f298d09500   \n",
+       "507   a3e8eda445c34e95bdef7aa75bdd8a77   \n",
+       "583   7d4f5249de15493a9916c03e509b831c   \n",
+       "584   f3f7d8c728e74230baeed747a5322ba5   \n",
+       "642   2fecd25df8624a41b15dfc97ed4c8f98   \n",
+       "657   2051a50d9370428297dc08a87db4a43f   \n",
+       "658   7cb38a3325564607a81c0da5733bfbfc   \n",
+       "659   966cba4a3bfe487692b305d923fe2777   \n",
+       "673   6b43fb3f165245e3b72eba2ff2357d98   \n",
+       "783   7fe016b30663401baf415f4dd1078d36   \n",
+       "996   127a87ebeede4e6c919d43b600763a3b   \n",
+       "1070  66db719c5a7844a0b681876f7cd4c269   \n",
+       "1071  d0772d26a75141f9ac11998c16b06eed   \n",
+       "1263  2303b34ac97b4689bd5ff851d5982a96   \n",
+       "1311  6d8e89f6fb0a4c8a8bb5e059846425d9   \n",
+       "1438  b270d508a6354c6c84510e83f94ebf19   \n",
+       "1476  ebc72a274dff4315b703e5de0a894831   \n",
+       "1478  27a956e9da094da98ebba3312a456078   \n",
+       "1480  e66622a75ac14fffaf2e8223025479a0   \n",
+       "1800  c0da3fa83cd34379b49c56a33247910b   \n",
+       "1801  393e05923b7c4d289d305273b30a1ea3   \n",
+       "1806  3c9ab685601748b9b55f06c6a529d070   \n",
+       "1809  4aeed784e57043e49895293e576f732a   \n",
+       "1832  0c4170b6934245269ffc3f41acbb4a87   \n",
+       "\n",
+       "                                                  title             owner  \\\n",
+       "6                              Lambda requests on a map   amani_geosaurus   \n",
+       "23                WebMap for Landfall Spotlight Article   amani_geosaurus   \n",
+       "36                          Headless WebMap about Parks          andrew57   \n",
+       "38                          National Levee Database Map          andrew57   \n",
+       "44                                   SarahAWebMapSample          andrew57   \n",
+       "46               VectorTileFromOtherSiteLayerandBasemap          andrew57   \n",
+       "191                      Brick Kilns around Jaipur 2019    api_data_owner   \n",
+       "192                      Brick Klinks around Delhi 2014    api_data_owner   \n",
+       "193                      Brick Klinks around Delhi 2019    api_data_owner   \n",
+       "506                                     Coastline_India    api_data_owner   \n",
+       "507                                  Coastline_India_l8    api_data_owner   \n",
+       "583                                          slums_2004    api_data_owner   \n",
+       "584                                          slums_2014    api_data_owner   \n",
+       "642                      Superresolution Inferenced Map    api_data_owner   \n",
+       "657                                        oma-test-map    api_data_owner   \n",
+       "658                                oma-test-map-updates    api_data_owner   \n",
+       "659                         oma-test-map-updates-052220    api_data_owner   \n",
+       "673                       Parcel_extraction_results_e02    api_data_owner   \n",
+       "783                              Extracted land parcels    api_data_owner   \n",
+       "996                                  Addresses Geocoded    api_data_owner   \n",
+       "1070                                   wm-test-n-layers    api_data_owner   \n",
+       "1071                             wm-test-n-layers-dgray    api_data_owner   \n",
+       "1263                                      USA_coastline    api_data_owner   \n",
+       "1311                                           Giraffes    ArcGISPyAPIBot   \n",
+       "1438                         API_downloads_across_globe     arcgis_python   \n",
+       "1476  Location Allocation example of Pizza Stores in...     arcgis_python   \n",
+       "1478                        Map_View_Google Drive Image     arcgis_python   \n",
+       "1480                                  Mobiliario Madrid     arcgis_python   \n",
+       "1800                                   wMap5_withCharts     arcgis_python   \n",
+       "1801                                            testing      DavidJVitale   \n",
+       "1806                             Chicago Libraries 2012  jyaist_geosaurus   \n",
+       "1809                                Guinea Power Plants  jyaist_geosaurus   \n",
+       "1832                                      LeafPickupMap  naubry_geosaurus   \n",
+       "\n",
+       "         type   access  \n",
+       "6     Web Map   public  \n",
+       "23    Web Map   public  \n",
+       "36    Web Map   public  \n",
+       "38    Web Map   public  \n",
+       "44    Web Map      org  \n",
+       "46    Web Map   public  \n",
+       "191   Web Map   public  \n",
+       "192   Web Map   public  \n",
+       "193   Web Map   public  \n",
+       "506   Web Map   public  \n",
+       "507   Web Map   public  \n",
+       "583   Web Map   public  \n",
+       "584   Web Map   public  \n",
+       "642   Web Map   public  \n",
+       "657   Web Map      org  \n",
+       "658   Web Map  private  \n",
+       "659   Web Map  private  \n",
+       "673   Web Map  private  \n",
+       "783   Web Map   public  \n",
+       "996   Web Map  private  \n",
+       "1070  Web Map      org  \n",
+       "1071  Web Map      org  \n",
+       "1263  Web Map   public  \n",
+       "1311  Web Map      org  \n",
+       "1438  Web Map      org  \n",
+       "1476  Web Map   public  \n",
+       "1478  Web Map   public  \n",
+       "1480  Web Map   public  \n",
+       "1800  Web Map   public  \n",
+       "1801  Web Map   public  \n",
+       "1806  Web Map      org  \n",
+       "1809  Web Map   shared  \n",
+       "1832  Web Map      org  "
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "filter_value = 'Web Map'\n",
+    "filter_column = 'type'\n",
+    "row_filter = content_df[filter_column]==filter_value\n",
+    "content_df[row_filter][view_columns]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1567216f",
+   "metadata": {},
+   "source": [
+    "Boolean masks can also be combined to represent multiple filters. Here we combine the Web Map and Public masks to return all items in our organization which are public web maps:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "7dd8ded0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>title</th>\n",
+       "      <th>owner</th>\n",
+       "      <th>type</th>\n",
+       "      <th>access</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>8df836df4d544067b715c296608beea4</td>\n",
+       "      <td>Lambda requests on a map</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>5776d859b5a84b1b96d5c5bbfcc0d3d3</td>\n",
+       "      <td>WebMap for Landfall Spotlight Article</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>36</th>\n",
+       "      <td>81ef30218b3f41e89019160faa4de099</td>\n",
+       "      <td>Headless WebMap about Parks</td>\n",
+       "      <td>andrew57</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38</th>\n",
+       "      <td>54fd67f260fe413da84ed4f2d9e1dac2</td>\n",
+       "      <td>National Levee Database Map</td>\n",
+       "      <td>andrew57</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>46</th>\n",
+       "      <td>ac02f94f0b8d42e59c74fdf9fb249a06</td>\n",
+       "      <td>VectorTileFromOtherSiteLayerandBasemap</td>\n",
+       "      <td>andrew57</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>191</th>\n",
+       "      <td>7d76c6397380497f9879df74f80f0214</td>\n",
+       "      <td>Brick Kilns around Jaipur 2019</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>192</th>\n",
+       "      <td>e91b9226ef224e7da4f32cb034c8b94d</td>\n",
+       "      <td>Brick Klinks around Delhi 2014</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>193</th>\n",
+       "      <td>711b1725f6334aeca2151734b37d3c50</td>\n",
+       "      <td>Brick Klinks around Delhi 2019</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>506</th>\n",
+       "      <td>6527ca7eea2a4cad826e11f298d09500</td>\n",
+       "      <td>Coastline_India</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>507</th>\n",
+       "      <td>a3e8eda445c34e95bdef7aa75bdd8a77</td>\n",
+       "      <td>Coastline_India_l8</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>583</th>\n",
+       "      <td>7d4f5249de15493a9916c03e509b831c</td>\n",
+       "      <td>slums_2004</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>584</th>\n",
+       "      <td>f3f7d8c728e74230baeed747a5322ba5</td>\n",
+       "      <td>slums_2014</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>642</th>\n",
+       "      <td>2fecd25df8624a41b15dfc97ed4c8f98</td>\n",
+       "      <td>Superresolution Inferenced Map</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>783</th>\n",
+       "      <td>7fe016b30663401baf415f4dd1078d36</td>\n",
+       "      <td>Extracted land parcels</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1263</th>\n",
+       "      <td>2303b34ac97b4689bd5ff851d5982a96</td>\n",
+       "      <td>USA_coastline</td>\n",
+       "      <td>api_data_owner</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1476</th>\n",
+       "      <td>ebc72a274dff4315b703e5de0a894831</td>\n",
+       "      <td>Location Allocation example of Pizza Stores in...</td>\n",
+       "      <td>arcgis_python</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1478</th>\n",
+       "      <td>27a956e9da094da98ebba3312a456078</td>\n",
+       "      <td>Map_View_Google Drive Image</td>\n",
+       "      <td>arcgis_python</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1480</th>\n",
+       "      <td>e66622a75ac14fffaf2e8223025479a0</td>\n",
+       "      <td>Mobiliario Madrid</td>\n",
+       "      <td>arcgis_python</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1800</th>\n",
+       "      <td>c0da3fa83cd34379b49c56a33247910b</td>\n",
+       "      <td>wMap5_withCharts</td>\n",
+       "      <td>arcgis_python</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1801</th>\n",
+       "      <td>393e05923b7c4d289d305273b30a1ea3</td>\n",
+       "      <td>testing</td>\n",
+       "      <td>DavidJVitale</td>\n",
+       "      <td>Web Map</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                    id  \\\n",
+       "6     8df836df4d544067b715c296608beea4   \n",
+       "23    5776d859b5a84b1b96d5c5bbfcc0d3d3   \n",
+       "36    81ef30218b3f41e89019160faa4de099   \n",
+       "38    54fd67f260fe413da84ed4f2d9e1dac2   \n",
+       "46    ac02f94f0b8d42e59c74fdf9fb249a06   \n",
+       "191   7d76c6397380497f9879df74f80f0214   \n",
+       "192   e91b9226ef224e7da4f32cb034c8b94d   \n",
+       "193   711b1725f6334aeca2151734b37d3c50   \n",
+       "506   6527ca7eea2a4cad826e11f298d09500   \n",
+       "507   a3e8eda445c34e95bdef7aa75bdd8a77   \n",
+       "583   7d4f5249de15493a9916c03e509b831c   \n",
+       "584   f3f7d8c728e74230baeed747a5322ba5   \n",
+       "642   2fecd25df8624a41b15dfc97ed4c8f98   \n",
+       "783   7fe016b30663401baf415f4dd1078d36   \n",
+       "1263  2303b34ac97b4689bd5ff851d5982a96   \n",
+       "1476  ebc72a274dff4315b703e5de0a894831   \n",
+       "1478  27a956e9da094da98ebba3312a456078   \n",
+       "1480  e66622a75ac14fffaf2e8223025479a0   \n",
+       "1800  c0da3fa83cd34379b49c56a33247910b   \n",
+       "1801  393e05923b7c4d289d305273b30a1ea3   \n",
+       "\n",
+       "                                                  title            owner  \\\n",
+       "6                              Lambda requests on a map  amani_geosaurus   \n",
+       "23                WebMap for Landfall Spotlight Article  amani_geosaurus   \n",
+       "36                          Headless WebMap about Parks         andrew57   \n",
+       "38                          National Levee Database Map         andrew57   \n",
+       "46               VectorTileFromOtherSiteLayerandBasemap         andrew57   \n",
+       "191                      Brick Kilns around Jaipur 2019   api_data_owner   \n",
+       "192                      Brick Klinks around Delhi 2014   api_data_owner   \n",
+       "193                      Brick Klinks around Delhi 2019   api_data_owner   \n",
+       "506                                     Coastline_India   api_data_owner   \n",
+       "507                                  Coastline_India_l8   api_data_owner   \n",
+       "583                                          slums_2004   api_data_owner   \n",
+       "584                                          slums_2014   api_data_owner   \n",
+       "642                      Superresolution Inferenced Map   api_data_owner   \n",
+       "783                              Extracted land parcels   api_data_owner   \n",
+       "1263                                      USA_coastline   api_data_owner   \n",
+       "1476  Location Allocation example of Pizza Stores in...    arcgis_python   \n",
+       "1478                        Map_View_Google Drive Image    arcgis_python   \n",
+       "1480                                  Mobiliario Madrid    arcgis_python   \n",
+       "1800                                   wMap5_withCharts    arcgis_python   \n",
+       "1801                                            testing     DavidJVitale   \n",
+       "\n",
+       "         type  access  \n",
+       "6     Web Map  public  \n",
+       "23    Web Map  public  \n",
+       "36    Web Map  public  \n",
+       "38    Web Map  public  \n",
+       "46    Web Map  public  \n",
+       "191   Web Map  public  \n",
+       "192   Web Map  public  \n",
+       "193   Web Map  public  \n",
+       "506   Web Map  public  \n",
+       "507   Web Map  public  \n",
+       "583   Web Map  public  \n",
+       "584   Web Map  public  \n",
+       "642   Web Map  public  \n",
+       "783   Web Map  public  \n",
+       "1263  Web Map  public  \n",
+       "1476  Web Map  public  \n",
+       "1478  Web Map  public  \n",
+       "1480  Web Map  public  \n",
+       "1800  Web Map  public  \n",
+       "1801  Web Map  public  "
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Combining masks\n",
+    "web_map_filter = content_df.type=='Web Map'\n",
+    "public_filter = content_df.access=='public'\n",
+    "combined_mask = web_map_filter & public_filter\n",
+    "\n",
+    "content_df[combined_mask][view_columns]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49f5fc4a",
+   "metadata": {},
+   "source": [
+    "The [.apply()](https://pandas.pydata.org/docs/reference/api/pandas.Series.apply.html) method can also be used to generate masks that can't be created using the standard comparison operators. As long as the function called within the apply method has a Boolean output, then the result can be used as a mask to filter rows. Here we use a [lambda](https://www.w3schools.com/python/python_lambda.asp) function to return all items which have a type that ends with the word \"Service\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "4bc5ef6e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>title</th>\n",
+       "      <th>owner</th>\n",
+       "      <th>type</th>\n",
+       "      <th>access</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>72567bd147fd478da9563bc56b434870</td>\n",
+       "      <td>geotaggedphotos1</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>6fd3252f1ad044869dd4f949ea4b20cc</td>\n",
+       "      <td>hu_indy_18p</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>d77abcdc3f04488f84ad22bc7afdfcad</td>\n",
+       "      <td>Landfall density 2</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Map Service</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>ffef49c345154bc5b24c8e2e39587ec4</td>\n",
+       "      <td>Landfall Spotlight Article_WFL1</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>e0959e7018914be0931a9f15efb56c94</td>\n",
+       "      <td>request_locations</td>\n",
+       "      <td>amani_geosaurus</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1827</th>\n",
+       "      <td>c4b35a4cd48b4cbbbc6dea300afed7f8</td>\n",
+       "      <td>UK_Primary_and_Secondary_Roads</td>\n",
+       "      <td>jyaist_geosaurus</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1828</th>\n",
+       "      <td>f129290c5da14d7884b26951eddd6b29</td>\n",
+       "      <td>KingCo_PropertyInfo</td>\n",
+       "      <td>maggarwal_geosaurus</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1831</th>\n",
+       "      <td>42e944d92e1346f5a4229aa76841e5c2</td>\n",
+       "      <td>Leaf_Pickup_Routes</td>\n",
+       "      <td>naubry_geosaurus</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>org</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1834</th>\n",
+       "      <td>1cc19cce694e4caf95ce4471befd55b7</td>\n",
+       "      <td>Vexcel_Houston_Nadir</td>\n",
+       "      <td>rohitgeo</td>\n",
+       "      <td>Image Service</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1843</th>\n",
+       "      <td>b120ffa7170f4be0b5aaad8a284c6be5</td>\n",
+       "      <td>Trailheads</td>\n",
+       "      <td>yjiang_geosaurus</td>\n",
+       "      <td>Feature Service</td>\n",
+       "      <td>public</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>450 rows × 5 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                    id                            title  \\\n",
+       "2     72567bd147fd478da9563bc56b434870                 geotaggedphotos1   \n",
+       "3     6fd3252f1ad044869dd4f949ea4b20cc                      hu_indy_18p   \n",
+       "9     d77abcdc3f04488f84ad22bc7afdfcad               Landfall density 2   \n",
+       "11    ffef49c345154bc5b24c8e2e39587ec4  Landfall Spotlight Article_WFL1   \n",
+       "19    e0959e7018914be0931a9f15efb56c94                request_locations   \n",
+       "...                                ...                              ...   \n",
+       "1827  c4b35a4cd48b4cbbbc6dea300afed7f8   UK_Primary_and_Secondary_Roads   \n",
+       "1828  f129290c5da14d7884b26951eddd6b29              KingCo_PropertyInfo   \n",
+       "1831  42e944d92e1346f5a4229aa76841e5c2               Leaf_Pickup_Routes   \n",
+       "1834  1cc19cce694e4caf95ce4471befd55b7             Vexcel_Houston_Nadir   \n",
+       "1843  b120ffa7170f4be0b5aaad8a284c6be5                       Trailheads   \n",
+       "\n",
+       "                    owner             type  access  \n",
+       "2         amani_geosaurus  Feature Service     org  \n",
+       "3         amani_geosaurus  Feature Service  public  \n",
+       "9         amani_geosaurus      Map Service  public  \n",
+       "11        amani_geosaurus  Feature Service  public  \n",
+       "19        amani_geosaurus  Feature Service  public  \n",
+       "...                   ...              ...     ...  \n",
+       "1827     jyaist_geosaurus  Feature Service     org  \n",
+       "1828  maggarwal_geosaurus  Feature Service  public  \n",
+       "1831     naubry_geosaurus  Feature Service     org  \n",
+       "1834             rohitgeo    Image Service  public  \n",
+       "1843     yjiang_geosaurus  Feature Service  public  \n",
+       "\n",
+       "[450 rows x 5 columns]"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Creating masks with .apply and lambda functions\n",
+    "\n",
+    "service_filter = content_df.type.apply(lambda x: x.endswith('Service'))\n",
+    "content_df[service_filter][view_columns]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05a20701",
+   "metadata": {},
+   "source": [
+    "### Accessing Content by ID"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec8a7700",
+   "metadata": {},
+   "source": [
+    "Once we've identified an item of interest in our DataFrame, we can return the content of that item by providing its ID to the [ContentManager](https://pandas.pydata.org/docs/reference/api/pandas.Series.apply.html) .get() method. If we know the index of the object in the DataFrame (i.e. the leftmost value), then we can access that row's information using the .loc() method. From there we can get the id of the item and provide it to the get method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "35621706",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Target index: 1843\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Return the index of the last item in the previous output\n",
+    "# In this example the index column is labelled 'name'\n",
+    "\n",
+    "target_index = content_df[service_filter].iloc[-1].name\n",
+    "print(\"Target index:\", target_index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "1fd7594f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "b120ffa7170f4be0b5aaad8a284c6be5\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=b120ffa7170f4be0b5aaad8a284c6be5' target='_blank'>\n",
+       "                        <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAACFCAYAAAAenrcsAAAP/0lEQVR4Xu3deXSU5b0H8JzT295zz73ef3qrvfXeaq0WQYpCC9wby1Upuyg7KYiCSihBILKDSYAQiApCrKlGoITNSpBF2RTKIihQ2SEhyySZTJLJ7Ns7+/bOfO+8w6ltHpOXzJpZfp9z8kee73viGPKded9n3ueZDBBCOpXBDhBC/o4KkkAcsnqYzx0F73SwEekmVJAw3F67EFWTM8E11LFR2LxWC0zvvATXzmwYj3zCxqSbUEFC5FC2wbhiFPiKOWhY9Hs2DpvP44ViwxzIlz4B281LbEy6CRUkRB6rFVcy70fN0Ay0bC1h44j43B54OSM7TLoRFSRMFpudHSIpiApCiAgqCCEiqCBdpD3xKfRfnWSHSYqjgnSBsfImHGtHQJPdD3a5go1JCqOCdIHHYkNDdn805Q4F7/KyMUlhVBBCRFBBCBFBBSFEBBWEEBFUEEJEUEEIEUEFIUQEFYQQEVQQQkRQQQgRQQUhRAQVhBARVBCSEjxmE5oWjINkzmh4bVY2DhsVhKQEW9VVcOuHwLigL+xVt9g4bFQQkhI8Fgtuv/Qb1M4dAd7lZOOwUUEIEUEFiRLeboVHr4bPSwuqYs3H84Hft40djgkqSJRIXn0KpvxhkKxawkYd8ge+LJIaeH0+NiIi+MATkPr9ldAVTAZXeY2Noy6tC8LbLPAadfAHnpEida3/D2As6AVJ1mg26pDx4im4i0ejrXAu/D6hLqQrXFoNdIEnIsefsqDeVMTGUZe2BfFYzFDlZ8HwZhaUf97KxiETns3Un22H28KxUYe0B3dAveIRKBaMDW47SrrGz/ugO7obih35cLY2sXHUpW1BXGo1Wmf3gy6vFxTrV7FxzPn9flhlDeA9HjYiEdId/Rjy/GlwqiLfgSZtC2KXVEK3ahTkM38Ja00lG5MkJUz36vKHw142CoYDu9g4ZGlbEEezFA0zH0HzzMfgUsjZmCQx5b6daJg/DG6Tno1ClrIF8ft8MJ44AP3JQ8HTmY547HZ46cNqiIiULYhTJoFr7wpYCkfC2SJjY0K6JGUL4jHq0TQvE82Lh4K3mMHzPCyy2M96kNSSsgX5R8IJlnTBBFjm9EVjyTo2JqRTaVEQybqFqH/+YdRMeAS3BveAXdXGHkJIh9KiIHWFyyDP7gOcKYJ8Qg/IivPYQwjpUFIURJht0lWUwakKbzrWodZA+uZ81Iy5B9efyIBy/0dQlm9Ay9uL4TJ37Z1vkp6SoiCtRXOAk2sgmTSAjUIiXIsIX6qSJVAuHAJ8nI3Lz2bC18k0MCFJURD5tvchnXwP6of8CIoP34FD2coeEhLDmWO49uS/QvbKQ2ie1APWG1fZQ0iSchu0UJXmQ3f+NBuFJSkKImgsmofK8b8E/lIE2ZwxbBwya101arPuQ8PEn8BWd5uNo8rv4+Fzu9jh5BZ41fW7HPDziXWjZVtpAXC6EG0vD4LXbGbjkCVNQQT6U8cgfekBqLe/w0ZhcXImuGwWdjiqgusXygqhzZ8MruoGGyct7sIJWLflQr1pGXzeyJcLRIv22H7UPft9SJdOhT8KjyupCpKMgusXCobDsWVi4I9pLRsnLc3erdCv6w1V7vOBV8fEuiM5mleUVJAQ8YE/Bq5Bwg53SliMpT+yE8rdK+FskbJx0vK53TCc2A+nRslGKYUKEiLl+lw4Xh8A6fYyNiIpiAoSopqsx6Ev6Iu6YY+Dt4a2QZnX6YR+/1Y4FC1slLKMZw7DdCE6M0pdIWzmYNi3GVZpAxuFJe0K4vd6Al/hz7woKspRN+NHaHnt2S4vldV9fRKNWX1we+KvgDPFUZmFSwbGa1fgKp0CXe4g2Jrj86Sg27cl8DteE7g2eg68K/KZw7QqiF3eClNJNlQFU+E2mti4yzzO0H7x1VmZ8B2Yjuon/wvN8/pAVR6dWbhoEi5suepKeCN48mC5OTOkrz2J5kWjwDtC+52Fi7vyNaQzH4KqrDAqm2GkRUGExVPw8eBuVUE1/+dQTvsZnG0q9rCYMd66hSsD/w3KLyrY6Ft+vy/43kJ3MV34C/gN49C2cnbglVF4lXVH5fFE/hNCF/xvCu/TRGFLpZQviPAya9q2EqY/zob15mWYvjkHc9Vl9rBu5Xa5YSzLg+aD1eCj8I8aDt2h3VCvegItuc9DtWoa9OsmQXdkH3tYUrAbjVAWTEPziulwOyJbMRqdgkThmSZWvDY7lG+MgH5lb5i+OMDGd8Ty8Qs/+y4/X//1V7C++RQ0s/rAIemeqWDj+ZNwFD8H6dzJgeurgdDl94Rmcwl7WFJQ7K8I/j7VMx8Dd/osG4ckwoL44bHb0LhpNVQ3rrBhwrA2SKA/vrfDbUFNV89D9eFaOI0GNoqK62tyce2tFexwO7zbC92n78N0tDwqpwXh0B7YDs2KHlAunQztl6eg2lOatOv13ZwFqh2F0Ox6K+IL9QgLAtSsXQj/xvGQjB8AV+ClLdk0ZPUC9vweta9msVHEzr8+HZKRD6J5Uh/89emHYYnxPV+RcnHGjje4EK6P4syhkkN5eE/HjyeOIi5Ibe4L0ARejhtG/gwerZaNE15NznOoG/0vUH+ym40i4tRqoF86DN4tU1Ez8IeQZT0M1bvJd6uJ4fgnaCvKhv5geVxfUZrnDYVn3f9BXvJ2u/HaLZtQv6e83VgsRVwQ4VYK2YVT4J3x2W07FmLxLOWxWFH3Ql80vnwvLg55DJXPPwh7mAu+upNkcm9Y1oyE53AeDIc7n4WLtqa1OWia+kOYzn/57Vj9/o9hnf+/kI/vAfnxY3cGv/Nv57+z17KPj8qeyxEXhIhzhfieSbi8gXNtrr6OHY6YMfDkJ8vPQnNOL9huX2fjmGj5eDNaZg5C7dql7cabtpShbca9kI26B7L1RbB8uBi6zz5qd4yp6jpuPP0TGIsn468D/7tdFg4qSIpQrp8PR25/qL44wkZdF5xx++77McJ3sXiV7Uz1xL7w7ZuO2w9+j41gaKiFRS0PXICXwP3R76CYOwJeuwuKDQug+KAI0pI1uNb/HnDFfXDtvsj/vCP/CSQhNOb8FprcB6HeXMpGXcLbrOB2v422N6ZAWbqq296PEagP7UPr5teh3Nn5NLNT0QrN3jWwXT4Dw6VLMK8eCG32Y2gqXIiWRf1we8gDUAZe/SJFBUkRwqpFjyP860BnYw1s742BaVXgwnjCQ3BIGtlDElrDmly0bFkLD2eCZNZg6C5GXg4BFYQE8Q5H4Hz+Pah3robhsz9F5T6meDMf3wPTB4vh0mnYKGwZ0fxEUJKk4nh9ESsejoNh7Rg4No+DaV/kH3vwNxmKP9BWnOlMWD/BHfsINllynVKxhI5z5w4FrkuK4NFF70bUDOOZCGY9SNIT1k/4vyyGasEY8HGako6du9/3Fiq6BulGwttYrdvfgyEKsy3h4i6dgyynB1RlqyO67qjLz0b9uEfR+mn83kyMh/QoSHBuv/umLTvi4YyonDwQ/k1TcDPzx3C2hrYZnrOtGW2Lxwa3uYlUSDdIdvJeSVXm9+ApH4vq3/RrN57sUr4gbs6E5pxnoFk+DLLSt9i429hrr6Nm1I+hWj4A3KYXUTXsEegvnWcP65R69x/grJgKZfbTcTs1Mt26itoXn4R23gDULHmtXVY1ZwKqJtwP1d4d7caTXcoXxKlUoGXW49DlPYrmJbPZuNt47XZUvfgUrgz5KfTr+qDl2fshL1jMHtYpt06D+pxh0H9zho1iRpo9BE0z+8JU0AvVIwe1D/3CCr7I731KNGEXxCKpDi7NTAayHWVoLl0J/dWvYT6+NzjnnyhU+3dCvnA4ml55HKaLZ9k4oVQvnoWq3/4TLo3tB2cEb0omk7AKoqzYDL54DOQbxRcC3U1t+bu4PLw3HPq/3SYvPAuFf6EoxmMxw1LyKjxH8mE81D0Xknzgf02xPhfykrxv12obzp6A8vWfQzO/D1zy+Oz8EQmPwx7aNUuSC6sgrRvzoHujJ9qWz2CjLnOoVdAtfAZ82STIVt05tTBsLYBh4wyYr1xgjo6csH9s26ZcNM/rDVvlNTaOC8Olb2AuzIRmRg/Ypc3fjutPH4UxjqdKpOvCKohwvum0WSDJGQ3pxF7QnAt9mlLYEqZ6wqOo/92/Q7m9NLi/q3LFMOgKeoL7/CB7eHQI58kdLLuNJ2nxYrSUt18ERBJXeAXBnYtf3fLBcOyaCtnSHDbuMofz79cxlnoJtId3w5dgW+pHT2xOH0nshF0QwbWXxuDG0PtgltayESEpIaKCEJLqqCCEiKCCECKCCkKICCoIISKoIISIoIIQIoIKQogIKgghIqgghIiIaUFcFjNa86ZB+sbLwU94JSTZxLQgwU/6WfM/UM34BbgzZ9mYEDTt24HTfe+F3ahno4QQ04K4LXa0rp8NRckC8O7kWH1I4uvWwO8DZRNw9elfsVFCiGlBCLmbcz3/GQ1jfoCaudPYKCHEtSDCQk3j5xXQnzhIKyPIt1sHORJ4BW9cC6L+/CBcf5wC7dxMGC9Ef1ktIdEW14JY6xshmfoQGqf1hlOpZmNCEk5cCyLw2qzgnXZ2mJCEFPeCxJuwe7lh13poNxeCPuqBhCrlC+JorIFl43AY8wbB1ZTcW/yT+Ev5ggi7KCq3r4J2dzF8Hnfg9M4Ba1M9exghHUr5grCUG3LhyhsM1eEDbETId6RdQRpzBkO3rCfUH7zLRoR8R9oVhHfY4eF08POptxM5ib60KwghoaCCECKCCkKICCoIISKoICTlCfcM22UN4N2hf5ZjWhfE3FgL5c5S8EnyUXIkPOo9ZXBtmoaW9cvY6K66rSB+vx/G4xXQlCyAUyln45jz2O0wrhwHT9kkGKPwUcokcTUUzoNh+VOQju0Fryu0J8NuK4jHbIZ+5UjYS0fAuH8XG8ecn/ehpXg2Gqf9J+zVN9iYpBCusgaKnAfQNuWncKo0bCyq2woi0B7aBfnGV+DWqtio26TTB1SmE8PFr8BVX2eH7ypqBXGajHDbrOxwOx6OS9iltsLj0u/bCl3hi3C0tbIxSVMZtobQPz5Nf/E0mnKGoe3PHwa/5xokUM/6NaST+sCuUDJH38F9cxrcunFQvrMseHqTaIRTPkPRONh3vADjgfif8pHElKFYs4Qdu6uaqYPg2z0etf3vC36vOXESytn3o23cf8B84yZz9B2a/eXQrPwFlPNHw5egs0a6U4fRunEePCYDG5E0leFokbJjd6U9exKNi4ZA/em24Pcerwe3RjyKGxN/Dd7b8auDUArd0Qo4DDo2IhEQbr7U7Xgb6uCKydDn+Ym4qFyDtO7cFtxBUTP9Yeg/O8TGJIaCKyY3DIVxRSatmIyBqBTEyVlRm/0MGhY8B6/LzcYkhoQVk/LSRVBuyUvYU9dkFpWCEJKqqCCEiKCCECKCCkKICCoIISKoIISIoIIQIoIKQogIKgghIqgghIigghAiggpCiAgqCCEiqCCEiKCCECKCCkKICCoIISL+H+93asluckbjAAAAAElFTkSuQmCC' width='200' height='133' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=b120ffa7170f4be0b5aaad8a284c6be5' target='_blank'><b>Trailheads</b>\n",
+       "                        </a>\n",
+       "                        <br/><img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by yjiang_geosaurus\n",
+       "                        <br/>Last Modified: July 28, 2020\n",
+       "                        <br/>0 comments, 16 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"Trailheads\" type:Feature Layer Collection owner:yjiang_geosaurus>"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Accessing items with content.get()\n",
+    "target_data = content_df.loc[target_index]\n",
+    "print(target_data.id)\n",
+    "target_content = gis.content.get(target_data.id)\n",
+    "target_content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6e5253b",
+   "metadata": {},
+   "source": [
+    "For more information on using item ids, see this [community post](https://community.esri.com/t5/arcgis-online-blog/where-can-i-find-the-item-id-for-an-arcgis-online/ba-p/890284)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d9fc08d",
+   "metadata": {},
+   "source": [
+    "## Exporting Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf5d20c4",
+   "metadata": {},
+   "source": [
+    "Pandas provides a convenient [to_csv()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_csv.html) method which can be used to generate zipped and unzipped csv outputs. Simply provide your target path with the appropriate file extension and call the method on the DataFrame object you would like to export."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "2e6f663e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Exporting data to a csv\n",
+    "target_path = \"org_content.csv\"\n",
+    "content_df.to_csv(target_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "488b9fa5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Exporting data to gzipped csv file\n",
+    "target_path_gzip = \"org_content.csv.gz\"\n",
+    "content_df.to_csv(target_path_gzip)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "cfb77f34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Exporting data to zipped csv file\n",
+    "target_path_zip = \"org_content.csv.zip\"\n",
+    "content_df.to_csv(target_path_zip)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07b3fb58",
+   "metadata": {},
+   "source": [
+    "Pandas also provides additional methods for exporting the data as different file formats (e.g. [to_json()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html), [to_pickle()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_pickle.html), [to_excel()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_excel.html)) which behave similarly."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/guide/03-the-gis/organization-inventory.ipynb
+++ b/guide/03-the-gis/organization-inventory.ipynb
@@ -2,7 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "eb5374db",
+   "id": "63c4b10f",
+   "metadata": {},
+   "source": [
+    "# Portal Inventory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42a813b1",
    "metadata": {},
    "source": [
     "Being able to retrieve, display, analyze, and export the content within an organization portal are important tasks for any admin. Here we will leverage the [ContentManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#contentmanager) and [UserManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#usermanager) classes of the GIS module, as well as some functionality from the [Pandas](https://pandas.pydata.org/docs/index.html) library, to accomplish those tasks.\n",
@@ -26,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "255c8207",
+   "id": "f40f8dc9",
    "metadata": {},
    "source": [
     "## Import Libraries"
@@ -35,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "57228c46",
+   "id": "744116bd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "e72eda47",
+   "id": "d8ce68a4",
    "metadata": {},
    "outputs": [
     {
@@ -69,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05cd7ebb",
+   "id": "abca04ba",
    "metadata": {},
    "source": [
     "## Connect to ArcGIS Online"
@@ -78,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "4c403f9e",
+   "id": "381d4d51",
    "metadata": {},
    "outputs": [
     {
@@ -122,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c3c5683",
+   "id": "c8806f8b",
    "metadata": {},
    "source": [
     "## Querying Content"
@@ -130,7 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fc71bbb7",
+   "id": "4ae14d15",
    "metadata": {},
    "source": [
     "To search for content within our organization, we can access the [ContentManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager) class via gis.content. \n",
@@ -143,7 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "480ba363",
+   "id": "79af1155",
    "metadata": {},
    "outputs": [
     {
@@ -162,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2feb66cd",
+   "id": "fef3d52e",
    "metadata": {},
    "source": [
     "### Searching for Content"
@@ -170,7 +178,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6014647",
+   "id": "55de05fb",
    "metadata": {},
    "source": [
     "If we leave the return_count parameter as its default value False, then we will receive a response dictionary containing metadata about the query as well as a list of returned items in the 'results' field.\n",
@@ -181,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "489d9374",
+   "id": "86ac5837",
    "metadata": {},
    "outputs": [
     {
@@ -210,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51bb8322",
+   "id": "152ff064",
    "metadata": {},
    "source": [
     "### Displaying Content"
@@ -219,7 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "49d75100",
+   "id": "8404b157",
    "metadata": {},
    "outputs": [
     {
@@ -313,7 +321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "003b4b2a",
+   "id": "d5435bc3",
    "metadata": {},
    "source": [
     "It is also possible to have these items returned as dictionary objects by setting the as_dict parameter:"
@@ -322,7 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "dff4fd98",
+   "id": "d6da0012",
    "metadata": {},
    "outputs": [
     {
@@ -516,7 +524,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83479378",
+   "id": "34d9e145",
    "metadata": {},
    "source": [
     "### Sorting Content"
@@ -524,7 +532,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb21731b",
+   "id": "339448aa",
    "metadata": {},
    "source": [
     "The sort_field and sort_order parameters of the [advanced_search()](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager.advanced_search) method can be used to sort the returned content server side.\n",
@@ -537,7 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "5bb3a659",
+   "id": "645015ab",
    "metadata": {},
    "outputs": [
     {
@@ -632,7 +640,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef1607ee",
+   "id": "7ea4079f",
    "metadata": {},
    "source": [
     "Here we return the first 3 items that the user created by setting sort_field=\"created\" and sort_order=\"asc\":"
@@ -641,7 +649,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "c6de47d8",
+   "id": "112471bf",
    "metadata": {},
    "outputs": [
     {
@@ -735,7 +743,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da057c61",
+   "id": "43b0a554",
    "metadata": {},
    "source": [
     "## Querying Organization Content"
@@ -743,7 +751,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da8fa867",
+   "id": "75cc805d",
    "metadata": {},
    "source": [
     "### Searching for Organization Members"
@@ -751,7 +759,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c8cd50f",
+   "id": "0dd43cbc",
    "metadata": {},
    "source": [
     "We can search for a list of the members within the organization by using the [UserManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.server.html#arcgis.gis.server.UserManager) class within the GIS module. Here we access the UserManager by calling gis.users, and use the [search()](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.UserManager.search) method to return a list of organization members. The search() method will return all users in the organization if no parameters are provided:"
@@ -760,7 +768,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "e9aa180e",
+   "id": "fe13e7c9",
    "metadata": {},
    "outputs": [
     {
@@ -782,7 +790,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "922eb605",
+   "id": "d006c443",
    "metadata": {},
    "outputs": [
     {
@@ -814,7 +822,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "045503c4",
+   "id": "7773c879",
    "metadata": {},
    "outputs": [
     {
@@ -857,7 +865,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de1a2aa8",
+   "id": "3d07ba3b",
    "metadata": {},
    "source": [
     "### Getting Member Content"
@@ -865,7 +873,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c65e952c",
+   "id": "ebb244c2",
    "metadata": {},
    "source": [
     "Similarly to above, we can set return_count=True and see how many items this user has:"
@@ -874,7 +882,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "7a9e92c3",
+   "id": "78af4b24",
    "metadata": {},
    "outputs": [
     {
@@ -896,7 +904,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "d8407b03",
+   "id": "44239cb7",
    "metadata": {},
    "outputs": [
     {
@@ -922,7 +930,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f43b387",
+   "id": "60c942ef",
    "metadata": {},
    "source": [
     "### Compiling Organization Content"
@@ -930,7 +938,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3dea0b00",
+   "id": "ed6595ea",
    "metadata": {},
    "source": [
     "If we return all items for each user in the organization, we can compile those items into a single list representing all of the organizations content.\n",
@@ -941,7 +949,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "7dd1f076",
+   "id": "a7c8d14e",
    "metadata": {},
    "outputs": [
     {
@@ -967,7 +975,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3efa6f9",
+   "id": "850f4e7d",
    "metadata": {},
    "source": [
     "## Analyzing Organization Content with Pandas"
@@ -975,7 +983,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c848a63",
+   "id": "965c56ae",
    "metadata": {},
    "source": [
     "Let's put our compiled list into a pandas [DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) to easily view and filter our data"
@@ -984,7 +992,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "b8acee3d",
+   "id": "7fae7951",
    "metadata": {},
    "outputs": [
     {
@@ -1217,7 +1225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a371b836",
+   "id": "3e3cb9ac",
    "metadata": {},
    "source": [
     "We can use the pandas function [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) to see how many occurrences there are of each value for a particular column. Here we return the top 10 most frequently occurring item types and the number of instances they have:"
@@ -1226,7 +1234,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "3d641a4e",
+   "id": "07d8e877",
    "metadata": {},
    "outputs": [
     {
@@ -1257,7 +1265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ba0e6cd",
+   "id": "25f3946f",
    "metadata": {},
    "source": [
     "Another [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) example where we see the distribution of access levels for each of the items in the organization:"
@@ -1266,7 +1274,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "ba6337fe",
+   "id": "055ce1e0",
    "metadata": {},
    "outputs": [
     {
@@ -1290,7 +1298,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb949c64",
+   "id": "afb7847c",
    "metadata": {},
    "source": [
     "Using the [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) function in conjunction with the [groupby()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.groupby.html) operation allows for an additional level of analysis. Here we see the breakdown of item types that each user has created:"
@@ -1299,7 +1307,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "cd70598d",
+   "id": "55137546",
    "metadata": {},
    "outputs": [
     {
@@ -1331,7 +1339,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "372d9dab",
+   "id": "9555af52",
    "metadata": {},
    "outputs": [
     {
@@ -1363,7 +1371,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a051e53",
+   "id": "24bf807c",
    "metadata": {},
    "source": [
     "### Filtering the Dataset"
@@ -1371,7 +1379,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7e3cb44",
+   "id": "c1427876",
    "metadata": {},
    "source": [
     "We can choose which columns we'd like to view, and the order we'd like to view them in, by providing the DataFrame with a list of strings matching column names:"
@@ -1380,7 +1388,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "25ac238f",
+   "id": "c4402555",
    "metadata": {},
    "outputs": [
     {
@@ -1484,7 +1492,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67f4d11c",
+   "id": "2d2c814c",
    "metadata": {},
    "source": [
     "Creating and applying Boolean masks is a very efficient way to the filter the rows of a DataFrame. By using standard operators such as <, >, == and != on pandas Series objects (e.g. the columns of our DataFrame), we can create a new Series of True and False values, called a mask. When this mask is applied to the original DataFrame, a new DataFrame will be returned with only the rows corresponding to where the mask had a True value.\n",
@@ -1495,7 +1503,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "8be6ea3b",
+   "id": "c2a4f290",
    "metadata": {},
    "outputs": [
     {
@@ -1523,7 +1531,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c0fdaf8",
+   "id": "2fb3bef4",
    "metadata": {},
    "source": [
     "Applying this mask to our DataFrame, we return all fields for objects which have access=='public':"
@@ -1532,7 +1540,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "ab2c3303",
+   "id": "54534e8e",
    "metadata": {},
    "outputs": [
     {
@@ -1770,7 +1778,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "433a42f0",
+   "id": "9faa69eb",
    "metadata": {},
    "source": [
     "We can apply both the column filter and Boolean mask at the same time to reduce the amount of information displayed:"
@@ -1779,7 +1787,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "d5984b62",
+   "id": "ae8d1fa4",
    "metadata": {},
    "outputs": [
     {
@@ -1882,7 +1890,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cc34a39",
+   "id": "5a0345c2",
    "metadata": {},
    "source": [
     "Another example where we create a Boolean mask for all objects of type 'Web Map':"
@@ -1891,7 +1899,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "4db93840",
+   "id": "8edd82c6",
    "metadata": {},
    "outputs": [
     {
@@ -2312,7 +2320,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b0a79b2",
+   "id": "9c85e358",
    "metadata": {},
    "source": [
     "Boolean masks can also be combined to represent multiple filters. Here we combine the Web Map and Public masks to return all items in our organization which are public web maps:"
@@ -2321,7 +2329,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "92edfe37",
+   "id": "299024e6",
    "metadata": {},
    "outputs": [
     {
@@ -2601,7 +2609,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fac763a2",
+   "id": "a893b341",
    "metadata": {},
    "source": [
     "The [.apply()](https://pandas.pydata.org/docs/reference/api/pandas.Series.apply.html) method can also be used to generate masks that can't be created using the standard comparison operators. As long as the function called within the apply method has a Boolean output, then the result can be used as a mask to filter rows. Here we use a [lambda](https://www.w3schools.com/python/python_lambda.asp) function to return all items which have a type that ends with the word \"Service\"."
@@ -2610,7 +2618,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "7c2ae067",
+   "id": "d4f4e4b2",
    "metadata": {},
    "outputs": [
     {
@@ -2779,7 +2787,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce89cf6e",
+   "id": "0a409c06",
    "metadata": {},
    "source": [
     "### Accessing Content by ID"
@@ -2787,7 +2795,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b59f793b",
+   "id": "736fa4d4",
    "metadata": {},
    "source": [
     "Once we've identified an item of interest in our DataFrame, we can return the content of that item by providing its ID to the [ContentManager](https://pandas.pydata.org/docs/reference/api/pandas.Series.apply.html) .get() method. If we know the index of the object in the DataFrame (i.e. the leftmost value), then we can access that row's information using the .loc() method. From there we can get the id of the item and provide it to the get method."
@@ -2796,7 +2804,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "27c0c0a2",
+   "id": "4d42d933",
    "metadata": {},
    "outputs": [
     {
@@ -2818,7 +2826,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "a22bf3ef",
+   "id": "8e7b6506",
    "metadata": {},
    "outputs": [
     {
@@ -2867,7 +2875,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8438e2c2",
+   "id": "7cef5753",
    "metadata": {},
    "source": [
     "For more information on using item ids, see this [community post](https://community.esri.com/t5/arcgis-online-blog/where-can-i-find-the-item-id-for-an-arcgis-online/ba-p/890284)."
@@ -2875,7 +2883,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1aa151f2",
+   "id": "cf9decc1",
    "metadata": {},
    "source": [
     "## Exporting Data"
@@ -2883,7 +2891,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "704d5af6",
+   "id": "548344fd",
    "metadata": {},
    "source": [
     "Pandas provides a convenient [to_csv()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_csv.html) method which can be used to generate zipped and unzipped csv outputs. Simply provide your target path with the appropriate file extension and call the method on the DataFrame object you would like to export."
@@ -2892,7 +2900,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "1c2defb6",
+   "id": "1bfcb80e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2904,7 +2912,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "e713f62d",
+   "id": "87557547",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2916,7 +2924,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "7bc22234",
+   "id": "fa20d094",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2927,19 +2935,11 @@
   },
   {
    "cell_type": "markdown",
-   "id": "060986ed",
+   "id": "47157c31",
    "metadata": {},
    "source": [
     "Pandas also provides additional methods for exporting the data as different file formats (e.g. [to_json()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html), [to_pickle()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_pickle.html), [to_excel()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_excel.html)) which behave similarly."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1208c3ac",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/samples/03_org_administrators/inventory-organizational-content.ipynb
+++ b/samples/03_org_administrators/inventory-organizational-content.ipynb
@@ -5,7 +5,7 @@
    "id": "63c4b10f",
    "metadata": {},
    "source": [
-    "# Portal Inventory"
+    "# Inventory Organizational Content"
    ]
   },
   {
@@ -13,7 +13,7 @@
    "id": "42a813b1",
    "metadata": {},
    "source": [
-    "Being able to retrieve, display, analyze, and export the content within an organization portal are important tasks for any admin. Here we will leverage the [ContentManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#contentmanager) and [UserManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#usermanager) classes of the GIS module, as well as some functionality from the [Pandas](https://pandas.pydata.org/docs/index.html) library, to accomplish those tasks.\n",
+    "Being able to retrieve, display, analyze, and export the content within an organization Portal are important tasks for any admin. Here we will leverage the [ContentManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#contentmanager) and [UserManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#usermanager) classes of the GIS module, as well as some functionality from the [Pandas](https://pandas.pydata.org/docs/index.html) library, to accomplish those tasks.\n",
     "\n",
     "In this page we are going to observe how the following can be accomplished:\n",
     "- [Import Libraries](#Import-Libraries)\n",
@@ -52,27 +52,6 @@
     "\n",
     "import arcgis\n",
     "from arcgis.gis import GIS"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "d8ce68a4",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'1.9.1'"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "arcgis.__version__"
    ]
   },
   {
@@ -141,9 +120,9 @@
    "id": "4ae14d15",
    "metadata": {},
    "source": [
-    "To search for content within our organization, we can access the [ContentManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager) class via gis.content. \n",
+    "To search for content within our organization, we can access the [ContentManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager) class via `gis.content()`. \n",
     "\n",
-    "Using the [advanced_search()](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager.advanced_search) method, we can query content belonging to a user by providing the string \"owner: < username >\". By setting the return_count parameter of advanced_search to True, we can simply return a single integer representing the number of items which that user owns.\n",
+    "Using the [`advanced_search()`](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager.advanced_search) method, we can query content belonging to a user by providing the string `\"owner: < username >\"`. By setting the `return_count` parameter of `advanced_search()` to `True`, we can simply return a single integer representing the number of items which that user owns.\n",
     "\n",
     "Let's return the number of items that belong to the user currently logged in:"
    ]
@@ -181,9 +160,9 @@
    "id": "55de05fb",
    "metadata": {},
    "source": [
-    "If we leave the return_count parameter as its default value False, then we will receive a response dictionary containing metadata about the query as well as a list of returned items in the 'results' field.\n",
+    "If we leave the `return_count` parameter as its default value `False`, then we will receive a response dictionary containing metadata about the query as well as a list of returned items in the `results` field.\n",
     "\n",
-    "By setting the max_items parameter, we can limit the number of items that are returned in the results field."
+    "By setting the `max_items` parameter, we can limit the number of items that are returned in the `results` field."
    ]
   },
   {
@@ -324,7 +303,7 @@
    "id": "d5435bc3",
    "metadata": {},
    "source": [
-    "It is also possible to have these items returned as dictionary objects by setting the as_dict parameter:"
+    "It is also possible to have these items returned as dictionary objects by setting the `as_dict` parameter:"
    ]
   },
   {
@@ -535,11 +514,11 @@
    "id": "339448aa",
    "metadata": {},
    "source": [
-    "The sort_field and sort_order parameters of the [advanced_search()](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager.advanced_search) method can be used to sort the returned content server side.\n",
+    "The `sort_field` and `sort_order` parameters of the [`advanced_search()`](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager.advanced_search) method can be used to sort the returned content server side.\n",
     "\n",
-    "Possible values for sort_order are \"asc\" for ascending or increasing order and \"desc\" for descending or decreasing order. Default values for the sort_field and sort_order parameters are \"title\" and \"asc\", respectively.\n",
+    "Possible values for `sort_order` are `\"asc\"` for ascending or increasing order and `\"desc\"` for descending or decreasing order. Default values for the `sort_field` and `sort_order` parameters are `\"title\"` and `\"asc\"`, respectively.\n",
     "\n",
-    "In this next example we'll search for the last 3 items that the current user modified by setting sort_field=\"modified\" and sort_order=\"desc\":"
+    "In this next example we'll search for the last 3 items that the current user modified by setting `sort_field=\"modified\"` and `sort_order=\"desc\"`:"
    ]
   },
   {
@@ -643,7 +622,7 @@
    "id": "7ea4079f",
    "metadata": {},
    "source": [
-    "Here we return the first 3 items that the user created by setting sort_field=\"created\" and sort_order=\"asc\":"
+    "Here we return the first 3 items that the user created by setting `sort_field=\"created\"` and `sort_order=\"asc\"`:"
    ]
   },
   {
@@ -762,7 +741,7 @@
    "id": "0dd43cbc",
    "metadata": {},
    "source": [
-    "We can search for a list of the members within the organization by using the [UserManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.server.html#arcgis.gis.server.UserManager) class within the GIS module. Here we access the UserManager by calling gis.users, and use the [search()](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.UserManager.search) method to return a list of organization members. The search() method will return all users in the organization if no parameters are provided:"
+    "We can search for a list of the members within the organization by using the [UserManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.server.html#arcgis.gis.server.UserManager) class within the GIS module. Here we access the UserManager by calling `gis.users`, and use the [`search()`](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.UserManager.search) method to return a list of organization members. The `search()` method will return all users in the organization if no parameters are provided:"
    ]
   },
   {
@@ -876,7 +855,7 @@
    "id": "ebb244c2",
    "metadata": {},
    "source": [
-    "Similarly to above, we can set return_count=True and see how many items this user has:"
+    "Similarly to above, we can set `return_count=True` and see how many items this user has:"
    ]
   },
   {
@@ -943,7 +922,7 @@
    "source": [
     "If we return all items for each user in the organization, we can compile those items into a single list representing all of the organizations content.\n",
     "\n",
-    "We can remove the item limit for each query by setting max_items=-1 in the advanced_search() function:"
+    "We can remove the item limit for each query by setting `max_items=-1` in the `advanced_search()` function:"
    ]
   },
   {
@@ -1228,7 +1207,7 @@
    "id": "3e3cb9ac",
    "metadata": {},
    "source": [
-    "We can use the pandas function [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) to see how many occurrences there are of each value for a particular column. Here we return the top 10 most frequently occurring item types and the number of instances they have:"
+    "We can use the pandas function [`value_counts()`](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) to see how many occurrences there are of each value for a particular column. Here we return the top 10 most frequently occurring item types and the number of instances they have:"
    ]
   },
   {
@@ -1268,7 +1247,7 @@
    "id": "25f3946f",
    "metadata": {},
    "source": [
-    "Another [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) example where we see the distribution of access levels for each of the items in the organization:"
+    "Another [`value_counts()`](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) example where we see the distribution of access levels for each of the items in the organization:"
    ]
   },
   {
@@ -1301,7 +1280,7 @@
    "id": "afb7847c",
    "metadata": {},
    "source": [
-    "Using the [value_counts()](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) function in conjunction with the [groupby()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.groupby.html) operation allows for an additional level of analysis. Here we see the breakdown of item types that each user has created:"
+    "Using the [`value_counts()`](https://pandas.pydata.org/docs/reference/api/pandas.Series.value_counts.html#pandas.Series.value_counts) function in conjunction with the [`groupby()`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.groupby.html) operation allows for an additional level of analysis. Here we see the breakdown of item types that each user has created:"
    ]
   },
   {
@@ -1495,7 +1474,7 @@
    "id": "2d2c814c",
    "metadata": {},
    "source": [
-    "Creating and applying Boolean masks is a very efficient way to the filter the rows of a DataFrame. By using standard operators such as <, >, == and != on pandas Series objects (e.g. the columns of our DataFrame), we can create a new Series of True and False values, called a mask. When this mask is applied to the original DataFrame, a new DataFrame will be returned with only the rows corresponding to where the mask had a True value.\n",
+    "Creating and applying Boolean masks is a very efficient way to the filter the rows of a DataFrame. By using standard operators such as `<`, `>`, `==` and `!=` on pandas Series objects (e.g. the columns of our DataFrame), we can create a new Series of `True` and `False` values, called a mask. When this mask is applied to the original DataFrame, a new DataFrame will be returned with only the rows corresponding to where the mask had a `True` value.\n",
     "\n",
     "Let's create a mask to represent all items with public level access:"
    ]
@@ -1534,7 +1513,7 @@
    "id": "2fb3bef4",
    "metadata": {},
    "source": [
-    "Applying this mask to our DataFrame, we return all fields for objects which have access=='public':"
+    "Applying this mask to our DataFrame, we return all fields for objects which have `access=='public'`:"
    ]
   },
   {
@@ -1893,7 +1872,7 @@
    "id": "5a0345c2",
    "metadata": {},
    "source": [
-    "Another example where we create a Boolean mask for all objects of type 'Web Map':"
+    "Another example where we create a Boolean mask for all objects of type `\"Web Map\"`:"
    ]
   },
   {
@@ -2612,7 +2591,7 @@
    "id": "a893b341",
    "metadata": {},
    "source": [
-    "The [.apply()](https://pandas.pydata.org/docs/reference/api/pandas.Series.apply.html) method can also be used to generate masks that can't be created using the standard comparison operators. As long as the function called within the apply method has a Boolean output, then the result can be used as a mask to filter rows. Here we use a [lambda](https://www.w3schools.com/python/python_lambda.asp) function to return all items which have a type that ends with the word \"Service\"."
+    "The [`apply()`](https://pandas.pydata.org/docs/reference/api/pandas.Series.apply.html) method can also be used to generate masks that can't be created using the standard comparison operators. As long as the function called within the apply method has a Boolean output, then the result can be used as a mask to filter rows. Here we use a [lambda](https://www.w3schools.com/python/python_lambda.asp) function to return all items which have a type that ends with the word \"Service\"."
    ]
   },
   {
@@ -2798,7 +2777,7 @@
    "id": "736fa4d4",
    "metadata": {},
    "source": [
-    "Once we've identified an item of interest in our DataFrame, we can return the content of that item by providing its ID to the [ContentManager](https://pandas.pydata.org/docs/reference/api/pandas.Series.apply.html) .get() method. If we know the index of the object in the DataFrame (i.e. the leftmost value), then we can access that row's information using the .loc() method. From there we can get the id of the item and provide it to the get method."
+    "Once we've identified an item of interest in our DataFrame, we can return the content of that item by providing its ID to the [ContentManager](https://pandas.pydata.org/docs/reference/api/pandas.Series.apply.html) `get()` method. If we know the index of the object in the DataFrame (i.e. the leftmost value), then we can access that row's information using the `loc()` method. From there we can get the id of the item and provide it to the get method."
    ]
   },
   {
@@ -2894,7 +2873,7 @@
    "id": "548344fd",
    "metadata": {},
    "source": [
-    "Pandas provides a convenient [to_csv()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_csv.html) method which can be used to generate zipped and unzipped csv outputs. Simply provide your target path with the appropriate file extension and call the method on the DataFrame object you would like to export."
+    "Pandas provides a convenient [`to_csv()`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_csv.html) method which can be used to generate zipped and unzipped csv outputs. Simply provide your target path with the appropriate file extension and call the method on the DataFrame object you would like to export."
    ]
   },
   {
@@ -2938,13 +2917,13 @@
    "id": "47157c31",
    "metadata": {},
    "source": [
-    "Pandas also provides additional methods for exporting the data as different file formats (e.g. [to_json()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html), [to_pickle()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_pickle.html), [to_excel()](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_excel.html)) which behave similarly."
+    "Pandas also provides additional methods for exporting the data as different file formats (e.g. [`to_json()`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_json.html), [`to_pickle()`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_pickle.html), [`to_excel()`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_excel.html)) which behave similarly."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -2958,7 +2937,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.11"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
\<insert pull request description here\>

Sample Notebook for querying, analyzing and exporting portal inventory.

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ mohi9282 so he can add it to the list for the next deploy 
