### PR TITLE
ResourceManager sample notebook for accessing item resources

### DIFF
--- a/guide/03-the-gis/accessing-item-resources.ipynb
+++ b/guide/03-the-gis/accessing-item-resources.ipynb
@@ -1,0 +1,1321 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "37c13066",
+   "metadata": {},
+   "source": [
+    "# Accessing Item Resources"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fa9e41a",
+   "metadata": {},
+   "source": [
+    "## Table of Contents\n",
+    "- [Import Libraries](#Import-Libraries)\n",
+    "- [Connect to ArcGIS Online](#Connect-to-ArcGIS-Online)\n",
+    "- [Listing Item Resources](#Listing-Item-Resources)\n",
+    "- [Analyzing Resource File Data](#Analyzing-Resource-File-Data)\n",
+    "- [Exporting Resources](#Exporting-Resources)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e4e67ae",
+   "metadata": {},
+   "source": [
+    "An `Item` object in the GIS will often have binary or textual data provided in the form of resource files, and to manage these files we've introduced a [`ResourceManager`](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#resourcemanager) helper class. When an `Item` is initialized, this `ResourceManager` instance is created and stored as the `resources` property of that `Item`. This property then provides access to a number of methods useful for viewing and modifying the files, including: `list()`, `get()`, `add()`, `update()`, `remove()` and `export()`.\n",
+    "\n",
+    "Users will generally not interact with the `resources` property directly, nor will they create a `ResourceManager` instance directly. Instead they will more often create classes and call methods which in turn initialize a `ResourceManager` instance for a portal `Item` and leverage these methods under the hood.\n",
+    "\n",
+    "While the adding, updating, and removal of these resource files should ideally be accomplished through safer, higher-level functions and interfaces, users might be interested in directly calling the `list()`, `get()` and `export()` methods directly. Let's take a look at how we can use these methods and what we should expect as a response. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fcc607b",
+   "metadata": {},
+   "source": [
+    "## Import Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "8fd25219",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import datetime\n",
+    "import pandas as pd\n",
+    "\n",
+    "import arcgis\n",
+    "from arcgis.gis import GIS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "358020a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'1.9.1'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "arcgis.__version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5da6b28",
+   "metadata": {},
+   "source": [
+    "## Connect to ArcGIS Online"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69e85c08",
+   "metadata": {},
+   "source": [
+    "Connect to your ArcGIS Online portal with your profile to access the portal items available to you."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b9b594b1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"9item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/user.html?user=api_data_owner' target='_blank'>\n",
+       "                        <img src='https://geosaurus.maps.arcgis.com/home/js/arcgisonline/css/images/no-user-thumb.jpg' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\" style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/user.html?user=api_data_owner' target='_blank'><b>api_data owner</b>\n",
+       "                        </a>\n",
+       "                        <br/><br/><b>Bio</b>: None\n",
+       "                        <br/><b>First Name</b>: api_data\n",
+       "                        <br/><b>Last Name</b>: owner\n",
+       "                        <br/><b>Username</b>: api_data_owner\n",
+       "                        <br/><b>Joined</b>: April 10, 2019\n",
+       "\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<User username:api_data_owner>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "profile_name = \"my_dev_profile\"\n",
+    "\n",
+    "gis = GIS(profile=profile_name)\n",
+    "gis.users.me"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5be304fe",
+   "metadata": {},
+   "source": [
+    "## Listing Item Resources"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f78c3ba4",
+   "metadata": {},
+   "source": [
+    "The resources belonging to a particular `Item` object can be returned using the `list()` method. This will return a list of dictionaries, where each dictionary represents a resource and contains information including the resource file name and size as well as the time it was created.\n",
+    "\n",
+    "Here we will query for a `StoryMap` object belonging to the current profile by using the `gis.content.get()` method and providing the id of that item."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bbfe8d9b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=f1b6a842fbea45bca693c2fe6622bf70' target='_blank'>\n",
+       "                        <img src='data:image/png;base64,/9j/4AAQSkZJRgABAgAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCACFAMgDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDiPtSuBjgelXrZ+OBgVzsSsqgliau2l0Y2KsSeeK0A6OKQA89avLKAuWGKzbeWGRFO75jUz3AAPQjFFhpkk16oBUGohP8AL1zmsq4l3/OMDFVzdOqnB4rlnC7udEJWOiW5VT8xpXv06Zx7msEXhdAcHI702R3MYINQ4tPQ0TT3NlmQnJcc1PG6R5AbANYEEjFADnINXYS+75hk9ia1jHQiTNlZ03BcnkVctrgByM8VgRy73weCPar1vMF9jWUtHcpbHSJIrDitO32GAsG+YfrXPW82V+90qdbhvNAQk+wrmrxbV4vU0g1szUuboYxjnuaz/tDl/lwK1rC2N5w3y/UVX1LTmgfcAOODjvUU8M1rcbqrYgiuGPynk1LvOQKqRqVcdcmpyefpW8lyojcldMH5jwe9V2IDcc0+Z/3QGec1SMwVutclryuzVaIszSHygCeKoSyY6VJLPnvVRp1Y7ar2OpSqWGPL15py3LZVfzqnMcS4z70pfgFTz2q1TaLc00dFazY2jk0VV0mTzpRu7daKrkbOdyszy5ELAgn5fSnpGI26fjUcNxEpyT+tPa8gOQHGfTFexoedqa1tIsa471JPuMTZPFY41AQqPmUt25pF1cvuWQBs9D6UtA1LLTEgqx+Xsc1WmdScKwNU5pt7ZOQKhMzA5Aye1ZtGibNaJ8xjB5rStrfzY+WOccgDpXOwzuzg4xtresb4Ku1mw54HFEUr6jk2loaUduUVRsz2zTrgeWPkHIqeOZdoOcmoy4clnAx71s4qxipu+pFbqR8zdafErPcEBhgd6lM8SpjipbWKJfmBOc5Ncs4XdjpjPS5IILiMltwK4yMVqaXexQgrIpEjHrjtRJsNvkghAMhhVeEx3WoRYzknnFc86XK7o1VS61O4tHSJPlIAPI5qpfziU/M4GOKrjbbhfmyCeQe1QmPc2c5B5x6VtCJhJlWci3IIYsCfyoa7ixwetM1Rhb2251x/dPrVBf3lqNsZJ6sQOlZVaV5aGkKmmpbeXnPao2RZBuHX61BBICgAOTnBpZpkt0Y8D1pxpJIHUZA8vz7c5waYlvv3luCTxzVVrlWk3rye4qS4unih3Dg9qtQQnNla53W0mGbOaVd+0EH8Kzrq9lkkzKRwOMcVq6THLeR5Zdoxx70uTXQv2mhZtbl4JUkjOG70Ve/s/ERJ4ftRU+zYudM8mKF5NiLz6Uk0CIuCSHq/EUgAkxknvVW6ZZpA5ICnrXdy6HK5XY200xrpGkcfJ0GDjmiTRrpJwsQZ1IzurV0yWJSIgcZHArZEaRn69xWigmjNzaZxEiXEcoikQ7s4x61oJZv5Y4AOMnNaGsRIDHIzYIOQfWmx/vwEQZJ6+lQ4Wdi1PS5Rs4zvJYYIOKumLAyRVhrSWB0AQnPXAzii4heKHfIny9M5pcocxFHqDx4TIOOKk+3SPIqq3ynqfSsiWSNpVVSNxPNWynlBfLyfekmxtI3bO4iAEcmMn1rRh2RyffHPauUhaTO08kdzWtaE7wWJJz1qJu+xcFbc2Z7l5SoT7g4xSGVrVftUQw8fPenBggB4HNR6yXFlGIPvMP3gPpUcvcq5s6XdSapF5jy4HoK2bfbHcCIvx1OTXI+EbeW4dwCQQcnBr0KHQIJcXE0fmN2z2pxjoZzkrnN65FLf6vaWlvInlHaDnoMnrXeaT4dsoEAmPmAcY6VxOsQw6fq8TxRkBxnaGzgiuj0y/uJ0HlygY5+bpUaqTG9Yo1dc8L6fcWUv2aCKC4wCsijH5gda8Z1GG/uZ5IYgW2vsbb0yK9R1XxIqwPbHmV/l4PA47Vk6BpqQSZVQd3OcVo7ERujgXimgYwlCrYAIPWnSv5sW08Y5Irsdc0XdeSXUDNIoO35QTj6/ifaucvNFm+xGVCyyM2CDwTz/APqqlEOYxmtBPMgGevIU10UD/ZYkUEnHFYCQXUD7okOemN1aRin2rlunI5p8g+Y6JJVuY1bqgPze1FYtu0scDKA0ZI4J4BopqNtwueWpeiNfLfOOuamXEikuR/skd60YNMhkXJjBJ9TVe60mW1y8JJHZTVWZN0Ns4mLk5wQcitKS+kjRt8nTkZrIh+2nDLbOcHotQXFw8shRxsI6rjFNSsg5bstXF3JesBKfu9AOlT6fdNauQwHPQ+lZYZ+FXualjSaaQLEskjv0UDJNQ52d2aqHMrI7CC8+0Lxx6e9WZo/MiKuMgisCxuWtxHFeIYDjchkGNwBI4+hBH4VvRXkU8eIyHIGfl71rCSkro56kHB2aOY1OxCsTEuCTzUkAZI8TNgYGM1PPMJrhxtbgjKjgip4bZJpVYsFiXg7h/OpcdS4vTUgjni8wLkknvWxayxQLlyM+grO/su3uNTghVzEjkguOikc106+C9Vkt3NtLBcBQCrH5cjv+NYtWZrdWMx71ZDuCtgHAWo59WeSD7NDEWkYbWJ6in6fvtrjM1o0gDYK7e/ersmpRLckjSzFgjBQAk+maQmzT8Iv9ivkj8olpCA3y969TNxHFbF5GCBVyc+lea6bqNvCS6W7LLt4LMAPyzW9PLcw2UbNIbqRsHHADD1/WnC5lPcyfFMUd/cJPayOHXLHGcAcVJoVhraO0ySFICgHzjIb1xW14d1RJ2Npc2Xlnp8i8Z9wK1bmxungje0OEDEFenGf0q+VXJc2lY871zRdUt7xbh5xvl5DAYB7AEfhW34Qj1x7iRrsoIoU4ABBY/wD1v611TWX260EF5A0Ww4En38njnNVf7Pv9LV2gAlTJI7kjnFU4pdBc7aK+txuiK8BACH5kIwfr71Bp6w6nAsU2wM33fatJpo7m48u6iaN4/mJxycg4H6/pVWXS1hulktXZQF3YBz17D8jSlHqhxl0ZHdeCZWYSRxgpzkof19qzJfCF40m23k2J0O/nHfOfSu3tNVNhb28M0hbK7cjn5uMDPv61o3E1lOG3bVKgMQD1X/IzSUu49eh5y8V3FDIssUckYG3ZjnPfrRXUZSaBlVoycFBlskkDHPGQcjr7e9FbKxFzxRYUCBQuCTT5IFZsHgij95kFQeOhNLtkkfLMSehrFSZq0I1rEqNJuAyKoT6Ta3K+YIlLEcMODWg1i7htzkAeg602ON96quFXHT+daJvZkHG3VtJauQeQO9OinaCRGVxuGGDKehxW3qkSKpJdWbnOKxI4huUggF8jBHUd6xmkdNGT6bl+8kn1eSOWeXc69dznkk9cH174+pqbS7gRTLF5igg4XPcHkfzqukqQQsS3KAdu+4f0JrPyB86dAeBnpWdD3Ph2OrE8skubdnT3tkJiHjRkkyPmU/y/KoI7kQkQuuWPrTrC9Wa3EMsjBwR1Ga0Vs4bmYLtEhGMOvAI6/nXU6kXscPs5R3GWVsk1xE8gjyjH5WJ69K9L0rUZbCMq8YNvwBjoBiuNg8LiRRKkrRqMfMB0J4wf0rXhuZ9EiENw6TQmPaJVPAHTGPyqHDm1CUtLHoFnbafqeliLyY8svzAcE5681zr+ELxdblntWRoCM7VOCeo/Pg1Z0zW9IuLYbHFrOg274vlXPHUdKutqdzp8zTRCO4LDChflIxk59OeKhR1M3JrQqSW0kc8Mb6Zvz6IG71abTIxKlwsTCTGNrAjg+lXLPxbYXEypcxzQzcgeYhGc44B6VuQ6tYSMELryQAG/Cq5lsTyvc5y007yb0MwTCn5SeMe3/wCutgzLaBImBeNt5J7gkg/1P5VrPp1pcAuiKCecjvWPc2ktnctIMFM8jHHTv+VVpJE6xJG1KJAoZh5ZIU7z6kCri2kas1zbyZ3KAQT6ZP8AWuI1RjEj+TtEvnM6ROcDGSc/hxVPTvE9xHcoZFMa4XeuD97OevpjtSfu6NlKDlrFHYXcIiEjso3HAKEDBH+Tj8qxPsskMri3fy2ds4bpk5OPpzWwmt2OrBUDjc0fOD0JOBWFqt+NHaVrqRWi2blc+uOP/QT+Vapq2pCjJysisl27TulxnIcruQcDB6c8jmkmuIYGASUmTDMyJnJwcdOnpWLDqfl2umxo6zyz/LIQc4+XOTn3K8/XOawfEOqp/aNskMqSRJZoXI67mBI688DmspTS2OmNO8ddyfUPFN9baTGyNmFZhskVeNwwzDPBPzEdfT04JWTo+spf250WWNFguZWeEuu5kXnoT0bgDjuc0VKvJXTIdlo0bdlYpNabimcE5ANUpoI4JCSQvPfinWHiCERBU+cnutUL63uL9/PyVBO4AnvVqDByuXCgl2qMjuDWdf20gfO4BF/DNdDptq5t1aYKu0DJzwauzaVazxBUwWb371T21IW55zJaJNOFZwFY92waQ6DdyzGOzXzNy70P90jqPxr0zT/Ay3EokYYXOckYrsNN8O6bp8gTygGK4yT1rF2asdEZ8jufOOr6ZqVg6xXqMgkw4AOQcDGf6/jTtGjY6hDbxlVkkB2tJ91TjIP6V7t4r8L2F7bAsqqEyQQMEnHSvLLnw4LO5MkYKFP9Ww7Hsf5UvZ6aCdd8yZRla1uY5Xkjit54X+fB5bkDGPX1xWnZmOYYlJCPny5g2T7E89B7etZlxZulpdRtagvKR8wOAo/r2qPS7/7HpLQyxFghYghc4PUD9GzXHOM47HYqlOVuZ6/rc66TVZLPZFNFksMOUyeRnP5cVTtb172b7MJS0Ry4YsFIAyCDnGPrnvWRHr9ss5z/AKkg53pjaxGOPbnOR+VW4J7NFzH5cZulYIEBIX5Og9gSDjryKzlVqRi00dMI0ak1Z28iczm0mAhfdv2hG3dcnHIPc4P/AOuri+IvLUSROVlXgxvyuMY4PBHGPzH4YeoatafZg80YN0RgKMDZ19O4GeR3PasmS4jlughdm3R4Ulj1Ix29Mn8q1pVKijeSOWvGk52gdhdeKJ5o/PtZmBRQWTOSBnk8deg/M1Po3jrMiLfAtBM5G5OW6En045H6Vxkl7A8wlQyLDbKIztwplUlgGP8ALGOwq3rdhHaxrc6U6G1t28woQGJ3DqMjlSM9eKqUpy6ihCEL31Xl/XqesDxXqfh9IJWRLzT2Ub5o5dwj5APatm78aW8uj3N0q7yuRsbjcASMZ9+ma8O07xQy6De2MrqI5lRVQDGMnJ6fn9OPYyprsz6FJAoZfNuWlUHJYxlGxyf93sRk1HtakWrIfsaU023rbQ9O1DxBbXCWxlTyyLbz0yclSQfl9+n41x91c3d1aLcxuI5n5McZxtfHAGfTB6etYY10mS0lv0V0MCIMHnaCyjOeBz9O1dLpMtrqnlhLiOMtMrEtwFUKNw/HB9K6ov2kbs5qkfYysjGvNYulFpJA8kJl8yN1XjIViR16dfr37jL9Y8Q3NxAltqZ4SNTsYEMWKcE89ff3rqtd8OklFmRIreNyqFRjGRjJ/Hv9O9eYeILO5W8u3ubgyGFwiuBy+PkU9v7vJ/nxSUZw91lSlTn78fuLD608dlCllLsuI02Hp8zE4wD9P5UnnQXWnajcysEnCRx28aeq4Aye/CufwHrisJvKMoAYr84xxkE/0okiktdgdsYO3Cc8ev8A49ilFcuhM58+ttS3ayCxMc3mKXZTtAYHaemDg8HPOKKrboZkYSfIqYVNvUkegooRF7mtZag9qwUoOvXvXZ6Qs15DkhXUDK4ODmvNFvw0AVo8uP4s9a7fw1qy2cCNg4PDAmuuMrmckdLcloLaPMZyzfMFGTW1pIF4nzB02csWTGKbbanBNEp2oR1G0c1s2P2aV0kndjyMgdKcldEppG7p9kYoyTMrAcYU5xVPU70Wmo2AliDp5u9Sf4SBjP8A49j8TWii2CuFhlRW7LnrmprjTkkCvw7D+9WFrFN31MLxOfNslu4V3rgcDu2M/wCf854O4kDbhJAQpzx1NepyGEMYXwmRx2BNcbeWdpvmQH7rEcjmtYPoRLuclJbJK+x8KhGcGsm70spFJAo2xt12jqTx/U/rXTT2qRgr5uQQcHvVSVxMFUg5Hyg0pQT0HGVtTkE0ONrkh5Mom11zg5+XDKT+A/OpEha1Tf5cTLG/yqHOVBxnHtxW88aqpKkMuOoHaqsCeZHIHI5GCMdf8msXS0NOfU4FpnF00chY7ZMH14P/AOurl4Eja0dXVdoVC3GeO+PpitTUIJbO+ilj2IjNuZtgyRnJ5P8AWucu3Rrt0QFtnUseRwPw4OalrWxSd0aN9cu8k8kqIVljC5x/t7s59Qcj6UrrMGSytpSzSxKoZ24w4GevQYNUoZmuII0cjAbamV9f/wBR/OpvPFzdRKi+Xt8sckkKcc/me3FSr/MaZDKptw6zRI3l5hbkZ3YIH5cflV2OQR28chOXtQzBGBw/I4x1x/KomjaWSQMPuyETNnOcnB9+eRn3qVIGFkWMmRtO89zuKj+h/E0+XuCk73GI8yJ9rKBlCHecdN3A47AdPr9aSO9ltpZVjyE8pflA65wD/n6VDaCWWB7UyAGeRUAbnccj2pJ5TtYhCjrbgMCOQQ/H4j+lFrDbvuepeGvGv9pQx6PriLLHcQ8zuMujHAHJ+n1zisPxZaW2hJf6Xdzx3lwmJIZVXbkMQcn06g4/yeO06dVYsATKsQCZOVBGT+eD+f51DqWoSXt7JNdSmQkBeeSQBx/L+VWpO1jNws7oglLmMMAcBwicccA5/wD11pXUTqEYgu5jOeOrEDp+PNUplRY49m4xlCVJHQbsfT/P41LLdkQkMvWNycHjngfXp+lTYopJGhAYuQykkgDPYd+n+e9FLIxCoGUIWDNu6Zyew7dDiiqAmeGIF41XLq/y47r6fWu50WwjS2VZI8Nt+UmuQezY3XmRxnbkE7f516t4asG1KyWRwNoAG41dN3Qp6FC0SZAwQA7TheMc1cg1FxMYpjKnAySOB7108OhL98J5hJ+6Bmn6hpduE85bAlwuDGAMGuhR7GLkupjySylraWzu45Zg4GxWGR74711+lX1x5MlvcDybmMblJHDDGRXC39vObUlLYwsnzgLwRjuKks/GhW2VdTjbzYx99MAzDtwf4h655rOpDQcWbmpeJIZlWb5d3Rh0wehH9fx9qy1uLbVhNLbON+MABscjjj16Vz/iOWyngfUtOuPNtrhRvJGNrcAhu4bp/OuX0nVLnTy+1wrA5yeRUwaKnFnVX1xcQKolBzyu4dKzhdKIEiZsHGC3rXQ6RqFpqlk0eoMnmoflZh976YrjtZt47S6uo1dgsbncpzwOxH48VUmkRFM0bDzYPMikOcklfcVca2R1ZY8BiDle+a4v+27iOWJd+UAIJz0HGP611ekajHJPKzqdpHyH2P8AkVnzu9i+XqQX4VEtozCZZF6ZGQOef61k3mj21tEbqLEUvIwc857fnXT3LQFBISA+fzrIuUeRpMhXJ5wee1DimF2cYpiSGFVXa376MDPPzDjP/fVPNpeQXMMYkRZJmDIN27aQSOf88+9XL2BRfb4rZhGGyQfyP6CsuG/mNxC5HMTFlBP3effr29+Kykn0NE0wmSW0u2haPy2UAuobIxx/9Y/jV7TbozrJCU3EqCQeQeen6is25kWe4kY5YqhUHrgDp/LFXLe3ncb4toMyhBGvynIAOfT6UX01D0JoLN5EdomU4O9VDAHdweufTIx7VQjGZ2jkBBdRGFb8ufTpV5jLprGKbcrsw+UewxtP06/lVfz47+4jglHyl/kaM9zgd/pT3AfDLFb2sccsZKYckE9SQP58VUmiVVVAodwjEbhjIyef5n8qZtZFUNCxJG5WI5Iye350+fzPNRgGCCFRn8O/akBO6RzJCFkAeGHGwnAJyT9P8inXDoEaNWLbRsQBef8Aa7enXBqqiPJMgboFZQI1ycAeg60RLlyEG6dcKvv64/Wi12BYuWjb90qgsAFUA8AZyfpz+lFL5AmuC0biNNu5Sx6NjJ/kfzoqXoBvaewDxEKMMSu08jqRXoVrftp1ibe3QDYu7OTzRRVYYdQt2HjG9hjy0UTg8LntVxdbudSiMmFjUkoVHP4g0UV3UtTlqKxZu9PE9sxknkxtJODgniuA8UeH105Eu4rqRnkOQHAIX0+tFFOa0FBu5yd5LLpUs9vFJuiuEV3Q/dOfb29azLa5lWNGYhlcEbSOmKKK4o6XOybukdHa3Ti3VV4GT/OrerRh7dZhkNtC/gKKK6I6rU5nozlXg/eFyxJJ5966Ow/dRDbwSct70UVnbUtbGvAu+E5wSUyMjpWXLO8UvYlzgnpRRVpJLQl7lu2jUsUcbljdSAe+TyDUOsaJa232i4gXZJsJzjsQwI+nI/Kiis2tGadjjS5Se3C4DIAm5Rgnnv8AgMVpXN7NBG1zGdmJBuVDtzt3jr24Uf8A66KKwS1LWxmTXLPZ28ko8yWRmcsxPXOPqfuiqj5tpo/LYghQ2R6kdvTrRRVoRakkMqxI+dsca8Dv/nNM1G5kKWsIOFMCkgd+f/1UUUD6FmxhBnCZ+aJtgLDIPXt9aqMv2ezWWM/vHGGb13Fh/JRRRUrcRDCga4ZMnAIUZ574/wAfzoooqm9Rn//Z' width='200' height='133' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=f1b6a842fbea45bca693c2fe6622bf70' target='_blank'><b> Exposing patterns in land fires around the globe </b>\n",
+       "                        </a>\n",
+       "                        <br/>This story map analyzes global patterns in wildfires using spatial analysis tools in ArcGIS Pro with satellite thermal data. <img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">StoryMap by api_data_owner\n",
+       "                        <br/>Last Modified: January 12, 2021\n",
+       "                        <br/>0 comments, 1 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\" Exposing patterns in land fires around the globe \" type:StoryMap owner:api_data_owner>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sm_id = 'f1b6a842fbea45bca693c2fe6622bf70'\n",
+    "sm_item = gis.content.get(sm_id)\n",
+    "sm_item"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54b57aec",
+   "metadata": {},
+   "source": [
+    "Note that to get a full list of the portal items owned by the current user, we can use the `gis.content.search()` method as below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ea3eb1e9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1240 items returned belonging to current user\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<Item title:\"Automate Road Surface Investigation Using Deep Learning\" type:Notebook owner:api_data_owner>,\n",
+       " <Item title:\"Pick_Pizza_Shops_San_Francisco\" type:Service Definition owner:api_data_owner>,\n",
+       " <Item title:\"ofek_aerial_imagery_for_deadsea\" type:Service Definition owner:api_data_owner>,\n",
+       " <Item title:\"england_weather_stations\" type:Shapefile owner:api_data_owner>,\n",
+       " <Item title:\"Community_College_Dist\" type:Shapefile owner:api_data_owner>]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query_string = f\"owner: {gis.users.me.username}\"\n",
+    "user_items = gis.content.search(query=query_string, max_items=-1)\n",
+    "print(len(user_items), 'items returned belonging to current user')\n",
+    "user_items[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "069f0aff",
+   "metadata": {},
+   "source": [
+    "We can then call the [`list()`](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ResourceManager.list) method to return a list of this Items resources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3970511a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "13 resources found for selected item\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'resource': '1584837341913.jpeg',\n",
+       "  'created': 1610462633000,\n",
+       "  'size': 3565854,\n",
+       "  'access': 'inherit'},\n",
+       " {'resource': '1584840733269.png',\n",
+       "  'created': 1610462633000,\n",
+       "  'size': 36384,\n",
+       "  'access': 'inherit'},\n",
+       " {'resource': '1584977960300.png',\n",
+       "  'created': 1610462633000,\n",
+       "  'size': 363718,\n",
+       "  'access': 'inherit'},\n",
+       " {'resource': '1584995889818.png',\n",
+       "  'created': 1610462634000,\n",
+       "  'size': 13850,\n",
+       "  'access': 'inherit'},\n",
+       " {'resource': '1584995908437.png',\n",
+       "  'created': 1610462634000,\n",
+       "  'size': 14455,\n",
+       "  'access': 'inherit'},\n",
+       " {'resource': '1584996591808.png',\n",
+       "  'created': 1610462634000,\n",
+       "  'size': 11135,\n",
+       "  'access': 'inherit'},\n",
+       " {'resource': '1584996631292.png',\n",
+       "  'created': 1610462634000,\n",
+       "  'size': 11129,\n",
+       "  'access': 'inherit'},\n",
+       " {'resource': '1585069439012.png',\n",
+       "  'created': 1610462635000,\n",
+       "  'size': 6470,\n",
+       "  'access': 'inherit'},\n",
+       " {'resource': '1585080995091.png',\n",
+       "  'created': 1610462635000,\n",
+       "  'size': 152744,\n",
+       "  'access': 'inherit'},\n",
+       " {'resource': '1585081014377.png',\n",
+       "  'created': 1610462635000,\n",
+       "  'size': 143621,\n",
+       "  'access': 'inherit'},\n",
+       " {'resource': '1596760258881.jpeg',\n",
+       "  'created': 1610462635000,\n",
+       "  'size': 148737,\n",
+       "  'access': 'inherit'},\n",
+       " {'resource': 'oembed.json',\n",
+       "  'created': 1610462636000,\n",
+       "  'size': 676,\n",
+       "  'access': 'inherit'},\n",
+       " {'resource': 'oembed.xml',\n",
+       "  'created': 1610462636000,\n",
+       "  'size': 998,\n",
+       "  'access': 'inherit'}]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sm_resources = sm_item.resources.list()\n",
+    "print(len(sm_resources), 'resources found for selected item')\n",
+    "sm_resources"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac19b1c0",
+   "metadata": {},
+   "source": [
+    "We can put this list into a Pandas DataFrame for easily comparing and analyzing the different objects returned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "90b4c458",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>resource</th>\n",
+       "      <th>created</th>\n",
+       "      <th>size</th>\n",
+       "      <th>access</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1584837341913.jpeg</td>\n",
+       "      <td>1610462633000</td>\n",
+       "      <td>3565854</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1584840733269.png</td>\n",
+       "      <td>1610462633000</td>\n",
+       "      <td>36384</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1584977960300.png</td>\n",
+       "      <td>1610462633000</td>\n",
+       "      <td>363718</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1584995889818.png</td>\n",
+       "      <td>1610462634000</td>\n",
+       "      <td>13850</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1584995908437.png</td>\n",
+       "      <td>1610462634000</td>\n",
+       "      <td>14455</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>1584996591808.png</td>\n",
+       "      <td>1610462634000</td>\n",
+       "      <td>11135</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>1584996631292.png</td>\n",
+       "      <td>1610462634000</td>\n",
+       "      <td>11129</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>1585069439012.png</td>\n",
+       "      <td>1610462635000</td>\n",
+       "      <td>6470</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>1585080995091.png</td>\n",
+       "      <td>1610462635000</td>\n",
+       "      <td>152744</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>1585081014377.png</td>\n",
+       "      <td>1610462635000</td>\n",
+       "      <td>143621</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>1596760258881.jpeg</td>\n",
+       "      <td>1610462635000</td>\n",
+       "      <td>148737</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>oembed.json</td>\n",
+       "      <td>1610462636000</td>\n",
+       "      <td>676</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>oembed.xml</td>\n",
+       "      <td>1610462636000</td>\n",
+       "      <td>998</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              resource        created     size   access\n",
+       "0   1584837341913.jpeg  1610462633000  3565854  inherit\n",
+       "1    1584840733269.png  1610462633000    36384  inherit\n",
+       "2    1584977960300.png  1610462633000   363718  inherit\n",
+       "3    1584995889818.png  1610462634000    13850  inherit\n",
+       "4    1584995908437.png  1610462634000    14455  inherit\n",
+       "5    1584996591808.png  1610462634000    11135  inherit\n",
+       "6    1584996631292.png  1610462634000    11129  inherit\n",
+       "7    1585069439012.png  1610462635000     6470  inherit\n",
+       "8    1585080995091.png  1610462635000   152744  inherit\n",
+       "9    1585081014377.png  1610462635000   143621  inherit\n",
+       "10  1596760258881.jpeg  1610462635000   148737  inherit\n",
+       "11         oembed.json  1610462636000      676  inherit\n",
+       "12          oembed.xml  1610462636000      998  inherit"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.DataFrame(sm_resources)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c6835c8",
+   "metadata": {},
+   "source": [
+    "We can see that this `StoryMap` item returned resources of a couple different file types, including several `jpeg` and `png` files as well as a `json` and `xml` file.\n",
+    "\n",
+    "Let's now look at a `Feature Layer Collection` object and see what types of resources it has available. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "78578907",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=3d95a6aa9fa34243822138c7a9efc6b6' target='_blank'>\n",
+       "                        <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAACFCAYAAAAenrcsAACAAElEQVR4Xux9BXSVV9Y2SXC3lhbaUupKqeAaQkIS4gkEd3enuIa4u7vj7u5OoVB3b6cybWfaaaf7389zci8hQKd0YL6ftbrXYgFX3vu+52x5tp5K8hf9RX/RDalSxRf+or/oL7pCfwnIX/QX/Q79JSB/0V/0O/SXgPxFf9Hv0F8C8hf9Rb9DfwnIX/QX/Q7dWgH57Tf596+/VnyV9O9ff5G3j++Vbz/9sOJbVvrXP3+UV7aWyoXtq+WXn3+S1w9slc/euCjnNuXL8cK46177x2/+Jrti5sjm4KlSONVNNgVOl7eP7ZHf/v1vvVaxHMmLlXObC+VITrB8/dF78sW7r/Hfbxzabn2tIr135qBsWDpY1s7vLVtWDpfzm/MqfuSG9Nu/f9Vl+HfFl0m4p19//ll/8105syFPfvrh71e/r+uHZ/78rVe5ljdL+N33zx6So3kRXJc/Q9//7QvZFTX5pp75i3cuy86I8fLm4R3W1/7+5adyLD9cPr58rtwnK9B1+OXXX/51zWv43NG8YCmdZi+fvXnx6vduM90yAcHm7AibIOn+98l7pw9WfFsOZUdJlIOtJHg0kjPr0iu+ze+XzvGXLN9KEtyxkqSPcpEsPzuJd28kqR62Em5fWd44vLPi1+RQTqzk9K4kgR1sJNZRv+dVSUK71ZH96WGS6FpJ4pwqSUS3SlLQz1b2JqggLRvAf0f2qGp9DYJ5MG2xCkyoXNxRLAk+LSTKvpKE6H3k9akkGf3u52+9d/qA7AgdLR+9eua6///glROSNeAB2bBkgPX+QBAabHzxDDeJ7VlNn+luSXC2kZ0xC8s+oAyQGyyZQ56R4M52EmFvK1uCp/CtC9sKpGh8a0kb3EZOrkopd9Ur9MU7r8vfv/hEiqf24BqnuleSaNd7rrsPFvri7csq/ENl08rJcqwgQnZGTZd//fQPOV6SdtUz/xHaHT9XCvpWknXz3K2v7UteIvn62voF3uU+eYWuxy/H8iMkuGttiejZTPZnhFg/++M3X0la/8e5z2fXZ1pf/1/QLRMQWIjCiZ0k09dOLm4vqvi2HMmPkyAwnD8Wzavi2/x+yqDWEtNDBaRTJYl0rE1hyhjSUhldBUSZfG/i/IpfU41yQXJHt5WwHo34vQh7CEslFZwYvUZNCe1cSRL7PCbRPetK2jB72RIyTZJ8mtHqrJ/nKtvCp0vJnL6SokyV5lNb0vs9JPE9K0lhv0oS3lWFrUslSe33qGrWz2XDYn++vjd+Fjc4b1wXCuC2sGm8l/Nq/TK8bSVryONq8aLUku2WD86r0PR/QPIndFOhrKnvV5KwrlUlWp8zyvNp2bikn+xPDZBEr7vIAMtbmzVK8mshp9dlSlKfJyRSnwnPEe3+MAXt/KZsFZxi+fcvv8jrh3ZIln9drkGMYzVJ964qEY4NJNn9+vtgIQtTR/WwpWLJ7m1HBfTD11/o882Wy7tLKn7luvTzP36QrcETJXdsJ2X0/dbXYcnWzeslr+4otL52ojhaNgWMUqUySt4/f1xyRrxwFb9sChgpi1pVooAHd7SV7z7/WP6tymXdAh9JdrOTVXMHXGN1bzfdMgEBffPpB/L2ib3y679+rviW/PLTPyVtwJMS71xJjuSGV3ybVDLLmwwHZshVLXZyVTIZ4kDGSol3qS7RjpVl48pJfO3cxixZ/bKflM5wke9Ue26PepmMDWZK8mqoWvU1XdC+3Pzcia6yvI2dZPupVehsK6Fdq8m7pw/LP7//ThJ61ZR0TzDfA3JmTaJc2lWq2vpF3meUQyUKbJZfZX2u/dz0ffHT5fO3X9XN+0QyBj3DDT6/Kcf6DG8f3y2l84bz/jMHPCTHS9N4DyEqvLH6bFvCZsmq+QMlTu81Wq8PKxfW2fzOstZ2fIYwp/v4+7FOhnnxWQhmhFMD2Z24VIWrst6bnWQMeEROlKZLYq8q+pqtZKj13LB8uHzzyXs33AcLffnuZcmfaK9rWkWyRnaWQxlL1YL8s+LH/iOdWptjnnXgQxXfugpqgrHjnatYlU/q4NaS6F5DYl1qWWH3tojpsqJtVT4v1qNgfEfudaLfY5LoomsXMtF6vf8V3VIB+U90ee8a2Z88V77/6rOKb8mJoihJ9LlfcpSJ8yc6ScqA5+Sdkwes7xdNc+V70e4t5FhRsqR6VuaiJfWylXWLhsiOmAVkuLS+zWVz4FgpmdJVMkbaUxtHdK9CaxDrVIVMmulTSS7t3UTMvz1sokKqB+X02iuw74NzhyV7eCuJ6FGLQhLv+6h89f5b1vfhH2UNeVKSPWupZYy/ihH/8d03EuPWnBavZKaXZA1/kZARMC+qeyUpnu6uAnwXGSDGpTbvCwy29EXVmt3q8hm3BI2TnJEvSPpgtZ5+D/O54jyaGMjY047Cg9cy/KoT1gFeHcoMkMz+96niyJQDKQvlcHYwrTKIymJ6N9mXuMB6n6C9iYu4PrmjW8trB7YRal7csZqamwTolxPItfzsjQtXfddCf/vwbSmZ1kPiPB9QX/Fqv+X1fevVksZY72PjipES4VCN8DVR9y3W/R5ZPduFVggKL6KbHdcixuspiVNhyhrWSj5RHybCpbnuoZ2c3Zir9/iPq+/xNtP/VEBuRBbtkqn+x760ENkaNoX4dd38MiimG/XuqX3qgE+UtcsmKEyxU41ZRbYGjZTcCU78bLh9FcnW7+eO6SB5o1/kQm+PmKlYfrIk93uWwrQ1dIpaiWQ5nLWcFu1XhSj5qqWA2zcGjONPvX5wq0S7PShpXlUlrIut/lFN1tf4Khb6RR3t9AFPSKpvQ+NQl6NTa7P529FO1STZqz4hH4Qj1d1WBUSFeWE/Sfa5m9fdk7RMEv1bEhoGtK3E1+J8n5K3ju2V3BHPSpJvcxXCelIw1V2VxT6J7Fmf0AxClTeus1rBq30MCO4Hr5wkREnzrS3ffmY086k1WbSe2UMeuerzPyqcOlYQRb8o3buaFEzzkZw+dpI+qKXsCJ9MC5s3+gU+z+9h/4PZMZKr8DDWuZb1tZ9++F4S3WpKplrfN4/u4WsbFhmIivWI7llT4dyXVuEpnukrge2xj9VVGF9R1BCoCqCmxOg1AUszRjrQmhzKCuY9Au7+L+j/CwEBnVmbLOuXDJJNSwdSY0DD7o6bQzO9PXSspPe5V948slPeUagTrZagdJYbNd7x4iRZM8dF8if1pLZfv3igfHzplJzdkCE//fg9rw2mzFHhKZjqJqumdbH6MoAUiZ4NJcWtkmwuc4q3hs8lDMAfwJscFbgN893l/TNXmPHijiJZr9csmuoi6X2bqfBewd57E+YbGDHFhYIQ2d0wdErfRxWaXVb484GUvjxIrZhqUNc69BUyhrWVRS9UpfXAbwZ2qatOvIFkgE2Hs1YwEADrEdbNltG1G0WpoGGP5gbJjsgZUjqlE5/1VxWcM+vS5MMLx62fg1Jat9BfiiZ1k4yhL0reqJZyoiRRUtVpxj1klfkkn1RYy+sRlESs+70qwA31N07xNVjnPbGqoAIGy6u718m2oOFyODdK9sRMkeTeD8q2kFHW74Px88e8SCHOGWvP13C/gJjBXaqpb1VJkvs8ytcv710nGerTHcu74sTfTrotAoKow7lNBdRAN0MWxxF+SIxLHfno4klqmLwxbckosZ4PSYp3A/oocV4t6Exm+9eSHVGzZNOKIbJq3iDVMEHyypYCbpCFCqe50QeIcG1BJsweYhYbBPhROM1DNqvzCOYC/DuUBSs2XQ6kr5S/f/nJVVgaWjpvZEuFJjYS6VCD97Vu0WBlyjB5SwV4S+AobvThrACuw2sHttJ/SlFh+dsH70jmiA6S5lGJmjHSub5uvp28eXgbf295m0qysoPB4Ljf9GHt1JrsJjP/8+/fqMUcIZtXDiXsKE8IHyM0eqwgXJXJRD7HFathnvXC1lwpmdSOFhJ0ck22xACmqXZG+B1MCgJchLI6kh1AK/tHCPAsw7cGldqeuBnyW7kwLfbBEtyI9byPUBW/9fcvPtV7HaPCl4lPycniGNm42E++ePsS/w+FkOJZTaFYDQnpVksubC9RQbwkl3ZvkAs71si5zUVyrDBBfv7xB+tv3Q665QLy7WcfScmMXpLrbyf7ksvCmH+QvnrvDdUsoyXR9wE5Wk5D7EleKkEd7RSOPE3IAnMe7VRDLc4Q+iARvR7la4ke9embpPnWlffUCUc+5QfVtHTElZHPqtBuDZ2uDLHLem1AAcA7i8aENtywbJhq6b7XaGlAsqLJ3RRKVJeNy4fKxpUTJahDJQnt3ogwJKP/g/KPb/8mbx3foxrXRFt++fmfkux7r6T61FHLMUBhlA3h3p7EhbyvDLUk6QOekuNFcfIBIjtju0t8r7oS7lBHUvwflMt71jNaBQLjx/s+ImEO9VQQxyhE+Uq++fh9hWPPMIoVp5YV0Z79aaHKeAXKQLGqZE7wuwg9FyiT7k+ex/8jFxPr/ZSU6D0hDH0jgn9zJDdahfvtim9Z6e0T+/RZqqp/UV1iejWTjAEPy8nVabJ5+QBdi73y/rlD6ozXU8hVXS3MSX7HEk5O7X2PHExfJttCJ8iZ9RmyNXCk7IyaqetVT6J61qEFhu8W5VRTAtpXo7UHFA3raoT7UFZohbu5tXRLBQTaJ0MdS2jAJM/6Ku2lFT/yHwmbvuZlN9m0bBAZAtqmYNxLkt3bVoUmUvFuFBcMTvClPRtVo45U30Ux9JBWclBxa8HEHrIjYoLkjHie0aezG7Joabaq5j2YHiipXrWkaLr3VRGbs+vT1BldSe2a1v9RRpWw+An+L8r7Z4/SKq1eoAKxYoxEO9ZQWGQrqQPbqPmvQYc5TqEAYFSce5NyT2II0CSiRz1q17VLRkma/wNSPKevFE1sJ6FdqnCj4TvFezaWRO97GYVLHdRWtgZPMmFYfdYI53tko67HjpiFEqL3FtvDBBqCFLNHuTaTaP1Mmn8zKZjiRoFNUdiG+9kV+7L1Pr7+8C05vTaVCTzQhZ1r6bfB/0DS9EZUOrc/LdGaudeG5svT64d2SqqHnSSo8Cd7qMXs+yStBgIcICi/8hAP1nVf0jxJ8mvO50HOK8a5rlpmW7Wsd9HSIwq5pHV1OvXwq/C8QBdYA4TyY1xqyRsHN1uveTvolgrIz//4UTfsXmLwvUlLK74tR/NDdePHkfGRHS+d0VPhySBl3BWKzd+XQxkBDIumuNlKklsV1bKLCCeS/B40i9K5phRP7akau5ZurJ1c3LmGuQEmAx1qKbOqU+1QXwomOyvj2dInKZzizOuf25Qr0boB2EA4ifszrg01W6AAIBwYFTmJ4C7VVStXok8AJi+a7s5AAAID2CQ4lmDWtH6PKEyIqnhJWoVw9Ruw4ftSllOJHMlP4PXA/KkeBk6FdavCzyS5VpL8se0lf7o/80awNriXOMXhS15Ux7+X+V60cyNqU0SzMn0ry/ktxWrd7LkW+IPI2b6Ua/cA9M2nH0rG8Hb8DPyNw9lh8unrr1xjSfC5GLem/P29SdfmoMrTP//+rWwLHq1+jQr/dE85mBUmUcroGSO6VvyolQDhMoY8L4HtKtHPQPj7YNoitS7JktS/vQpaDckd10WiPB7lXiT3fUI+eOW43usF+ZtawP9FTuSWCgjo9f0bFFotuiaUWxHK5I3vajSMMkq6b22FNaPIdHAak/u0oGZN8ags0R5PmNAfQp1OJiRKDa+QKX1oezIJmc3BaOIQ+7rUPGAcwCq8l+xeRSId6ykcM8wGAShSvwME/I4/oAvbi8msK9sbYQjoUE0FswoFAQIKrRytUCHerR6FbEW7qiZLr9dCIvF69M/vvpHcCT3V/2kuJ0pTZUf0XFm1cDT9kEiHyhLp+oAKfh3JHNlNYryflrUL+ik83CsfnDuilqa/BNs3ZLISScR1iwbKvtQAhS8p8uW7r0mM+mRg8hCHu2T17F4S3bOGJLlXl/Ae9Xn9nTFXIm/l6ZBCplSsmwpfjFNVyRvXQTJ715ZXd662fubvX34mq+f60FLHuDSQ77+8NjR/Dam/sTdpEfdx1SwXSfZqJOk+1eTdU4cqfpL00cXThMTYI+zd+iWD6eTHuahl7mkqI/DMKYPaMVcFZfXP77+teJkK9Ju8o5DvRr95s3TLBaQ8YZE/f+uy9f/nNmbIsbxgao63jm6X9Yv7yZ6E+XJeX0fuYeMiH13gJbQgCc4Ii5poUkRXMLSbQobZ1DC7ExYoXs1SCLdacX9zddJnypol4ygs4d0q6yKfkATfh9XhrUKGT+rbkuUqgH+rFwwm82QObUM/JWfYU0xIYeEPqSZl8s6nKeHbp29clBMlCbI5aJK8e/oQ8wWFk+wl2aeJ5Ax/Rn0td24soMLvEQQQzv2q2V4mf+GjTOH/nET2esAIuDJqQDujLIqmOpX7ojqrF09JYr8X9TcbS+rgNpKp+D5j0FNydmOBat3KhCdQBCyz6d1A7/mCbFo5ikwX595QTq1K4qWQ5T6YtkJ9pK91zRfw89GudzGiFKMwi9bMtxGZCwQfAZYT95fqXVu+U9/yj9BHF45xH1/dVSylM3tJ3qhW9EstSggEJx7/h9VZNcdL/Uo7Y6Edq8rWsGkS5XIPfU1YlVTf+lI8u58kKB+sbIdQ/VQpnvCinF6fLWfWphAZlA+ifKLWJc27hq7FXQwE/Ld02wTkl59+ksxBj0lGn4bWWqX/RIh4wMwXTu4haZ42RmP3MJg7fWg7KZnURk6WJl71HSbp9HsXd60jJMF3Evq04new6IAuO6Nnyzsn98u3n34gxbN8+XqkYvcY10b8d9aAZvLD375QXySDodSd0aZ0xBrLVwizRgUrb2w7FciHCJuwuV9/9A5DoBWt5Y1otwo4S19UIMKd7mL5C5xQRK4Wt1KY5olEZwv55LVXGPHasGykvleLEC3K7RFZ9Fwl4nFYN8AXlMdEOdVRoXKU85vzlbl30Zles3CEWmA7Bi5yRr3EqE/BWOSGbOXU6lRl4uOy9uVehDcxahFhnWJc6vI5X91pSkx+/PYrdegXy8alA+RA8lxrMvRwdqhaB3fe440I+/jWUfVJBraWdUvHSrI/lFAHKqF3zxyRrP5N1VL2YfChaGInIgNYKghpqON96vPYSUrv5pI+4ElJ9WvMvFBUzwaEo2Hd69I3C+5aTa2PHQMy5YX3+68+l7wxbfT53JkG+G/ptgkIHfaBT/EBv3rvzYpv/y69tn+9bFzsI5f3rlcM20UyvQFx7Bj12KDayUL/Up8H4WREco4VJsrKzvW40Ik+zWXdkuFMvgFKpHrVYEQHmwurs+ZlLzm3pUBi3ZoofLKV/enBvB602vfqxELbf/bmq1Iyub3EeTSVJO8mylw2FNYM3+qyen5/2bR8OH//D5MyDYoBcb9RPVAaokLvjQy6XZkPpdDI+X6FPHYSolACZSqRPWozWADGATREXgSCBD8kyQ3hYFsVuhny7zLtDIYrntSJ6wVFUTjN3SQBFeasWThENi/vy8w3CDVicHwRSj1eHC9fqhP9vsI6S7jXSgiXl4XMkfFO9MJaVGIx4u/RppXjJcunzM/S30nwasY6rwvbV6nFs6XAQvPvjJpCpZMypLMk9n1O0oe8yLVZv7gvAxxIJuJzhWpZY3VtjuTHKDp4nMWr+RN7yIGUedeU1CDkfU1F8J+k2yYgxKMJL0vOiJa6ASlXlY38EbKYTWD7CAfF1uqwbYuYSRy/M2qGbFk5mk58bh87OpIotoOphjMb436/bAmZpBj9EVqVVXP9JaFXDWrIzcEzVMt8ISdWZXKjATUyBjxY4ddF9qYEm8TVkMfktX3rVGB96aNc3reFGhyMC2a30Dm1JBuW9FMGfKfcVQxB8LYGjpAM/3vlneN7iefPrU+XQxnLVKBN2DfMvoZq2ieMdlRYmDPiGUnq15ICDz8DDAEcvqClERBExuK9H1Ehv4dOKywvBGRn1FQWS6ImDEGT0pluEu2oymVMO9aPWQgwF+U9r2zOvClmOr85R7aHTaD1/D26vG+9QreajEjlKsz6+NIVFPH+2SO05kdyApl/2hU7lwGKcLX2eB5A0Fd3XomAfvnuG5LW/zHCPYTDkYTN9rNh0ahFeG8X3TIBgXaBNtufsoTJPWwWSj5gvqEh03o3vi4mxEIcygy2xvorEi3RoKcVizZWqLCWkQ2GBVUgNgdPY+5ha+gkSfVvzvg48bhzTWU6G9WOtaR0th8XuHByT8IZlNNHKLNljWir8KGvFE9zUR9iAS0G6JPLZ2VL6GzJ6lNLYns1ZIEiYveWsDASU0Fd6tNxXzV3oGxeMVDOby2WZN9mFLj9qcvL3z7pnz98J5lDWl6z8ZZnS1Hs/6H6Gl9/9LZsWDFOtkctlDVzvRUetZbXD+9gSQmqlpE0TO7zMJ8TfpQlELE3NVh9qSelYFx7BgV+/dcVKwAtjEQlSj7eOXXj8vf/hiyJyvJ0dlOhZPnZKsx+gvmjimQpL+I+hkyTRM9GtHoxPXV/vR6SwoldCRdf3bVeMvs2YYFmhrcqE9/mkuljR4H58JWjFS9LwvOfXp3IEP+NenP+KN0yAbHUACW5VZNtyrCAVaipgcRHO9dmqPanCpl1YnxodtTrHLmSvCtPcOzzRz0jW8PnSMGYVoxgATptCR5PKGTxQQARQrrXk8CONhLQobok932KDj58jJBOlekIL29rqmMBVyC8wMo/K07NHPCIpPk1kLfVysW41NfP2vIzq+f0kj2x0yXHv6YVUnxy6azkTPChMEQ5GO2fM7abbAqaKPG+D8uH549VeALAjTH8XOm8QaoIDPMC6x/KDJK9iQskXXH0vrSVqkA+k2inmmXFiDbXMDWENMmzMQUDcCusu95X6grVzmepOLIG3EdIUpEu7Vkr+VO81a/4uuJbN0+/ocnpF/O3Mj6YEUGOjP4t5D31L06vy5VT+iet990KJe3YSIXPffzqWfptbx3dzXIh0CtqjfbEzZGdsYsZ3ofFgV+FkC6CFom9n1L+qMa+HFjRRFc7Cexc1fhgbg8xtH09+pDRsWv9kz9Dt0xAkDE+WRKrGlE1WT8b2RM/m69f2ruZjJrsUfWqilgQGHR/8kLZHjL6hmUpG8sywNHuDxHygMGhaY4Vxl31uYs71zLKwZIG96Zyef9WCVL/ApoWERFEm0J7NDHl446AMK24YRDSle3suOh5U/0o5FGONVRjX6KTtytmlgkjO9eXi2rBkrzq66ZVZv4ld7wDHeFVM3vScd+XtFA2LB2kDHCAwovvf6iKo3SOD39/T/xc9Vt+kJOrMiTB1Wj1KLcHeT+xzlWlZLa/3nMV9UOqyZ6kFVI4w08VwTRev2BiN9mdsEyyx3STKM9nGAYP6VxdneBxsjtunmSO7i6xng9Ion+raxrLAO/y+tpJ5rCX5L2zV7TuocwVsmqON7+PYsQbadvL+zZK0RQH2R2/RLauHK5Q8R4pneUtmX0aKHxOpNCmq28W4foQFQuKMrHn0SogRZO6yp6ERZKtSiZ/kqOkqT+Y1rsRM/SgojlDadWRt1rZ3uwDrgElgCJNizLI9beVrFHdZEUb08SG10PsG5A/4IOWJyjineET5GDagmv8k5ulWyYgJGX4NQv6sMjs1Jp0OaHOX2qf+8hgiM2jRBl9FTCbMMkoy9geNVdS+j+nDL6a0S4wrYUQclyzaLRCqGmqKYOlYJqvKZV2q0mHEoSw5YXta5i5R5Qjc0QnFsflT3KmtQl3uV8iHWzZB5Izqp2EuT7KDUAJfIx7C4nze05Cu9UgVAnoVI8ClNLvcdm0YpjEejwk4T3v4aYwaedqNBs2Hln6BL/H+WzL2lSTZPdqJsONDLxLVbbz7gifqH5PFfoPuO7mkOlyMD2AeBswKcn/Scke+jQFH8IMTWkEugoDAwzVliX+kEAMaGPyQHB8Fz9fSfL9TUMXcjTI3SAggVxPSp9HVBm9bfWHTpbEMbcA4SdulysQB/4MsH2ab50batuSOf5lvpGtpPg/ohCnsmr3R3nfR7ID5Wv9nZxxPXi/SJzisyWzvCTOuRqVwLqlo1Uh2MmWoNGMBK6d58VkMehIfizXIqC9rX7XlrwTpL+T2LelQvY5kjmyE9cegnMkP1IRSawk93uazwLIjJq4ZP9HpWhyV/YFWalccOG/oVsqIOX9jk1BU1nyAGZMcK8trx3YQuGI6F6VJQkoKFy3eBA1ARg7wuUBahlkwd8+tpcbGNurMZ1hfAcMxjBfFxs149nm91TIcsa7Wq0Eoh/JXg1kZ/wKK7MiyYRaKCQSoXnCulXmBsLagMFCutiqZVgjl/dukhXtqjHyEutxPxcf946NQaZ8ZfvKtAKAPkkK37KGPKEarQNfA+QD00KQIEBg6A3LR6rl8CPToPwDv79u2XhJG9KGuRkkPnEvMV6PE/5lq/DGK6TAc1r7R3rg95SxgidK9ugusrItAhD3Ss7ojhLm1FRC7WupUNcls8BCB3WtTy0c6dqUaxejAm6BXKjJOpy5RL764IoVL57hofdrK7kKEQ+mLyJcgpXfFjZZNi0fRicf9P65wxLu3FTi+zzLYkLkmX785gsqKfielmthLXDvm4Imy9cfv8vc1mv7N5AvEGyBNr9ehGlXzGyJ7FGd0LZgSi+WoeyJn0eFFO5Ql5n2JO/Geu8mArc3eakJ57sguThUBbEqBfHd2+Bj3VIBAX3+1kW1EKWs+WEERTd507IhfA9YOaQb6pcqy2v7NkjOGHtqHDB30Sx/dslBo6X61KcJT1CGgfaN7/0EFx6JIzhplqwunEMICJg4fdCzktL3cVk730v+rpYKybBtoRPlI91MMEnm0FbUrqmD2ypj1pRgB3WqR7eTA2krCIVwLQxryFQznj6sk4Qp87HsxL4uS9iRuT67MUcOZwfxegiHMleQHiyxPStLnGttyR7bg/gZAouebpMnyZY3juxU7L1LdicG0gJE2ttKknsNtXp15JVtxbo+fencp/R7xoRGe9ZlxGrj0oEsj0fJyKp5QxgJBBQFFAKzwSdBEi5FNerahYOUGbfIlpApFG4ogdCuVcv5fcZnsBAUUIJrNSqg5IEdpGj883I0P4r+BJWRp63kjeuoe7maWB+NWTeCK7iffamBEuF8n6yee8U6XI8+ee38NcGarUFjTGWxWvGiKT2o+d89fUCiHSE0Zj2jXBqxPB97dTg7hMore2RrPt8H54+oAt5wVTLyVtEtF5DyBL8EtTOAUhb65uP36FB/cOEULQw0LzVzryaS5FGHXWbRTlXVCtnIhhVjVchcJAmZZOQzBj53Vf0NStUz/O9i22ayZ12FFverdbnS/gpC+HP9on5qKapKWr+HFaZ502oBmmwJnSOHc8JZ97Vmfj9lPsM0gFvQ+CxLUQuDdt7y0M9CaGvN6NOYQo5+c+QYoKHRx5KkVivRuxk7HHGfoK/ef1M3tZ1EOdVSLTtJ//+GvHlkuzJnK0ns8xT9mazhz8uJVcZhLZjsIu+dO6brhMoC1FYFXH0DSidXZ5lwdU9dM/8akjvBQRJ8H5KInk1kc9B46+fYcag+AzonwaSAu3sT5qlvYy+F07zKcky+sjtmhkLHRyV98IumWNK5ge6F4v/BT1ivhUjezsjJ+v0FFLqjhYmER9Eej1mtA/YJEc3X1H+x0KU9m9iekDvyBdmbtJL1X6fXZsmnej/vnTlElPHNp+/LloChuq9NJG1YZ1o4WGT4Ieg3gXCxMez8MSooCOf5zUVUvreDbquA/B5hAbHIEY4NaTWQ+UUVcOlsH9kYMJIMvLyNLX2OgA41qGGA2S1mHzH9vIlOhCIwt8CxDHt6V5HXD2wzP4JcTOLL/AwYrHC6l0T1akZmAG6PV18hqX8b02uijn3h2JbGUqlFivN+WMLUvKO2K7FXVUnxa6LQw/REf/zqaVm/0Fuyx7sT3uD3k33vt8IZhGyTUS6DylbPGnIoK1whw3xCh+PFpsw70b2eWpU9jGLBSc8f35U9GPvVR4GzDaUBIdkcNEGvb6MMfzctXEX67rMPZfOKQRwKgSgPGo1g3fCnvNMNLQ2fAYlXMGnBuHbMRUCYX1fGxKSZ0lkehDawAN8oRML9nFconDHgUdkZNcl6LVgTE7G0Y0nOsvb16FcFd6lp/QwEl9NR+je3vvbemcMS72oGVgC2BnauzbaI9Qt8rZ+BgMGxNyHxEgpy2jCTbUcVREW/Ah2cmBAT63HfVa/fKvo/ExBo9g1L+kqc+10S2KWOxLjWo5OZ5qMaZlx3WfqCwfUw92BYbAibiEZ01882ltje7QhHUHuFxBodxHYGrm0Nm8HfAGaN6Vmbm8daJxXA4A74TjUpmeEmaQMeUzzfTgXHVzYFjDWM63O/bI+YJjuj57DoLsKxJn0LMCwSkaDV8/ob7aqQEPeXP9WL1gGExh7g/wiXh5TxNspHKkymzMNGTq1OZuMTMD6EJ9GjoUK+DvTZ0gc+I4eyY1QgJvJ+McYIjjCuD0d0W/gMRrE+ee0Ci/ww7cO6lgy5/os4v/zrKJ85XpTMPnmUeXyo1vzNwzupGNa87GEtLFw3z8MapkfhKGCbhWAtTpSkqnV898pr6nck+T9OC5vo0UCWt7WhQsscbboBQXD4Ny0fyNJ9KAILQYlsDRmvMBcQUPdNv49mqfKE0h2sm6Vha19aAHkgQfemPKHSG+OkAMFyhre86r1bRf9nAgJLEO9Sg1gbGhjMi4465Auyhr8kJ0qTFRu3Uc3e3Iy8cTD1OoAz8A1QZoAIyusH1jPJREjUzZROvH7QWBB0oCHxBOsCATJOvhG4vFEvyZ7kQMKazP73yzunDkicS3U2ZgH7HkgPYcNPzpiutEBIDFoYYHf8AhVKOwnvXp31U/E+T0jhmOc4JSTBrS4tUtqg56kEzm/OVWj4gmwOGMRpIyBE62J6mFwLoIPF4UQ5DXyqMMemkj6kHedVxXu3UCd2puSN72aqmnvWkszeteTi9uuP5fn0tVdYzLczcppsWTmM4d19iVcXU8KSoezl08tn+IwYpgH/Bv7Vxe35DILszwijYCHqVlHLg+CsZ483jnlq76Zc64q+x5GCJNPr4t7gqtch0LB0WwOHyt8QNLhOtOlQxnKFhPXl1Jo0tSIfqZUcImfXXZkLBstlLGFbXc9T1rDxrabbJiDISG9Y6Mvw7Y0IJd0Rrg+YuHYP1CXZkoljnOvJ7uipxNSBXRuTeaDF4XyGOt4r8W6qeb2qKxSbQHOfM8pEhmBx4Hyvnj/YmvnG1L+8Cd0ZykQoNMr9ITrImf2bSXr/x+n4r108gqYam2kZ9ZM8sB1LWtYuHWvKQVSbQyMjAXqiNI0h1J1xSyg8nHXVxdwfrEHJLB95dfd6dtaZKJidpPo/JMcKo3lPYCYk9iD0y14yETXCtF74bfhlNpLsXlXObiyUtfO91fH1lTh0GXY1zwC4sTt+YfmltNLpsufIGfqEWqxEJvAQSbIQnNpd0TPJeCA43ujdQWcmel3wm/A5MEYIgvX6wU3K4I0lc0Q7vV7KVY4wYNge/e47J65YiPKE8pIop9qyao5nxbdI5duiyxP81sQ+zxISblwxinAan4XvasmlvXf2iCrYarJm7vWvfavotgkIsCxgSPlpexUJi71mPpJjJs6f1L+thNlXUyzsyXZdlDjHu9hJ3iRnhvYiu9tJeu+GbIJipEUhQebAR2VX7Cx9rzLDgvBVUAR4ae8V5/DNI1v1PjxV07eQE2rO4TTvjF9kGNHN+CJIrp0oTZIotR5gcozhYY7jJVveG7KyaCAqmthBN66ypAx4keFFWAGM58kbV1aV2hV9LNUlzu8pCgdK9SEASSrk6Lm2EO4BG45y9nivZrSMoeib71YW4u0Oq2rDa0KIEZIOc7yb1wzuXFXeOnZ1MhDOMphm1fwhsnrhSHWYH5fNIXMYTUSPhcV5xsgkWiKnqnIwM0Sy/BtJpPM9tHqr53hw4mKq/4MS49ZErfMGOZIXob5GdTNYz7eOFX59+9nH6tT3YaXEzz9+rz5HxnXHuAImlW/E+vHbv3F43P7Uldx/Qm00qk3oSH8DkC7Joy5hU6D9A5LpV41W4ou3EZBpLFkDW1BR8VpllvB20m0TEHQIYrrGJ5dPV3zrKkJEYuPyYar1bORIbjD7wH/Rh0Y5w67YOcr0VeTs+nQu5jsnMKnwCBf9Q7UcGQMfV204hSYaGj13kqsytI0UTHK4pqwFGoiVqr+hx+K0ZI8wgyCgwRN9HiCWPa5YG1galmDJC5X5PnIOqOnB2M/P3nhVSuf0logedSmgsFoYdLZBLdnHauaj3R+RFa2NYFl6WWCRlr9kBC1rjKt1yMD+lGWSP8lFdsbMlSTPehQsMC6CBBAKCCh+H8IS0smG11v0vIFkId3rcxYV4v6AKiXTXSTV9y6Fh5X5ueWt7SiY+H2U+GT1rmmFZKhvSun/tApbA32O+oSlm5YNkA0rJqmSMLN1sfYYbQQqme1HJRDn+aAczlpmrfY9XpJOy5/Z/wGFoyvKYNiVSusbESJeHIvkWJnCZoHaKCRFzw0sf2DH6tyHoln91KmvzsQiwt0pfs0kb/Tz1kgm8jY3skK3im6bgNwM/fTDd9SkFTEsNorlzjcYKoD3yy8QhA3m2DJr6Xp0bksJS0WCOlWRyJ53EdbAMgFWJHo3ZfYd+RLOB1YG3RExmeN6oL0SVbNhekesR3PV6jaEbfCZIrrZyuaweUwiQvNBIOBPIHiA6+A3EKFDoGBr2ExVAl+rENgRTga0s6OlDWhf1rnY0eQw4G+t7Ho3hcQCHzGWE0wJKwI/DKXieaOeMzOpHM1nYO0INZFshHUb8pIKYC3OFQPkWaeQ7ZUthbJqbn/rfSUPtjeh3EGPWdcJ2vn9c8dkW8TLFHiMN0KvheU91M4dyQlSpbVT/71NldWjcrI01vr9G9G3GHs00022R0y1ChuSmLgG9hlVEOFdq0iyV02GbmFxoDBBLA0qGz90bmOOWr+GjMJZCHDxWGEkJ3LeqpzI/xcCcqvoRrVE5Qkl6qkeNpI5+AlmulHGwCiY5z1kPDA8MuMcPaqMVjq3H8OhKb3vUwFqotquimLzubp5p1lOEtK9oV5DhcWjqqzsgOy40fqp3rVkX9Ji9WXaEmIBJkErIkoGrRnWrTqvH93DhtBwW9gk9ddWSZzPw+b7g1pJ+vBuFCpYAwheyuDOtGC74uayixGJyHdP7pGMIS/QnwnrZifRXk+b+4Cgu9lI1shOxPHoXUnq9wKFb+1cN4WTKXxuhLsjXB6UjEFPGGssJtS6ZrYLcysYoIf7jHKsyRyE5b3yVglkKnZ/X5tD2Z3bVEjn/3qa/+PL5/X3qkmCogaM9bEQYdii3my6urxvEwcKZo12UN/ORrYFj7B+7lB2BKs0ykPB/5b+zwXkS3V6UQT3zSc3PhYBWgMl7Tui5pRlg9F5eLUwvHFoqxSOfVaO5kfy/1hUWJTr0YcXTzIyAsccGjfZ/xFWumYNe55jaDKHtzXzgXujTKYevwPIBksH7Vm+qQhabdOK4ZLmjlCnsQb5E7rIpV3FDFSsWz6JGwknfsnzthLvVpeDK7KGPs8CPXYY9qrCzkQ473G+TzMvsqJjPQoWW3KdjeC9fhDTR35jNGx3zCwm1wAzsoY+QyZGaU2oCh7um76MQ3U+H0K3SA4GdbDj64dzI1mrZuCb/unRVHbHzpT80c/RkmNtkVyFQBshRpuwLa2G5b1krzrWgXmn16Zw6omlFORGtH7xAN7jmgUD6X9VJAggQvj4PQQOjhUlcl8Iw1zR2VmFgoE1xrDAjy+jQvgbfhewC/VmgKcYIXRN49efpP9zAUGEA7BhW+iVrG9FenXXBjqJ6KBDEz98lvzRrcjoFtqnTjwYo3BSF2WemVxIJCHRw4wZtOV7JCyE3AEiPF+8bXpBUMaABd+fslgtiB0ZNG1I6wrfupZQKQANjOBAycxezBCjMC/OpQ4jcIA7EARANmwgejfwWxh4h8afVTOdeQ5KRp9GCpVsmN9hb7yLYdCYntVZXmEp9dibuNCav4ASwKxfDLjYHj6dveeHs1bKiZJ49rKcXZ9KYYXiyPK1YwgdQo1sNmAZ1gyFnKiDSnCxoc+B9ULhH6JEmb4KH4Mmy+nVCdbfx6RGPDP9Ol1X9J3DrwBEvSpq+dvVigylP5g1gH3MGticZ5FUJFhEzCZOHfCsPuOVEDUa5U6vz5K9yYsl0rGGXNq99uov6m/huXdGTmKF9q2i/3MBOZi5kj0QSKJhAywFbcYfMRWZwL5rF/hLhFNDZTAbCWxvsD4a9i300/ffMtKFhn8wDyANnEs4v5jAjopfXPNG/gx+5+yGXCbk0L+eNbYXoVjO8OcqfvIaAqPsYffkc+yBQV8E/JjwLjYcMrcrfpHkjrOn0KHQ8dPXzWREDK7IGvy4nFoVzwnnqX0e4DCI0tm+Eu3WTK1GVSmc7s321fNbS6wW8TP9/paAQfLm4c2ENnmjW7OH/8zaNBMde/da7XxuQxb9jaLprorR4yVWtW1gR5SoVNZ1hW9VVaHbQgoFZlQhz3AofblsCxkr+1OXyuq5fWTtfH/WgmF/ykOkd0/tlcyhLzLBeSB1EV87vSZRcka209efsyoy3P/754/xOfPHvmR1tgFhLaUiHM43oT1hJ4ZjvHFwExVktn8Nfc6XjDD623BEaeGk7mVWVZggheD/47uv9flMGP5W0C0VkNcPbFbT53pT7bVvHd8nGb0bst8ha9BDkjvqBcXIPpLmV1/yJjhI0Qxfnu9RMsNDwh1qERJA6yEcjLDiG4e2KUN5kinXLhyqTKkasWtVYnfLxBBoygSfB1RDN5Ccca66+VfyAiCY9o0rp7K8AaHfaCTjfAz2j3Vrao3u/C79ZooBMa8JoUjAmx3Ixk/oRsGI97iXTGaBBBb64t3XZXPgRHnr2B4yzBuHt0uKClHRrL48+wNhbfSpo0MSJSsWAoOCIdBwFO/zqPoIVeVYcTKtUKZqZ0SEvtRrg1AakzO2K4c/hHWvzUoFrE1QJzuGj7dHTOb0dljUw1mBkjboOYVldWRH5DR11I8T18OaYUBeet+mupYPS8bQdrJ63gDZvHKc7IyaLTti5is8asD8D5QcyvgtUA/J0vKE50RoGISoVUa/5soDddlTg+cyrdrPKSw0QoPhfYnutWXdAl9amANpy3j0A6xW/mRXfgbVCajtw/R/DJ/7IxG1P0K3VEA2Wg6YSTA9B3+EsKBpXlXoNCd71KLpxSBkOqVuJkxafpIgIj+wCgiDwmmNc7uLmHRL4EgpmNSDcG1Z6yqmILGsTwKfD3e+j8KF64Z2rclY+runDnD4XNrg9pxOiMgUjivYAh9hyFOSPKiDqS72RbPUmoq3To2IU6k2BU6S/emhnFoCjY/7ZBTJuQmnccCSscTd/T7ZGjSK5eXZ41wkdUg3ifVsYc4ncWkoR3IjZGf0LDIthhxcUocUDMYkJAonHe4i40ODI4yePqwznxcKIKePDZOHaf7NJaXPg+qo1jMwRq3v7tiXmR8CQ6X4NJYU33vI8Oi9WL90JP2qK/QbW6BxT/CRkod0N5ZY7yOxT0syPaCnqUo2v41EKaqY4xU+Ymg2COe4wArEuzWwCsP1CL5Ctq55Wt9mHIcKgpU6rv5H+XGniGahxAUh90z/Bhz4XTrHVyHyRiqn1fP81b/R/RvViRG1UwoJbwXdUgH57M1XOPcKFbsVCVoDzIHs9Afnj5rw6ZuvMiQLDV0wpaek+DWV7VHzJLLXQyxQ3B4+RZL9HlCLUIPTR7AxEJgVbW1NiNLJ9IfAvGeP6cwhx8DsKzvVl0inOiogNoRaSPwhBAuhwvuwKstaV2eP85IXzLgdlrM4VVefyJea+QuFKdmjuzGBx4YdF9PwVZ5Qv4SMM4erOZh+dzAMm6/amqgVmB33zB6U9nblQsPqtLcqE3Q3IwSxTpUlyfdBcxLXFE86+HDQEV3D+3gONI0VjGkpcT5P0OGNdVWnP2ScbAseKZf3bmQmHPOFAWOyhj6lmnWGpPs35dFuMb0ayoH0QAnvXkv9miqCo95QVXCiOMHqK7x+cLPkDX+MAo3fDu4ISIueFjvZk7iCZTax3o9L9qiOzLzHed5PBQSFgGfdFjqOs7mOFSWxXgv1axjZelJ9CAvDo7rh1OoMQl4IDyb0v3nUtFxj+kxSv5d0LW3VN3MxPBM5nb5kYu+neRoY1jel/zOS3PcZtWRtOcEmo++9siFgIn8/d8TT7Fm5FXRLBeRGBOE4XpJCRxumG8PXCvvZSKIyf/6oZ1kCDkZGxAWbgRIDQJ1Tq5I5IS/JzQxI47gb/Uyc4uTAjrYSal+TWhdRLoyLQYKPs6DGu7D3Oc7rYbamBneuwrwEs7NlIVdcBxu78DnjEEP4sPDQivEe9yj8qEotCUYmvFBfAqdSrZ3ryUMyIdgoO4l0aara04ZdiagIQDEkfhMJOFwXtVSRbi2sTVAQxMCudzFBaUkMQlujlIZa3dE0WK1sa6OCZycr9HMo3IQgQ3CWvFjF9Gh3rqzP6cxp8TioJ0OtSbh9LRVK9Xt8n5UYryckqEs9luuD2Qk9IegYEtfDRn21ZhLQsabpruxRh5Ef+GdIYGINY9QyB7SvzDXFveEeAtpVlqJJXZSZd5ssuGpuhJAhqNg3RN+WtqvH2bywToGd6vKZ4ZQn9bKR9fO9aTEKx7fjFJrSuYMks09DKhCMbv3u809Z3s7GtrLix1R3Gw6ug/KAIov1a23q97qZ5Ck+i/wRhBOHDcW5381WiZs5hPT36LYJCBYbEzaQOUbrKc7PS+jzrOxQvIr6ns3LB0lqX/SZ20jGiM7qU9Tm7F0wSJg+fKhi5bTe98p2NdkoRV/eRi3AS3Y05ZGu90rWmJ4clvDxq2dYQRvj8Qg1LTQyGC2kSxVaGDBbpMv9ZEq8j0w3rgFGXdgSjGejwmHDzcdCY9HBTBAYMG+AWivkCxB6TBpkCgbRr5Li/xiHWGMjQ5RZAZ9gNfCbKNHHZuK3Y11qy4qO9a143GL5wFBgDHQ0AgZaqpFhjfBZMC6FqOzfEDaLT4V7hEUKUwWBZ7K04eIPlAA7GPFvTyNo+D0wED5raV8FLELikc/jgNITW1kz14P9G7G9GqkFrkclwhGwZaFmS8//3gQzbwC0K24+s/tok80vUyi4HsaqZqkFxvMh2IHOwKN5YcbHSJpHX3NvykrCa0bqVGhL5w2R3InOVAzgg1DnFhyndGlXCWf+FkzoaKbOYITSiK7crxVtMDjDRgXZhgou2buRvHl46586Tu56dNsE5EDqYknzrqY4/F5JHtCOGeFIB4x5qSEXthVxoVDJCWEpnqJY3MmGmw5GTPW/XzYsH01IgQMpMQTAkvUF83JTuwPC2HDAQZS9jenZbmuy2LBUltZVMDDxcdnoSlon+DWOJtNsyXdQ8OwNTLL0gnM+VW/jP+D6GIuJsgpsJosQFaKBGbDBuAZ+D/Vhy140CTjL9QKUSSEEHDTQ2VwPFgaCjJOoUIuV7m0nwV3rSFDnamQQfH7xC4ZBUeUMiIlnCUJ5C57Hs5mcXpsmG5YNkUKFp2sXDZQDGcEcG7R+6QjVpo/q89no+jcz3+tohBO9JdFuzY3G71nmG3k8KMlqpTF7rHCqJ4Upb8xLHNWKhCl+H/cBBswbZ6/O8zn6W+e3FEpy7wdMuFgZO97/Bd4nesY/feMVhoNxMhYO38zuU1U2Bwwt446yySiCqfDb9Jmrc93QfoxkL2YC04o4XpmWz5J+1JMxtPyzPms413d526qcfIOj5zYuHcSzTW4l3TYBwdl/WT62PONhzaLh7NSLUkc01a/hVY0/MNV4sDh15hCl2J+6TN47tUch0g7FsE/L7oRFkuCHAXC2xPTwK1Z2qMyNQ2k6x990AbPDRzF4eYlamqAutSWuzwuq/YwGRW4BPec46y7SpYleoxrhA8s99N+EMN0aKMb3ktShnSTW6xH1dfS9jrUYvoxzrWN1ZlEbti95MedhwQdAuBSaEwKCwW5gOjCNpZErpKuZmojr8BTe9vBHbHmg56HscHWm7ye2BvRA1yQgBT+jEIj1Xm2MELKI0QHDJ9oyk8/1Q64BIddyYVfUUeWNep5Ci+EOtIZlViXJ/ymWdWBoNoMD6pttCRzGeb9gUjwDFATyLodyorjmWD9YM1i3PUlLOHQPDJze935J8rqbwpU5sru+Zta6fJMU6JWtBZLsVVvh2/UrkJEzQgEoSldAgM0IP+MwIjZ+lQvNIx9TMPIJifNvx8AN1hj7gtwTJs3gSDskIffEzpKLO27++I2KdNsEBBEHZGVxs3hAxPkRnWDrarnNBEEj4PWK2XGLlsH7EKojuWEsztsSMlmiXRrLxpUTeK72stYmiwwhieuJ0o2qkjfJVXKGPcEydVSrYtMx3ua904cI6dCPQTjUsy6dZ1ilkumOZDb8Xurg9sbBdm7IAz3LwwoLIbuOyBmEFnkPDFWAYLDyFoLRyYSK4S8g+rIzdoERmq7GUmLANo6hhpVCPz2sVLxrDYZVkRvKm+JDeANND3yP+4VFyPCrxaHa5QkJu/LNUu8c3yXp6sBG9FCI174mYRcYCueb7I6ZJtGuDemXYZDED3/7XPYlzefgBAhmglstlrBjkgwsLJ4JVitZ/YjMYa15hiE+h2k0OIcl3UshsdN9VDhQZOj8LJzuI8Uz3NU5T+GaorzkRsMBwSufvXmRLdogCAUCDUgXFIx+RraFmPMjQZuWDzGjaLtUMxXXCq+2BAxh8AB7GNa1sqQMgbBeK6h/hm6bgNwOwkKjW3Blh5oKXeDEJzGjWzTDh44g224dqzLeD/iFeqSsoU/zRCmMKT2cEylrl4zn5uI9HE6/fsVkMiAsC87x5u+ooKYN707myBja5prEmIVQRp7ibmqpAO+g6ZGVLpzmqValCn0KwKgYpypqmfxYhwVYkOGD03ZN5hoT1UvnDVSmxPEMdhyXdH5zoaxfPoHPwvlXnYzAoXc+ZUBLMkj5Ij0k2cozEq3ykr7MJWFKCIQE0DKwU1UyMCJ/EDaW2ahgI3KHiBKOiWP23v0xhU8lCouqM/qFe4b1w1nuucOfpUBDaPDZleqIZw9vKcmDO1uDDAzv9jTVyHEutVh5/WfocG40hTp3+FMUrrPrs+Xy3g2yevFoqz+GVu0DqQu5x9nDnlEIvFzvpzWFdXfc3IqXvGm6YwQE2hqHfALHMyyrTvjaxaPY6grtWTi5u0IQdbbbV1eGr2JCr6qlX9m+SjYu7ivJnjWJyS3+AxgusFMtMknKgFasdoXFgvVAD0W83xP0QbaEX2s5LARNd0bhFo6DAyMbh1oxvus9VmccFsNykCcsC0KsCX1fVNhVT4K71KKmS+rXilnzRM/6bAgC1MrpbSdxfk8TIlpGB0U6N5WM0U5kPDRjWejsxnzWeyG8CYJAwxpm+tWQpN4PS7aPqSRGByTuAwwcaN/ETGDxhFV4ifNyU9WKYX0B5bJHdeVRzJHq/0W63MPcytbgMVIw2VHyJvaUTH0fVhCwLdnvftXaHa1V0OxtQRFkt7IAg3sL673eDFHIPVBRPYn9Jqg4xggnFF1CGdFaj+9krbvC/iHpmzbwWd4b2nCRWf9v6I4REIu2xtC2aJf6kuVtzCtChyDUDoV2b8iNAdPhbzjjBzLD2dMBoQjpVl9iPFsI6p3wf3wGGwATDaZCCBdzvXCGemjXKgwagCl+j2BZMkZ1o0DCv2DdlZp5SwAARxbMfdq8x7ZgBheMMAEaIjgR6tScGj69X3PCz+3hk3kmH46ES+rzMBlv/rNl0SoH4+xvWmFxeE3C8rUDmzglxUJgDGTSMSE/2u0+dZ6rUEDBsPAdcsd0pBZGeBqzjDN615G0Ie0Ec4txqA2mXWIED8r7USRaNLWnpI/qZYUuiFCWzPRU62jCrwGdGkrK4I5UONDsCKLAv8P/S6Y5Wu/rjxD2gmc9qh+KCScogUnr3YSWFJErdEwiWIGwNY6etsxVBoFPENRBSRISpYD2/w3dMQICLYFIxYWt+Uw0Jvdvw2agk6XxfP8X1fwYTQP4gSEKKAQsnumlpncPC9/A7MDYxS8PVk1qjhXIn+wmq+YPkx3R8+STy+dZaQutn+j3pAR1NdW0W8oGQNyIAE2SB7xkhRfQ0OgMhNZH7gah5LnP2NLCYDIihGLJ82XRKEAy+wZs/8U1cBQaIjybVwyWfJ7N/rLieLeyfn3kfWqrZXtScH47ojggq2CPekG++fSDq29OcHhnXxOk8DX3BkHGkIoopwbU9GD4KIdqkjmwhXz+9iWeyosQNiDpP/7+DYVs/UI/Ph8astCjj1ZeDCpHW29872epFLBWYd2qlYXMTVQw1ut+TsT/7ourE6z/iTCONqtPHU7mhMLYGDCWEA/nxMf3qkVlA18jSGEsBL54lh8TkadWp7FkCS0EjBwqQgjtcY+c31p6jd/7R+mOERDQ8YJIyRnUXOJ9HiQDoVd69WxXaxPN1tDJ1Fhr5rhTq6JMOq1PM4Y2wRwsU1EGyRjVg+N0imf31g21ZWIprd9DktCvPTcCWXHLZEY0ON2IAMUyRnSQoM61jDbubJxZ+kIORlDAhAta2ljzGZY+EzA9oU67siYoRztJ96vDJiWUvuOo6TcObeGJWyz1sK+u1jBCn9fNhMPd7i+7h88I6yCQbx8HTPyViVkwNmqbIPy4BzrfylzsG+mCBjEbdioiqvXxqyflg3NH5ZBa27wpvlyDzAEP0lHel7KC45IQlsYzxKo/lT++MxNyWB8IBu4voFMDa5UA/DE40dDm+9OWSd6YDtajq8+sTZU18/rK9oiZPKgVg84rDqRDlUV27yq63xH8/4evHOM9wEqiHAVTH1EWZEkMQzGxCtoXz3Qlq89pmgiYdL/xWNX/RHeUgBRP78UFCe/Z2DpyB1GrvAk95Yt3XpdDWWEmW+zaQJ3zVpwIGOnUiHAJTIlQLje0R10OjcOBLLAk2FBscmgnI0gIHYc6NFZHuxqLCEFo80U59bH8KGs8HofBwE9hay2gE3A3tFsXAzPAtBBYS/IS8OCKFvdS7YZstR0tiUlK2imcwPERZjzn0YJYwYgi5miQN3G14TggJCJxJB0IQyvCuprq5tPrMnl2R7RzPdW0NeiPRTjWY3UzzlZcu2SMmeOL53V/gqU22cOe5aTK/LFt+QywNJGuDyo0W8doFBgMvgSYH/kQPI/J9psel2T09OsebAl7mclcCCLHK+laxveqyW5N7Bky9GaaY3UKFqwg/KsUzxrXVB+jFQBVyaiXw+m+0b3ulyiXJgZK6brDT4MA4n7Th3WU1fP6cMoi+ujh+2GfYTXZDKb3joDJn63uvWMEBAyTo4vAUo2ONcsiGIYhmSFvYxxZZtGRh0AY1dUcd5Dgda+a29rWrDGScBbBQAINDAPHF4yHTce/w+2rkjlQ5wSCNsQ5h2k+plsNTi2YD78FTRXm/LCs6NSI+QJsEvwM9JBzyEIZBMFv8SBR5DR6NqEg43NIfqKUA0IKqxLr8xQtCY59Y8hYBQCWhv5LZzM5fc08U60K7btmnp/6FU3k3ZP72PQFIQROx+fxTFgzONVFswZIIpKgytA4ciDRvY6BhY6NpPTlPhLYyeLEV5ad0TPJWDEONrKiQ22WnUAZIEIY0fMu3jcDHbqWOIsQU+NRKk9L7WnKgOBXJfg2l3WLh5iTrZS5j+aFc1DHzqjpsm7pGApc2sCWLEY8UZJorUDmml88xVo3Syb/cG4MR6FiWiV+F/uESumc4UbItwRPknQvO7XoNXivgLNord60fJA1hHyzdMcIyD++/YZQwjh+akq71mTyCwyJhYCWBiMgi75C8WeEY31GMpgRV22TPb6XSTR2sWGxI66Fz9NRdjR5CQhYYEc7/h3RowbbTM9syOLvQ6thVOex/BBqwqJpvagJDQOibso4/GByVPNCGCCMMP1BXepQAPB70MIQXggoNrl8OQmECAKPayV43C3R3s9ycHf68C48awPBiThvU1KDZikLwT/DPbGt1usuKgkOimhtrBZ+J8qthST5NKVSSfR7iDkpJOTS1CHH8dhItEHLblC8j4x6vNc9LNY8vSaFmhyH9LAkxe1eVRAfcuo67gPKIdX/Yckc52Zdx5he90qEUxN+nuOJKuL/sv8fKUgwo470uTYsH0WoueblK1NwUH6P/FH64OeIGDJ9q0mi/3MsT0I9367YeXqvtTkr4FBOjGT6VeXxe/vSgrn+LBjVNS/fvnuzdMcIyA9ff6VQw1Y33YaJQsykstQgIWJCR1YZomh2f5ZCh3StZtXIoYpBg+zvIf4PUCcSQ53h4AHLQxhM8s6WZe0Hs6OolbDxEQ415VC2aeG1EDbtQOpyducZra4wbdDjvC4YZNlLJssPRsEJS5jMnj/ZncyEe4HJhwDgM/g8Dhll62sZHABkAUPj3vCsEB6MPU3oVZsKAc+c5FFfPn/zwlX3BcK5g4iKWWAUFMKSNrXMOe8ugD2VKTw4sQll8AiLIkFnObcQhKTu4fx4/V2Fbb2bWs9twSzcJO9GKrDVZNPKcUz8pQ9+hlYK91o41UWZ9ykKOBx11EbBusb7PMyJJCAMd0OLAaq98Tcqec9vKZKPLp3mAURRPaqqQJkOQgshCILBdFg/1pRN7K6+1k6eJQnFgHNeMn1sOdsM38dzrl4wRHLGdKKFw9kyCCj8WbpjBAT4M9a5GhkbUYmMYW04Czbc+V5CGDA0SicwngZDjgFbIDQYkQNnNbBLPSvsQFYadUXQLjy8RT8b5VRX9iStlFXz/AmloNmh0dAOa4ZBGK23LxHFeZX5HZh+zAeGo5zi15znkAQp9qYVUWZOGdSepd04ZAaRHdwnoCC0OEpNAFuivZ83Ax064zu2Cu2q8DlwDZxAu3HFaNmfHiTxrrWNsKtvtHH5SOuEERA0PO6hdO4AWiZobjwX7gF9Ihw2Bz9JtXC8eyN59/R+avHTa5JkV/Qs64hPC/HgoLh5nBcG+HIwfYUUTe7OpCqEN6i9ja7TINmwuJ81b3IwM0SOFafwWQBvIIhYf0y6BFyEMK6a7iCZvatLove9kqV/v7K18Mpv/vQP+iKAjAid4/kgQEgQ5o/rKOn9HpCUvk+ov+lEoYbg4Dsoucf10MlZPMWBe7dRrRGgcbyzLQXF0sH5Z+iOEZCvVetEONQmJkcdFTZmebuazO7yjI52Bu9z7E7bamXWxUYKpvrKxe1rlMlCCMPALOgbAbNCkzNf0t0wU1hnVAzbkEGXvmSYNMqtuWQMfEJyx9rL1qBxHLiA8nt8H/AJR4yB0OWGWi8wECwDQrqEbB3sJEB9E9wbLBUEDwwEOMVnwaExjuYeEGDA73LEKvMpVRRP1+TpU7gurBLgI45JLp7uTL8MYdkY51rqJ9Qj1IOWJVyE0nB/mIfpAAayytZR/arhj7MvA12VmNCSqVZuw4oJjGKVJ/gCqb4NJWfYY5I95Elmz+GYwzrBYqCL8Yt3LknGkBdp5ZIHPC/J3g35Oywyta8sJbN8OcfM1Iv9WzbjdKp+TSV/Qnf+jcma1yMM08DkTBy/ADIRyR/YKw+/MMb1bskd/pjkT3LSZ60iYfZ1WE2AciXLqKCUvk+qsqrMLtX3KzzbzdAdIyAgnOkHwQCzWKJDFiYHM4IJwXjxzsD9NWSZChAYKqSTrTJeZVoOYPPAdiYCY5jc4HQwrmmsMpZh8XOmMheMS4ZQbZjuV5cRlL0pQYQg6X3v48ah9Te594MUAGTzLQPfEOYFvMF9Bnasqrj8Lt4rBAOFkPjMinbmWQCHIJjMTUBw2hk4hegVcHqIMn+0h/6GwkX6VZ3teH74gawIam0k6xY9fyXMifU4u7GAmjhtwNNqVRvI2kXDZP3iobJm4XBaEwQZMoZ3lBzF9JkDr2TmUaqCAdI4OQrfB5Ovnt+P4VIqDV0TnICFkGveeIeyBjQ7PneiZ2MeP41/b1rer9zuGXiKgQrGZ/r+uuU7IAzpxjNnl5sH8CFyX/1acs0COlRl5UBsr/pcTyjILcFTrZ/9VNEGKrxxDQyjuLD1ymnEN0t3lIDArCb0eZqLAmaGw4voBpgXsXuLY4aSigjXh6m9wShgcDjmcODpwLY2zAdNjonyYDCLlmUPh5O5JpghwrmxbAudIscKY+T1/eu5qTDtmLO7PWKGXNhWovjZFBxiRFCMR3NjqdqZ3wKzIlmIwXCh9uYcd1g7ZNctLcUWpoawsoK4LQTWhs+De4Iwr1k4jFlhnLgLTY0zUZDFjnaqLeE96klkD5xruJJnieB3cSQA2oRhZS7sXCspXugdUeFV3yncqRktbWLvJ+Wr996Q/LHt1K9aYF1nlNEjUbcjfDL/zymZ+VFycdc6tXhVeHxdybRuPNgUjU9I2gV3raVKoLKc3ZSn8Ksf/bhjRSaJez2CUsF0yAPp1555AqXz5uHtVyU+UXYCZRPrXINnQV7csUpK5/hTsWAfI3reo/edQWuDoxdY1u9UVY4Wxt/cefYV6I4REGBYJAWje9ajBoPWgsWIdWuiwnA/teoStRKAAMgVQJtb+i+A+bNGK0QKmUSmh/8BhgTjsQy+jdH0EDwTSjVwIt7nEfn8rWudYdBHr55lSQbO3kvzrMKMeJzHvRLXq54pBCzrvbAcg417hUbD70MgIKS4NwhBCjQd+i5aG2FFm2tQt7soHJahEyhkLJnmRAZA8m79ikllJ1vV5IxgTCJ5bf9WWTW3n6QN6yolc/pJ7pAWKlhDJMn3fgYF8GyRjrWkcEovZexqciw/jNaCVdPltPnx4lies7IlcDj9E4RJcxSKRbi0oOVM7d2MSdgz6zJ4XiQDDk5IRFaTU2uyFALX4HMXTnOTPYlLTEWvOv+odztWEKd/YmRDwFTOK072vptnUcL3gOI5mL5MDmas5HmOOeOcrWe9vKffzRvfndXVOC8EVdhBHWuYnEyZxQzuUl1KZ/RkEOBgVohEudwlibpuaMz6s3THCAisR6JHfdWA1Tn0AAWCGDR9bnMeG36Yu+hq/oD5EdkC00X7tDLl5H5NlGkGkQmB0QFdoH1gKRAtAvNC8ODkonPxSH4cB7mBIQEzkImF02jJ+l7cUSKRTg0k0beFyTOglNzB/L4luxzc3dQP4XcWtyoLJzvg+qaVFVEw5AoQ+QGDLXvB/Bv+BIoEl7XBdBY7WhzcX+7IVrIlbI7grBFAmQs7VtNXePPQFjm7IdOc8aFCi7baCKfGfDZMfcTaJPk9oErAdFluDp7MIxhK5/aXpN6PSdbIzrI9fJoUTfOWDy6ckJLZfSTMoZ5CsEaSPaq9Clgz3le8133qMLdnCczR/FAVwAeVkacKzmhBEADPluBagxMOM0Z2Y7IQiiHd00YtS5EKUy3mYFAez+SmJyCynTrs1XhmpSXXhDA+oCYSnAWTe1p54GB2jBnFqnCTieIeJheC34Bi4Tr2xOGsD0juRHf1TWpQ8eWOc7Je42bpjhEQaAUcLgPGLZriIkUz/RlpweGRgBhgUpSwozhwcSuT44BGQSQJDIZyDzriECA4yWVQBlp8UStjcTC9EFlYOvg9G6qTV1vCnB7gVD/4EDhSbXPAcHWMdzCSle5dWXFwQwoco1ruRjAgCGB8y4T4+c8aJoUA4rdxHxBU5FFgvdjQpEKd42sgF/4NvwSfh88EBkDyDWcAoncFloWC7vm09RBNEE78LZ3lRugFQeDZHAiNju/EMaX5k3vx2iVzBipcWs81Ik53NvfAquGuDa2JOTwTBBQ+UVxPOymdbk8FgcgeOjlRrpIxvB2FHZXIKD/BNBaEc3HUGxKKCKhEONZhGUzRVBdJG9RScke9JDFu9/FwVzSIoWEM9XWwIIjQoVcHrcppfVuoArwyMghOOHI5GM+EuQMJ/s9JlOu9DMfnqEBc2rtBkgbZm2qLrsanQ80bEsV/lu4YAdm8bCDPXw/q2oCbj5Bogvd99B3AkPhjcaYZSVKmWtjKbDIWDPVViGDhfWq77kZrI5RLH6CD0YAQEHwH/o2FUfA3S1AccfDOczwsE/3gqf0eV6G5R+FPZcnErFi/GrJh6QCFOf48szDEvjaZKNThbjK+pSYKFg3DIhhR62S0HwMO+N3WV/5Yfh+94xBmlGYw6mZvIBxgIE7bxRnxxwoTymbe/lthySaJ6WVyB+E9m8knl8+YNQwczwABGBalH0hAQhtH9qiqcMZRte0VJz/euzkPBMVhmseLYuS90+YA0Z9+/EG/U4X3geLJqF7NaT1RFLlqVi9J86nNItGs/vfKumVjGdTApJLsAc1o9beHTqA1/u6zj1mBfXFHsX53MHMll3avlkt71vG3INAVx4fiOeK9H1aIdzdD/um+tWTNolES6/WQhNtXk50x82TtkrGmbKizUS5Yt9Uv//kZWXeMgOxLXcYHh38BRoWWx6IgNwDmsjA1GJCVpI6m3RSvBbSvavU5wDQoHZ/fEhNCzCIiARmuWggmH58D/GLoFzH/jmaxoWkxkshyShSmlONYsx++/oLT33/95WdaOUBBYHqUo3z3+YeKr/fK1x+/T+cSvRdLW1el9UKnIQWviwnd4t8WnwmbiucCs+KZYU3Qn24RIDwjy0i6G6sV2q0atSUOswGhsxAjcyBQMc51reOKkFwsne3Fo8ygbFAUiHNYjheGc+4w8gjm9C57JvJQTYvzQsoTok+AUYRtrmUBklGtWbi5enYvhsBDu9oxaBLewxzndjAjkMdbAP6kDX6RpfXFU3uwjyd/9As8Ym7D8nGEh5jndb3CQghLwdjWktPHTrLVelj2E+F0y/6jWBGBGSg7CkkXs3dbQm/c0/Of6I4RkE1L+9M/YE8Awrx9HpWCCV2IMfEaNCOjWi5mcfC6RQMD0wJCgKHAeHgNCwyMi4XF3/RbHAxzQhjYoNTdwLYlL9iRcQHvLKP4b5bQKYheemwm7g/BATwHNhGTOXgGYxdbCjUFxKXM8exoqlYtz4jvI8gAqAjBwslPWSM7sK4Kx1RbCKUnZzZk05qUD6fi35h0WDShLbvwyhOcaIx4fePgNtkROZPFjAUTTRtyecIR3unD2kuRwluc8Xh+kynHgY+2JWQSoR0Yc/2yYYyiIfH43pkDrA5GZA2af9WM7vwODurE1Bv4e6tf9pRtIaOvSVwa+k0OZaxQIe6qQt6bsI/zw/yRFzPrw1YFF+NjMozfyU4KdW8jXO6reLE/THeMgGwOnkjNAM0E65De9wFZt7A/tTxi3ZgDBQfQtNuaUT2h9rUkuLPpPUcZOrA7R/iUhVYBm8D4+D98AbzPCBS0d2fjRGMTOE+rPd7D0dQ3HrJ9IwJuT+v/GDcN9VFgHoRzMf2ETidgjcKW5W0q8z7wB/cQ6aT+jYOtNQsPaweBZahYP4PBC0j6wWqhk+6PHP8AAtMi8YoxqOWnHl7as1ay1R/AAL04D0A0daS9q3Ksa0Xi/AAkACvMEcBBoqyrGt+NZ8tfU4clZhYv5/Ja3zN/41qAZDjlFkdII7xsOU0KQgqIh4EU757cKwmed0u4Y331U3C0t5uEON0vMS4NFD7WpvKAEsL+Yu0yRjmU/c7N0x0jIFtCp/OBUfQHmBFqj+y0LWuicid6yNGCGA5xiFEoE9i5blkJuw39DAhVzsiXGHaFdbAcRAPtjc9BaCAYsDD4Y4Fm+C38JgQEsX4cvIOK0Zsl+AaIlMFq4PqAeRDGvN4m8gJoB4GE9rNAKvgYWcNaUqDwecscKx4zx8gQNGVlazn+zRAGhWf1qaXOa1PJHvqU9ei0g5mBeo+IENlQU2MWcoyuy9lNBXK8IJrCeHpNqrx/5pC8f/awrvdEWb90tK7JFE41TOr7kuTpXqDsBcyOFoScES/KtjBz7ggEGOX4RZMd5cOLpzmEbn/ykqveQ/cjE7aO6NuvzNIa3N+l3Wskd3BzCg4Ia8rzSn75hX/ePLRNPnzlJOcEw4JZpl2i3+fsxmzz4H+C7hgBwTHNgBjAvAgRwiFHPRbPFexRg/i2eA4yxFd6ARBahTbBQLpV84bIsjbVFaLYydKXqtMaMRGHsGobY0VYEwXL09lodTApS0D0/xh4hx6F65v/awla/UDKIjmcFcR/w8LFONqyZ4Lnf3SoRdgHDWepJIbwQmAtVb2xHi1YBcB7cn6YGw7IhffBAOuWjr1qJM4fJXQLAtLhmVEdfSTPDKvA+Bw40skeVeTi7g08pjrdpzqHacNnCe3RhCFmWO8kv+aEeqhAgGBTW7cxymhntMH8KPykxVelBTL+S03J8qssRXOGMoCRNcj0q0Pgwrvacj7YlpBpUjJ3SNkERTvW0mFqCRQMQs0WQggeluj81lWS3acKj+TLn+pj0ENno1Swf8eLU6zfuVm6YwQEkZDw7jU5hCCxb0tlqqoclIZhDihth2bdEb2A1bEQIku8HLNjYS1Y/FcWLwdzgBEBm6DJAdkgBBAUaC98dtHzZqI5I0G6SRe2XSms+yNk7R/xrS2vKaZP8apF+AcfAlEfwC3Aw5XqVPK8dwx5c21Oxsd72FhLbgGCigmPUAorO1RVy2fOT4TQ/hnC+egIMYd3r8rI1aHMFXwd0AtFiXkjn2VJOwb7Yf4WaqoQLl7auuzoarfGUjTNhTN/47wekkQvFRx11Je3N4m7PXp90Ol1OSZ/4t3c+ttvHdku5zblUGmcLE1kGYtxwF+iMG1cMZJCD+Y/kBUuF3auIhTDZBSUsm8OMCdKIRBSOsNJsoY8Ka9sK1WodT/3CmsF+AoeYPi8E6J2DVmf9WfojhEQztbSTYPZRqgVjUEYTLAjahpLq1M9q1DrwP8wx52hD9z4JNDOYH5oueVtK1NAWG7Su4wRfZ9TzW7HYkFLdx+z3B2MJj9aEM+Iy80QLA0O4jleFEnMjdlaLF5sbyJS2ECWs3Q37bI46mFP0nJrkjHO2VQM8x66V2beABPn1ywaopalKRUCMup/hhB5O1Ecx1ZWHLJT3g9BvVRFK/n+2YMc7nY4N0pSfO+S/FHP8Dg15GDwWWhxJFNhIVPUIp1ak8nvoSwGrbtbyx2TdiNCt2bpNAdrw9QnKpgnSxKuOozVEiEEIZOPCTH0G71NqDtzaCueKRLn8yjX1JI8xODBPzvd5I4RkC/fuSzZY504NxaaIrP/vdRAaOBBTiNC8XL6CHuaVnNgppnnBAFgHgTJNtXoib0fM3VbHa4UO7L+Ctf0NlqnfCnLCr0Ojon7bwjQ4tVdazgLK8MbJe01JKBLY5PTKPNJDqQFSPHsvmYEp+dD8uax3ZLs20QyhzzNClVM+QBzQLMWTuqm0KeGvHFwc8WfMgz7vTmY5o+Q5fO4LqJMSDZaCIJ0vDBGjpckyZaAYayPgmBcj9m+++IzwaAEMOTJ1ZkUHjjVexIWyqs7rz064npkBmL/W94+vlvS+7VQOGfHs9mvR7A6CBFjL1GyslUFGPd2ZmMBzwmBYoxzayTrFg+ucLzDzdEdIyB7EhaY8gN/xNcb8zzw1D4PkvlZ6FeW9APT4XNB7ZAtt5VNQdN4BjesiYkemR5vRIPmPFGWR+hiYA3j5g6NCMvS+j3MwQAoi7CcYvRHCbDEov1g+QqnurOfHHOmEEzAGRqwAsiHoP8DcX1YmaKZvRmajvd5SIoVwqxVBxhHqaUPfpE1VRiEFu95n/oGDSTVvzkZojxxcvqELpLm/wCFumJ4tjwhhwPLUTzVUdIHPCF50/qy0DF/bAe+D2bdm7SQ6411Qyi8/Jn3ECwIAIaTAzYhd3EkL1JKXu4nOcOekQSfByXatRnhIwor/yjhFIBkD9POkDn4aX2OKy24FemjV0/QNymZ5cXzEktneapzX51zidfO780y94onJ98s3TEC8unr5yW4e2NGdSx5Dmh7VvB2qse6p5XtTcIN5hU+BttwuzeSnTELJNi+KZOLcOAhTNh4OJglcwbItrCpCl0GSfGkjvL2sV1knrdP7OcRCIhmIVt7ND9atqmW2h03X86sTbeaepBhxN/IKDiyAZoN2u/kqiT57K1LEuvagFaudLoDoy/5o1/k/3noZmdbKyP/v/bOA7rKMt33S0hAEFAR1LGNbXSOOgoIIpBAAgFCD4QuIEVRpCmODZAmvSUkQHoBAoQSqjRBCV0RLAiCZSwz4szVmTvtnjvLc+f43Pf3f/e3CQwiMnjWyZz9rJWV3fe3v+/p5f9QEwDVfmqjKF9LYMlns6o+URBXzdI73KD3KYGQdNVpAnLyfRBEphrt9pyDtHZX24Ku99gHe/9RuAF6WNzvZit5PllxGsw4u82dviHyyXjbWzhDDJ7V6x7L632HpbS52taN66VVaxBCsdK5Q6yPe3naUFvSI8o2Tuyt59gNktG+is+8JaG8GGAaUObbv5sQuvlJN8ua85uJMc9GwfkKKwB1WP/Nsrvf4guYveppsVJBtyq2f8mprVwXQuVGQA6uylOaVnPGTX0RD81GSnRGbFWNtm5NHe1rCjG+ZqDhna7eokx+0NcZELDx9S5RrDGhfgUreaGn8J9envKo5fRpYOtfGuJObi2bGnutLxw+4F0wagJYKILQwq7RAhDAFaDdPatXXVs3aahz7aK0iXVum+ucJqvgPutxy+7qcYFJSa98/mF737laa0YnWyoJg9aXakVbQGB7Zfe6S8H4rPjqakcJUrwzml8nRHethqPSnxBtH+7briIc+8+Z/MO1mJXgXtflFo/s2JpBpgb/AFhwZOtqy3Ou3uJB9wo0Ltu5nu/v3Kg06fKRLYUYwvvzul1u2+Y8aQU9alvREwlad4diKB7ZQucmv2sV25byvC3qc5PtXzTVdmZNsVUuDtyaOkbXhvPGKmrwf//9jz5I5v2M+JbtIYNAZEnrcLOuEdad9+f2qaN6DVbgcEmWvbFigYL4JYMfsK3uuJYMbqhZegqX2X0ban4fT4ACKtdc8zmtrnJW+MIR38uNgOwuTPUIfg199TQY7RQjtOR+BTu4Ot+DlzXymaqgfTzolp38gEcEGX2PB5tGmDihWX1ihMoegCcES1n4bPxbtZ+0udYKH20q6KGiITGW3rqyYyw6bStJ442rG6VxW74/re01Whgzq8U1fkjrAX8can9wjF/Y/z4tFqVdnKEj6gbsvVg9pr+BNStXMMY3QUoBYCUbemHnt3EbywkC5MYpQyy3o2OIJr4FB+HdUzjH0pLu8JkqF5v94fOPPWi4I9pOvjh62D4+sMMOOJeIDbbFz/TSmugvjr7lvq+imB8MX5DuWT6KReLYGa76xjFrZlItndNpsZdbarubXJxU33bmzFTdSanqZtdrnoXbKDPqSPM63iFgNzqxM9pfKhxhBJd5lD/85lN5AMH34M4FW7m2zRmu60qrCoBwasJ05wFw7yXdK1jh4FZq9cdd5bohFEHGkjQ0lgggi0BAfyiVGwH51cFSZZYUK8RwsWLU879t3mghfWR2udreWJWrYR6YSBfqwQqWnnSbTWlSQ+AKkxv6lKrmwtFwIS0DQ3KCsUowMt+D9qYwJ7hQKvBNKro4ooJAHNg0RZUdoQMlEUbOTwJppYouHoE/jE0ME0wWKhiHgQfH277Fcyyzt2Oq7CmW5Y67sN8dtvixpuE5eJgPRmCbr/rHWtI3dokslNbREWORok68QRA3pKNhRGbFi59soQo5jXto8AXd69mKkc2tsO8dTgjes/kd/KrprH5xSlrQHcDxs2WKAJeZfyr8auehLSf5Dkvvcqdv6oyNsuKnXDzVs65+NwqF9/J5U5tdE866UeshIaH6SHyUnkd4JzXwjwGezcoLdrMv6l7F1o4faLObV7XpTWtY0bBEZ5F/YVMaVfDJkp71FWyntKxhiwfHKJZk2c/ugtnOhc2y7Ieb6hgCxBqBRjTyCo6RATqxlw4Go/f05annS+VGQEAVRINy0mgbQUBIv7Kbe8Uvu9vexSmC3MdCcMLE4PWiwz1Zme0r2ZzmNeSjUikPoHe4oDA1aCQIyUTndgVtKb5r2Mc0mjp0371lzjN2aE2OrALCE+zfQGPx2ILEKM2Zcwy8XrMn8f5zuIg7sybb/OR7wo1+uI3L3AXcnT9NO0mYSVc7SsLV6gouGtFJXckI9aT6tJ1E6TvF/HQmYxkbVVF8ldPtJ2rPoN188fCOspK4ht6Nqii0EtxHkPBJcjDPon4wXFX32pwBCVIsHLO6fkNZQLW+N/MWW0mE1t6FRaEE05kgQ0q4nSJaPeYhZ1Xusc2znlK7SdFjDaXNdd06+3OV0+Vybahd1L2a7Vs0zcUKKVKCxBVMD+Ieql29mQf4LnJuFRVzhsaWPV7PWcIv1JS5ZHgHCSMbvsAPmFC3QnhvCMc+qWE15waempb8oVRuBOSI8/XBpw3iCsw5Jp6Tx8lUK3oPH5hTZ5iZcIPWCsyMq+oszE9tfrvq/qTFe+HBTeE+jMFILCcVRg6KdPwPWucD4eB7lzhfnPVkuE5BTEJLCu9X2z3I8s2ry63AbaNSLl+YAqD7f3jtIivNnmQZSdeqwLZp6qBwrv9r5wpRLYeJDq4mEfB3e23hOB0rDIvFEqM19L8Za4i2TEusJuFD8+Z1r62sEf1HuGsUOYnfAHKjZ42FmXQE0B9GwiEAkEAw5rS51bmIUQKMUJ9ajGdm9ohg3eikLhjUVDMfFA5JJHBeQITclvKMZfa8T4qKWgrMTEGQlQTb0160uS2qaDfixmkjVPEu7H2Nix/e0+w7Y7dLelS0kmc7KM3763f2aRqxqP+tdmBpiu2YP9Z+fcQDLwSpbgFB/Od/2oZJA1Uo3jBtlIHezzXCsopPunnhTu90e1lW+kFUbgSEE/LWhiUG5hLak3iE/YL450HbCBcUEw6j0pIxo8X1QkIBNX2DC5inxUSLYdF8tI6rbTzeazb+czLRpjwHJI/ApuufEhDQFtkUhUDgfvG6SQ2ilCrmmDQM1SRKLRlqY3/AB/m8lmPiPqsGDpXk2OrRD3lYn6kj7eP9W9XjxMz5vA63Wkq7n4brESwCgnmVaGjo4xG+R7f57z6TzBYMjd9PGz0WAFRErAtCOatpRb0ft3LdpMfC2Z+j21c5gagoJREkNlSkpOnTBbxqc3G/Y2qTyrKygIXjqhzZusxWPRVnhY+3UasKjLkg+S4XO7iAfHQnffYx99npbT0KDcuH1rzQSeubyfQRoJetbFPrQBCnx1RWIRhCUFSw/Jb98/9hR7cV29sbFtmu7IlOoKbbkkF11F3BCjgUSnrnO6QsfBdvtOZ6WK0NT4BUea5V1OeiciMgEDvv2CM+u2VtBeESlI6eOQgs82gqDFmAAJyBC04/EaDLuFsTQ5ks3ALer7Rwm1DRsJmPKbioCByvDybzYHDQUnI7hFwqvg9t7hgUpuTi+NaUCpbitCX+OQLHcY2+23+PLlYrv6OEiypQh7grBNlJcJ3zcKxPCLSItqXD2jlGmOEu7t2h+fZTgSefKw3fJDTgRe2HTFvI+hCf8DifH/Rt8YfVS+90sy0eWEdM+dc/fCVsMX4n3ytLF+/cw5aVbfz9lXScfG7+I/G2pP9tdmDJdO2jL3o8Vl22bBDL6lxb1mxGM5oLKXi+pGu1b9Esy+pwiQvym8tKoPWVli5Tm8Ea/J8/fK0O3qlNKukc7ymYGX4+IEaJM9tVUEo6gHPCeq8f20kNjkWD7rSs5OskxFx/rAiKbUHvmPD1/fTQqbV/P4TKlYCQ8Vn86APqH4K5Yc6A8dRKgkbHh6/v73PRNY3XuKosA8Fnepd75cMzLMVjNDQGfj/vAU8XAUNA0Lp8Nn8wGvcRBFmdB/z7EULiCWIYmFIMHu+tGt/D5xKb8BlBfxDmX8mAGLS9L2CyAGjz7NF+EKyZL2AGTXeBK8Xj4+pVkjDz+RqRbewFOjgWvj8YCSDeGstw2D2nZt9x12CYrO4/s9L8ObJEfC7nDqvMsWGx5Ha194/nP5KgdpK//fUvQoin2ZARWohuBgag0tterpiBBaK4VygzRmDXjO1rOzMnOQuZZWtHd5UwBHRgyUxb1Ptayx3Q3McxraLsxK6X9RzfR6cABVTmQAJhRwA2TBpg6yY+apnJNziBnCqU+OJRSZbe4WoDy3dWyxssq3cd5/a9oGwctxHQC6FyIyD440ufaCqTj0aV++Buz4yrLiHhBOIXw5w+gxS68M1CWiXZu1YE4ggQzCnGCrlC3CdbxX9h2iIcTXzMAtMFLea4Y3JpmnrLghDA+DyOjw7UJQIGo/E9CKKsTJxndFw8LjTMi/sDg2d1qW1f/eqEJv4WDbzfsvvWV3qZbBrHx38+SynLHvdZRo+79fv5bQgFn5/Rs74teqKtZfSqL4GUe9cQq3fKLUOwWAKqtprkSyxvUAt3fBVkJXAFSTqkda6jczetcWW5gL5n7BIrzfINiExIspQTFwiXkD9aOdj0ldoiygq6+voMtHnqAFlSRnPnt6+p28RfAW2ZMVhTgJumDhYayf7F08LP7S2Y5uKSCgrY9bou/rdwDo6XblLDJUI1t2UN/c/vdaMVj2gmXljxdJKW7uBm8lxB75vCn/tDqdwICIHl7OaXitnFXDCOu+ivZkzRxFhKu5sso9PVyiChTX3az7s/BGswsvz1Fl5TojkDjYSLoB0eaLEEz4y4LUEnLVZIQXbIQnGhxbyxnvnk5jlfniQC7+f1WBOsE4E6jClomiahGEeujHeJAEBjyi4gAk8WnwKtw4oAvgsm5XOxAhmdatq68QMl7OpUbeZb1tM63+3ctSu1YGZGjH+fsnVsgOrHtl/PXPxGVk9Pc/4+M+0TG0Tr+Ehb48bQLo6AvQQuVyyf5QEnKMr95sgbYRfpw71bLK3tVZbb6/ZQjeFbe2XOcFs/rlu45vL68lRbOvB225k1UdtxFz0Wp46IgL7597/YyWOHfTsIA1Hufb/78KiuNfPz+b2utzeWzdbrhKbfupZWKryxKs/md7zWZjavJVjXrbNH2PuvrhbOb3C9U1pU1nGjgFY/57eQXQiVGwGBaVjFPNsF3fjl7OhbmHyzFfS50wWba+RPb5n5hGO8aBXIdNEbe0aGGcfVrRRO28JsuCiqtsb7Xe4wP+/BNaFTFsaHmWH0YAqQ9/LHLvAACxhBQ1BxR7AsxAhBm7xGY7Fe3TwDEhsIHzgety7aUtpcb3MSrhCAgcgxyb6CKSokfv72ASvNmWz5gxMsp29dn9+PqebjkdY/0ffjCvFdgOJxG8sQDIAFM/lpSbdpBh2BKhjY0LJ73ClwOwRGbhgBbkt/rKvHPqK1arrfyVtU3qeCn/P/qUozY+4bBf2a6cweP1fdhaQCxUaGm8Lbdt3voTsA4fF3/X+C9MOrF9onb+6UJdJz7j3MtJOOpqUfIU9re619sGerAnq6iddPGCAB212Q4kep3XGRtWNwCmIUF0U2symokVcq3uN1BWX2Of5QKjcC8uUHRywnqbIC5QVtogSOtnRovNykXVkv+PkLFxRSUceNkKtUP5Tmc4IxtelV0vQU7VSN7+41Ku3yC10wh1uG+wNDw8AE6wS2ASOpaJboGZ1tSgjAWFpBWvrPCwpUxDBYCqwTxyBAgWY+tUz268U6vg0Cxub7eO+RbSX6jWFggm4VtIsdOrK5yNLb1AhXpflPsZAMUyAMKAKlexN8ihvLN65ecBweTFsxyoNVDMxc6iYS+FiPgB8AQYAtvPiJRP974rxLgytJVgyFgRv56eG9Oq69TpAF+xpXw151MQZt5hTmGHl9a11BcNnOSlTGAaCb37aalMHvPnxPQrV2TBfLbE9B158X5slfnjLA9i9fqHO/sE1FCei+ovmKo7h+q0YlCDmRVdbLhsUr1S+AvDh/3TknWb1/ceYhnDeVGwH5y9dfCsVb8x4tfBC7acaTdnBlpuagyevvyZtieQNjxRQE5PLZ23pGocAG7hWPc/GDFGnegBibHHu1XrOwtRcqCUYoOxYE00Edg8ewPmVjCFwcGEy+Pt/1gI+RaJkIXCveF3QegxwiLZ/gNThgzQH99sQ76kuiX+nEznW2clQbCfNUsH2bR4lRsB4+fnKWA8FtU0Hf71FZKsiNIn6C+YNWf5gFUAhlf8Y/ZIsecbFOp4r2/N2hwJzCpVM+h9YuthlNo+Vi8ht4Dk1NfIfAbJg8zEqd///xG7u9xaT950F/XCgSFMzWmUNPy1aVJQL4JUPidB5SE8DWOqUMPj6wzdLaXytlo9jKCcnWuc/azuyX5AZn9qwjN6w0d5Z+c2po5JgAPLfXLXqfkiohN3bMPRV07IxLXyiVGwFhD6FPh0ZZVvc7nImvI7frTFo/9SmfRWrihQEhgElgZlXU21XUxqRg/gNti2ZHY3GfWgIaGcHiP5oWwZnepKKsgq+qh3ayt/BMRAtIetuaep7vQMi4jYDCuKq9xHth4n08RmGRi5nX994wLA9ZOra6vr5sni0bmeiYIMpmNK+tiw3K4srn+7i/h6zAuV1K8za/ylY819tmt6olwDyEruCxRMvp96B3uVr6x7AmxDHcZt780JpcWzc22bKTqhuTihwPM/PpHf3eQwLxknGDZTmUvJBL6Ji20WUKtnEZS11c8c7LRbZl7jMuDpygzxATtw25PV97t+dM+uvvvzI2FaNgdiycIGVAwyVEQE6clRLvpzkBBPxg71bbBsKKez1QQSVj+poWKfWPt3e3FHs37ptvrPDhe4QYnz/gQV1rWlK47sSFJWP7nnEU50/lRkCg7SlPupPYQ8Wqv/+/U+3mZWln1ktixEA7k+aEyWa0cIzW6hpLbX+TtOLkByup0zW19eU+V57oNc+UJpdJe8FwXJTAfUlpzaCWb8CDKYqeiJeW1vtaXGdLn+qh9yOYMKO0Wch6oMGDmERCExI8BKc0e5r2Yrz/2kab2+5n0vCkKtnvwXEihAibdgc2dy5k+xut+JneEvysrjeoSRCGhfl576tpT9sXR9+0jN4NBOKd1rqS2mOWDE20oiGxVtirlv3qwCuKGz7av0MI7/yGFOca7Ug5BUhBoMzah4yuN1t2t5+EmzfntL5BqJOfvrlLizhZg/DqwomyTvPb1bCCvnfZhheTTgFGU/E+w5owPLa7YGY4/giICcctzvoc3b7aCgfeL0u7c8EzEqA31+RrcCz34SZaI7fsqeTTJh+xIiQLDq9fomugJEhCaHlrt/8BsD/nQ/ixpAu5kFgFBAU3AE2ChSAApMsWrf+S05ipbW9Q4RGIGxrpAsEKJgvJ5lCQROuj8bkP85KORIPihqglPZRS1qwJMUkjDzWEVp3mXB4uKJ9HkVGZJ4Jf4px63p2jvUOrD9xr5rS62la6YBPB4DMRKF3wOD6L7bT+dyH8r6Q8q+zO2nH9bP1Lg22uC95358+2ZUMa2qJuUc4FfUopV5bMpLWKdkH/NFndvzuNu3xYrOX2uMHmJl6v30uTIFOLZQm3Fcaj5sF3K3nRtKoQRzJ7N/QF0e7EMjVCHcDRtn9JmlLyEBm5l1/q79y5hkqiQATcq0a1tjWjuwtq9Ltol3OXibneLMlT8E/2LqPzDbb48TgdL9V79iiWpTeK5wuWlP0vmb3ruljxUglKevurw4H8D6V/OQHJ719PAgLjanuUY7K0trWscFBjd1E6W1ri5WEmxSUofvZhxzwVZUXQ8ggD74ExlSaO8wIAkzJD8cbKHLVpr362o2/Og8FDr+M1pEp3509Xyhn/d+IDoYC4ic9gIRSBXz/xfo9YgqDJEjnfv3BQQ+dSPCtc26A9BeEidQxi+8L21ZW14lipVbAkhtaKWc1r6vtzOrKK4HKlclmYA0Rq0DCJy5LX/Rp7Z9NyTd6RecOFCqBOS8b2O/OUikiAZLTxXb9B2hnGKxzc3Iqf7my78uf4+RBnIYtH+ZQqWamP9m11j1eUW/z6iizbv2iGsxAj9Fvzu11hfzzpGysDgSpLq55uIwtCDYQ9KAvbRltGx+r2StqLBiA3imvxo/VPgydlRQPXXgj2I1rpNoqK95UtUP4Q+pcSEGjF0538lil3wec29xcV3NzAnK/4ZUeb1cy7OJw8Au40pxEXdvmp0b8F8xb0/ZktdyacGWsYm3Qpr50ZW0kXhMwSew95fFrTKr4S7/7SOt9l6Z1+KvcEDKmsbrdIKFS0e9B/p6r1dbxQBa0RMB0ZIhX2yLy0utQWD7rPa0oSBqF2idz+TSy9zRVO6Pxaa6wj2RolDpr4z0e42Q3CUFhQPyEugIHnJVaXhsXVVHculqlldX0WDAf859kI1EMCagaSlg53rtpA50ZNftS5NH6ikdHb1S42ID4K4sIvT/is48J2lWzf4lQrfjJRAi+4pn53O6bfoS7egh5XaR/JmUTATjfzr53bBf3mvYO2b8lcWzemiy0e1kkdCNlJHto0ICzeVvavTx9q+4vm2PLBd2l93Zcn/gesYDtf2uhMOpqxZEwfK3w0VlYgp2+D8PM7M16Qu8HjMAlWYNvsYWpmy+59r1wOeow+PvCq0qAwFw2Kqa2v0MoviH0ZSvt2rKkVZHSqenA5j4TOZlcWvNCHhDtEypiMDEIQuGwICsyNcMHYMHAQC2ExQHFHKHDT1FbT8FTADGPLPWvm6y9BwTPouUKTEzfJTWzgP58FN585d4z9fouHdZQg8vz85HsNPKp5bWrZe9tW2fs7SsR0TOqh2VEI725ZaRntKguFnR4sMlHfRwTpK4bH2sbxyaqUF3R2Lm27661wQB1Bn0JbZw3RAk56vM6kXx3Ybnm9btNQV0AE8biiaa2rWnafBnaoJOM0ZEeGwOi0BuP32PaS8zrO76N/OQFZP+FhMc1rC8fY31ww/5E7aQF8JUTGiLnx7fMnOI2UovZv0DsgmAHheGPpbPvsrX2WnnSHzPTaF/toDpuuUuhPv/3cDq7Ktlczp4XqKX4gCAYm+J/SqIqYOEjtwtT0Q8HsCEggELgQzNHjxxPfUHNAcHktTM77EaDx93vG5zsQqqCTADeSdLcaNZN8QkL9Xw2rOMtWXUKs43LHkt0pWnP20P/985+MdQbEVdRplOVreom6o3H55Ip1rqyd5HTMFnatZCuf7nhWUOmzEcrm1bRRWptNIF2aMdoW9bzCipyCKehZy10bv8mW4JvK+dn6pDZOfkzHBTJjQF8cfUNTjTy+cVxymVd72rFgnK4BANpgEl8M+pcTEE76F8cOn/WkQxsn9VPBaeucs68G3ji+hy3vDZNU1/CUguSm1U7DxWJ3HzhOBMSkTan64oLhzmBJcKfUO0UmK+RWkTRQ8a21Z1gBSsRe4guSzbwLl9K6llo7uMgI0dy2N9nYOhUk8FgCXCoEAs2PcGFV5AKGioMIgyb/Yk7VMHic5sWtc0aFj5/fkpZ0lw/8SWn3aRKGP4L5mJ0p7FVb4NZvrctTm3ppxvmD1AVFW0Dz5AJ9+62aDw84tyfbPZ7f99+0k/1cBF7XkmFtnPUqOu1xADXeLMk9bXV12efICh57bd2ZT10wlS8B0WzAKbP5+19//L0n+kwqGd1bfjCm/mx0bMdqLbZf2LOBpbevLUYkNlg/YZDtyZuhlu1FjyV4lMNGnuGJc2DirG63WV6fn9uCbrgtbFGq6Jkdhm3tmZ77ZKDQ9D5e8O5SakJFtVWkxEdL8xMEs96NtDMgBFim3D732qL+d9u8pJ/reylIau7B3WclGQyvps3W/nG/+iHKNk0bEsaG+vNXJ+34q6utZPzgcBJiYa8YdUjPdPdT298sfCwsZkDcPhOkuiyRjfLg2T6dSwvJwm53aed52VQu1271M22lgJYNTwhfO/aeE1uAnvjfjcqNgHDyt6eMcpquiqAmGaxhbDO/982Oac8fGOyD3Rtt2RNNtBTmbHRsxwY/BNQ8yiY2rCntr07SUMC73wWK9G6pnaOOz3blPHSPbUt9XlqNTNreJWkhSB9nFVqwkdUzqrR6vK8noK2VSWvltTzQRWBZpbtAOqtDtILhFUPrSWjIBGE5jmxbrc+nepybfEU4/ctW2M/ffd0WdrjSUhIulYBRIMM6pLaMtpPvnwpSN0952Jb2rGizE2/S+xFcWjNwuWS14irYkS3FquKDXvh9hODQtZvbrZZj9NdUo3qpYSWlo2H6Uy/8VnHN3kVzbEG7K/w+kwXeKm0c3zNc8zhfAoZpTvPL7a2Np1uYi03lRkCID3Ifuks1hS2zRkn7AGtZPLRBuHv0YhApxfzuV9mSwQ1szYt9xZi4QKpcN6uszUeAv9HfQyJgj7vgZeExoXc3FYf7rObERVvxE3U1r6DBrPr+D+ZFw6u67Rh0wxSfQQLEmQD/WwJk5wr94YvPBC6X3ra6QNLWj+tpx0s3Wmbv+2V9YHJSn2tG99CsOfsPFah39q4dz7PLMKCDK+fbiiH32p7CWTYjtFcdASFBMK9llC9UtqpkC8HIeq63FMK5cG0ZegIjK69LtDZEgU81r9OdEtxZsVHaxw69/9rL7jVRNi/xcpvfJlowRZ+H9qSfPHbQBewj7Pef/2NnxJnEOTl57C2tbkOoXp78j5hbGsf9jlaXH0rlSkDA5CWgpSCkx/7jG7VnAFYWfp17jBjkQlEsIAJLNPX+orli6nkdrreSsX1OS0eGO1bPQqXZU31qlV6lzlG2de7ztuq5bnJ7KBbSkk1tBctBzEIcktmznq0dnSz826IhTR3zVrP5nW+zjE7XKLZY0L6GFT1yn7Jk6Z1uU5COFsZNA22ERIAWgdb3cQ8MD5OSZmaFdVniXBKjMVlIe8aCdtUsu/uNajLckfasMMII2gV+EF/B3lyVqfd9l5uFgiC9C3wPk3sf7tthqa1q6LtLRj+k7NgxJyj53WtJ0BHs9ZMe/8HrmYE+XfxoQ+18mVS/ok24v6I6ucsSriQA3KufTfqnURWhciMg0MEVaY6JOroTvloCwEXO6X6DZXeqqjYEiBXDjK+eTbP8UALulIu85rn24cdo1f7dR8fCJx8f+0TpOntz5QIdD/46hSksT7BfRBko2k1a+myTUr/3R6lFBQ0P0+N6ESCrA5m+qcY++6XKeSMfsxQ+1kq7T2a3ukWDX/whFIIViqdNpppz1Wp6d5DGwWY+Tlo/aUiYuT3u7W1OyaQrjYvbk9Hjfst/pEWYYcnWkaLO6HSVLRvZTkqo7PvORiePv6NWE6wmMzAprao6Rq7klMvNUhYbpwx1FmaD7StaoGPCwrFn/XwJd29abHU1gAatO7iE72xacdrrcCdzOkY7YbxSRch/lsqVgHBBN818SgyT4YJoUnmLB9V1wWyUGtoOFqc6t6ifFfSoabsynz/z7T+Yju5Y66vtIxN0HyZb+VxPv2ph7pMK2JcNjRPz5yZF2bSmtWz50z0tNfEaCQWxDAzPhSTzpCA61ATJfdwrOmRxGzV9WNdnwNDcBNAeRshnvFRUbOYr8BwTw1gE5AT9PK4Kdyvf6csOxiAVjJBpQ+3TidogtStnkk+Tjvdp0m0pz4Urzr/98Gj4t+OilI1BNkwYZGnNwec9+/ARKeTpTSr50V6yZ60u05q3FaPa61hw9zRy3Cha6W6EZtlTnWRxQIEvC+UKUXw8uCLVPj7gpxM593n9G4ZxBtSd0BjwvI2nvQ86vutlJQouBpUrATl5/F1BiKJF0Mx5vW5U/AEoNBqJlm0eQ7tfDB/0mNN4OZ0q2vKhD+o+F7Hg0Ti5RZun9g9rq/lta9jMuBrhrmGlcxN92lU1D1pYYv193CqeRyAQBs1aN/KVcv4jNOolq++ZlvgEYUDgsDbcV30k1LYf9Iwt7H6PrXNMvPK5ZC3IWTdhgM1J/El4yItzxkgqeFKH1hYqloKObFmpOk5enzu/0yX58r3DmtTEKpaMGXjm02HasyjFt+jEVVWql3iBnY6fHNqr5aW4fexUx9onivsAAArTSURBVG3DYgbA4bmdo7V3/kvnBQSdza+vyPYINR2u030EZMWoNr51H5eztT9372w+3YJcbCpXAgI6RtHQBMsfFGsrf9nRDq325n7nguft5UkPKWsSPHaxiFnrsnD/3P74YKnfsefoxO7NTluVWu7AeDF/MIqrBsY2tzuGj5KAUIuglQXm5sJSu0Crcp+5dQXJLbwlgOl5Dmbj89CaCI8+I8bXPoAXmgG4dn0vgHNaXKFNTAG9s7HQ0hMvC9dEYCxWAqx5Pin8GmjjtFH6Tma6v4t++/FxJ2y19TlbZj115tOn0VsbFgvdvixRVZ8RX0vWLbdvHXft2us2SmRms0sVmwB/RBC/9HGvjPYUzgtBzFbSfZ8MSPCF0YQKyjKuHhVnf/36d2W/6qJTuRIQ6GJmKC4mrZ34iIJwuUkNfVzAnxi9RYixG3vhYDnO1CZ++QuWgD+GnXCJsCoE3wSgaErmxpkflzWiStzWu1UIDMAOaFLiE+owu7I95A60afLDHlaosbdWzNIwh1E8rJH99sTbtn5sFwFpb501VEHvzu+JB77+9CM7sGTBmQ+fFxGfINC4hjk9blbWC0YHQpT1FAvaXWnj6viMWvGIeL3nq0+Ou9stbGeGr7pDJANeX5HpBKui5nOye9+jhMyPSeVOQP670opRbU+bYIT56SbmNqnTWc2ibfnINtr+Oq9tbXe/smIUrANZHV6HC6XNVu7/hAZV1ZaClsWiYGEQNlriqb9goQQnFOsDXoqGu/JOrQtgR3tWz7uUClX3bK+b7Oj2Eq0tA7YVl2vdmA7K2AVIixeD+CzmW8oSyYvCx+JkKed3udUOFGfq+FMSr1RHA5aRuIyECCsVvo9KnBXUtGT305XCj0ERAfmnyMNfMl+xZsIQX0Og6EdATiDZ1FsO795UtK8/+cA2TB6iIJVYBY2KVSEbBf4uANW8FouD64VFQTg0ytrMWybFJ/f75wjYEUq+T+7PjMfCR0Z1O63Djb4w2YeExkbbuXCsj0WGNbEdac/YF++dcskuBiEcOV1qSBiD3SXgWsHEHDfTnAWDGtnbzg1bP667HS5ZoC5gjRjERVvRo3XOq6Xl5LE3bWb8VTp3QNL+mBQRkAsk3LzSzDGCvQHETH5xy+q2dGQHP0XomDojqbZl9m5kk0JwQDldgaqpKetC5gvfH/eIAJzXk70iNuF/AJQA8wQp22kx3qqQ2hUiCwLoXjNLFudS+2i/z/hAZPwWJt+ueKjgkWbOWiTbtrmjbHb8pS4gXlXml1w8AtGksO/ttmJ4o3DxdNOUfhLKrO632ernu1l2xyjL7lLd/vjlr/U8K6nz+tWx1+Y/oz2HrxfNEKTQuehvf/mzzWtVXedv+7x/Plt5LooIyAUSI79Fg+vLjZoRV1NujjC5ml8pzYYFmNq4chitUBOCcaGOX+dWTW50mSyDMldlBEEuF0F8Xf8e6hu4YqPvDq1GiPPuCJaDWIXPw42iGn54zal9fszwB9k9dRV3p9+rkj6j7OsuNuGqlW3s5LtWDW8glMRfvblLk4DzWlc9rYcuWGX9xspcHV9ezxu/N87cvzTVCgY3V6zyY1JEQC6QEBBgUOc7/35K40pibirkiiNifK4ebc8cxYKk6wVW/VLDS6X5CawBqKYNRTjABO+khVt5gSHekIVAyBp6a6J9JCFLwusBW5jfrY4t7FnXZjh3g4U5zEOUpXUTB+rzpjSuYit+2UVg1aXZ48+6hPPHpEAAaFZ8ffk8x9xzNXTmh6u8mwqB0rjqmfZajrPy6fbhOgzWkOlE1uNRmPWjvH0tr2vN06zmj0ERAbkAIug8XJJhOb3vtVUjG2lmIvvhOL9CIY6YwK8C09Rfx9ttbuurXdxQSa4XjI8AZD7UwGbFVVNwzV+A/IhAEDcgBILbae0FRXMO7XyVOpgwfC1zov3uwyNW8uJAVdxZxFOWXl34YhghEsSSk8cOnfb8hdCxV4rtwJLZAoT748nPbF/BJDu2Y224yxrmDW5/eqhUvVwAVJel3TkvKYW79oUkzYqwMBWERYiMVzaV8B5XhefIeYyVc/NaVLDcPvfbkS3LhT2Q27mSmip/TIoIyAUQu/ywDrldqmmumvpDWuIVih8IRqc0ulQVYwSEKjLMH64wO2adHlMxHLzzR+cvATivJ9hWiz2Bfqg4iLDxOIJE3BEE8OPrRllOj1vkauV0v1EAemVp04wRei0Cx/GeKUDnIuKBz9/af9p4AQxLsiE/Ocq2zn7aVj6TLCxi8Ln2LkrVKjkGnOa2vMpemTPS5neopU7o5aO62pur8+zP/+tLfe6a8YO8y+kUR2byTSq8LhvRTr1oO+Y9bcdLX7bP3vYAdRCWhZl7sl3q4xrTUXUouqe/qz/sYlFEQC6AwIrdPneY7c2fqL6l/csy5PoEU4XMjr+S9oL2XdDGzmNYAoHLxUbb2vGPWnafenKvEAye5zkGtCbU9wIgbK1GpEKvUVZLKWEX7LMGbkYsi3G8YKW2vc5WPdlEgHO0lAf0ycHdgvRR2pmYxQnwmQJUlhAEFtrQHUDDH0W5vC6V7L1tK5SJomOBVQPEXCAw8h/gNmIfrNkUF2+tnzxctReYGGYGwI94g+/n+HMejrHCAfeFB7vI8nEOgmEtLGNecnX7+tMP7H//5lMxPwLFLsYAaCOj513KYp2NiH/AAiCreLEoIiAXiTbPftJmt6guzciMiiYTnXZN63CdMGIZaFK6NxSnZHa+Wu0kCI56pkItGjABlkT/W/hNU7OaRvtqeUJNy0i+2T7c94rQCecnVraMDjW0ffZMOl662djLqGNI8IIWQO+cSTBhTr8HPM7vAzQaXmnz2l1nhQ9db69lvKTettXPtrc9uROFq/VK6i9txfDGNjfhMh07vwEGz+37Cx07yiKYcMQt4ncQX02P8TtEQB1ZOay+rXcxUtGgf3OPVwjN4V9imd1useUjEmxBYgXbnv6iFfa9VYiauKcI3cYJ3c88/DBxfABFpHf5uf0pwDv+JykiIBeRCH5Lsydoi9KHezfb5sm9nPv1un39+Ud2Ys9WX81u4VtRuNhg7KLhmTwseKyVQNNgjCXDWlta25rOffqp4GoyOlzu3JpKNr9NFSvoWkn4uLSsgy8lP7x0/ZmHIjq0Jlv4V6kdbrWlT8SE22POpC+Pv2uzmlWynPa+SEn6dPnIRM12nNi1WanZFSNi9dqgX4skxcZJfS29w08sp2ttKx7eTIH0mufaWWqr6k7YwQGuoL0hxcMa22+OHnLxyGxb3P8Oe3tDYdg1Orp93SngvhifbZubUE2PFT/dzbI7X+Fcw1ts8/TH5TKyFvq76JW5I+Supbby5+hiUERA/gsJgILjuzfbccd0wGbSRs5aOeA1yfRoLbITJpifDE7AjABJnNi9Kfw/oG/ww7/45Hv9cNKuZfGjzkYfHdhupblT7ZV5z9mm6UPts7dObWTiOM82lEYqFiHSzsBQporHSDEzjsBvAcGx7HefeRz85p0Z463UBe50G+/Jm6yV2CAp4ur9+asvhb18PsRnMYEZLOG5GBQRkAhF6BwUEZAIRegcFBGQCEXoHBQRkAhF6BwUEZAIRegcFBGQCEXoHBQRkAhF6BwUEZAIRegcFBGQCEXoHBQRkAhF6BwUEZAIRegcFBGQCEXoHBQRkAhF6BwUEZAIRegcFBGQCEXoHBQRkAhF6Bz0/wEyrJ+mfHqlewAAAABJRU5ErkJggg==' width='200' height='133' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=3d95a6aa9fa34243822138c7a9efc6b6' target='_blank'><b>Enriched_CrimeAnalysisData___Violent_Crime_2014</b>\n",
+       "                        </a>\n",
+       "                        <br/>Feature layer generated from Enrich layer<img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by api_data_owner\n",
+       "                        <br/>Last Modified: June 19, 2021\n",
+       "                        <br/>0 comments, 21 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"Enriched_CrimeAnalysisData___Violent_Crime_2014\" type:Feature Layer Collection owner:api_data_owner>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fs_id = '3d95a6aa9fa34243822138c7a9efc6b6'\n",
+    "fs_item = gis.content.get(fs_id)\n",
+    "fs_item"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a2f7ec7f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>resource</th>\n",
+       "      <th>created</th>\n",
+       "      <th>size</th>\n",
+       "      <th>access</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>jobs/jf0e25a4606364e6992c440cf955b6e15.json</td>\n",
+       "      <td>1624159076000</td>\n",
+       "      <td>7741</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                      resource        created  size   access\n",
+       "0  jobs/jf0e25a4606364e6992c440cf955b6e15.json  1624159076000  7741  inherit"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.DataFrame(fs_item.resources.list())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad7c63ce",
+   "metadata": {},
+   "source": [
+    "As we can see, this `Feature Layer Collection` has only one resource file available - a single `json` file.\n",
+    "\n",
+    "It is also possible for an `Item` to have no resource files, as we'll see when querying the `Web Map` object below. In this case, the `list()` method will return an empty list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e1fccf62",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=a3e8eda445c34e95bdef7aa75bdd8a77' target='_blank'>\n",
+       "                        <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAACFCAYAAAAenrcsAACAAElEQVR4Xqy8dXQcCZrlWzuws2/enp1+O92F7Sq7yOUyu8zMshiSWcxgWzIzM8pixlQyKFPKFDOzZaayy+Wi7uru6a7ZnenZuXsj3bvv7Xtndueds398J5SgjMiI7/fdeyNCemPVOiXWbpJhzSYJFi8Pw7wl4ZizWIbPv5Bg3jIRFq6S4Is1MixbL8fqLSpExURhuu0Ifj16FL+bPo2fnp/DH384j//y41n8809c/vEa/vm/5OOPfyzAq5dn0TW0B/bedFh7MuAZPgxH735YOvbA0bEXjd0H0TF4FBMTZ/DV3Yv49t45/PDwDH737Bz+8OIcfnpxlnUGf/f8JH7z8hh+9fIQfnixD98/24vvn2bht18fxB9+PIZf/3gQL7/djRfPduKrx5l49XAPXkztxr0h1sR+3Bs9iCfjB/B0Ihn3ejW416HFs94EvByKw8vhSLwcjcLzYR0e96jxqEuLJ30xuN8bgzsdXDZF43lrHL7uSsDDrlj08eeB1kQMdaeirzMZt4eycGcoHc/7EvFVK3+nXolxlxyjrAGbHH1WBSZcatzz6PBVXxy+GU7E4654risOX/bz8Xg8vmM95/P3+uK5fXF4NpKE5+MpeDKUhMeDqXjQm8ptScVYawKG2uIw2hqL0aYYDDdEYswdi2FXPMZcCZhsSMJAfTzaHXHociWyEtBen4gWZxKcthhUO1Uo4XYV2ZTIrZPgem0orlYH4Vp1MC5XBeFsWSBOFwehsFYGb0MUOpri0NYQjyZ+noe/L1STLRZeeyycjhjY6+NQZ1WjtFqK3AoJcmxS5DlkKLYoUMJ13GrQ4mojy6XD5fooXHPG4oYjChcNSpyvUOJoqQqZZVIc0/OxRY3TBi0u1en4WIuUagWSbRIkeEXY2R6Gfb3BONgegWMmDQ4NhCFrNAz7h2U40CPD/rZw7HaFYKc9CCkmPyRW+mF3hR9OWHfgoG0LDlg24IBxIw65tuC4ZzuOOrdgr30DdrrXIca5FLH1y5HSsglJjZuQ0LAa8W1LEd+xkstVeGP2olDMWRKKecvDsWhFBOYvi+BjCT5fKsL85X8CZC0B2SjFyq0KSBRa3O08hR9un8SvHp7GH56fxT98dQZ/fHXaB8k//XQF//B3V/D0yWmMjhyC3ZsBc1MqXISiqecQoTgEV+chNBCO5r7DGB4/jcd3LuDrO+fw3f2z+PXjswTiHH5POH7/1WnWKfzdVwIgR/GrVwcJyX58/3wfvv1yL3789iD+7jeH8cMPe/Dqq3S8fJSM5/eT8WySTTiWgLtjabgzthsPhvfiMZv4bo8Gd7oVuNepJgRxeD4Riy/Ho/FsNBqP+1SEQ8XXNLjdqcN0ezQmG3W4XR/5ulxa3Gvga54YjHri0dOYjJ6WZEz278ZUXzoedSbgcRPf51Rg1CHFaIMaHUYFmtg8vRYVRuo1eNoThReDcRjyROJuXxJejSWyYvDNaAxejcbixRC3h6+/GCVs44l4NkxYhuLxbCAJ97qSMNWegHFCOMLGGzApMMDPn7RHYdQkbONrQLqtUWi3xqDDFoduNnOPPcFX7WzMTkLazIY1WmSoNYlQXReKSn0ISvWhuElALpQF4HxxAPRmFdo8cehojEeLg0BYYlixaHPGEThCQ2C8jng0OONhNKpQXSlBVY0UNSYx9IYIWG0KmN0q1HIfVDXpUMYhU+xNIJzpyK6KxpUKFS5XynCsTIOdeVIcKVXgqiEKFyw6nLdFIqNWAV2hEpE5asiztdDkKpFcGY6DRjlOGCKxt1mEtE4F9gylYC8HRib3+U6rFLtYSeUiqM5IoD4uRvp1EXbnheFQtRin62QEMJzrCMcVexiO2P2RZN2AaMdKxLpXIK6R1bQciT3LkTy0Akl9a5HUtRpvfLIgEJ8tCSEM4Vi8MgLzlobis8XhmLuUsKwQYdFqArJOjmUbFFi1RQ5tpA6DDUcx1XMGvd0nMTl6BF/fP4m/Z0P/07ec+N9eYJMex43rOljrM1BlT4benQpPzwG09B/j8hi83cfR1n8S3UOncHvyPL6cOoevb58mIGfw4xNBMagghE4A5A8vX9fvX57A7745it++Ooxvn+3DV8+y8OrrPfjhuyx892oXvnqaiueP4vH0TgyejEbi4bAW4z06jLdr8aCTEHRH4cteNZtUi4edWnw5FI2vpyLxeFyDB4NqPOiR43aXEmNtKox7VJhmI92t5+Tn9J9watBj0mKYk1F4frqFU9oZjQ5PIoa70jFONbnfzib2RmLSqcQQD1S3RQp7WQTqyxVo41TsNGowQTCeDMRRFWLxaCAaL0ai8M1kDL6min0/Fo1fT8biu7E4fDeRiG/HE/DNWDy+HorBSyrNo444TDdFYcAswohJgjEDAeHk7dNr0MFp3K3XodcWRSh0rGh02eLRaUvikiBb49Hn0GGATdvDpvU4FHDWRcBdEYaGslDYK0NQUxmMAipIIR/Xs1FbCYKXoDUZqRymWDRbCQyf63bFobchGW22BLjNUTDqpag3yNFoVcJll6GlQY7BVg36m5ToaFCipVGFercWFqqZyZaO/AotYVQSFDXOVEdid5EW6bc02FUYRTUhHGVJ0HGZyNdj8lWQXFVDekmNpDwF9haqsK9YjiRuY1xpGFIMYhxsUOBIvQoHHHJk2WRIqWWPXuUgPyKD8rySJUJKsQZX6nfhTJ0SJ2sjcIZ1qiYMx4SqC8RhQWkcm5HpJRSdK5Hctx4pXRuR2rIWb3w8bwfmLArEghVhWLxaRGsVitmLQghIOJ8T/wkQQUFkWLlFiSARv9TOZOzek4R9x9Nw/EYKsivT0NpGC3P3BPr69sPTthOVthRUOZJQ7U6GtXUnmgcOo2XwBOq7DvkA6R48g7Hx83gwIQByFi+nz+C7B1QQAvL7F+fx01e0WF+fwd+/OoP/5KtT+Omb0/jty5P49slBvHiaia+/ysS3L3fh2+dp+OphAp4+YMNPR+LRIJu7l1O7WY47VIN7rSq87KGVooV62h2JaT7+ms35Pd/7dIJwDLP6lBhtl2OkRY3bbKK7bj5HxXjk0WKUNqKxnI2oV9POxGDIHYk+NxuSU3GoKxlD7Ymc7EkYdrNBhenLhmnixGrUy9FmjkQzLUOHWYsJtxKTbVEEkfaKavGS1uqbyXjCEEtAovAjYfk1f/5xIgG/IhzfUkFe0O49ao3CHYI67VJRofgZdgXGbCqqVDRGG2n3aKE6LFQIeyTVQoc+LgdprQYbd2Gw6RDt2H4MEpw+J7fLLUWdLYIKEga7PhzNVWFoqQyFoygQpoJAWEsj0MTGb6M6tFEl2ghahyPB97iDcHTTcgmAdDkT0UhbZCesjUYxPHXhfK8Y/Y0KjHi4fW4ZRt0KDNLStTo0cNupOJZUFFVrkFOjQCGHxjVjFA5WRSKtTAtdtgZJFTFQ5scQEA1SqRaxVXIocuVQZhOKYipEsQx7y5VIKA5mhSC9KgKHuU+OujU46FTjAH/eZVYjvkAJ+SkJlGflkJ6TIKqYClMiRVaJiL8fjv38vkeqgnG4LBxHy2ndqJxnagiKfTOSG1YhsW0d4diIDOd6vPHR59vw2UJ/LFwRisVrRJjjAySUoIRhwUoRn5Pii/XSPwEix6qtcqzZrsTyLVJ8vFiEuX4KrNGpsetcImobd6PGswvF5kQUW5NRaIpDDQFxd+5B59AJtA2dZPY4QECOYXD0HO5NXsCTyXP48vZZqtB5/PDoAn7z7AKV4wL+/uvzhOI8/uGbC/jH7y7gP313Dr95QevG3PPqwUF8+SgDzwnG869S8eWXiXj+mFnhiQ7P7lMhBlUYbBGhzyvBZAstlVeGr2idnrQpcLtFieEWFZ4OafFqkrljVIUHA1SKbgLSyulPSzBMKyLYq7uE4wHtzKhJhdZKLTrpkXvoozvt0eh1RaO/JRaD3fT7LVSTRsGCxMChV8BaI4O9WoY2NmubRQsHJ7yrkg1N6zHAadfJz57uYeMPxuPJcDxejMXSakUxi8TgB0Lz9WAMXvRQ9dqicZvNNVArJRQyPBTg9eow1sx1U40GPNFUhGg2ZiSarDo0sjmaTWr0CrbLFcvvmorJ5r2427oPDwnzMNfd7lLAYZegxhiGakMImgwS9OvF6KCKeMpC4K2Wo5NAdLsTOARYBKPfJTymIjUkEI4EOohEdDgTUG+Uob42mEMgjKoVzuEhwYRX4VtONsgwTgUZrKeqWJRopOVrsqSguEaDXCpIlTESRdZYnDTGsWmjkJijRao+BtqaSOiKFIijbUtulCLRK0aiW4RUUwQy+FxWkRSpFaFIrgnCHquIUFBBGtXMF2oc5lA76FAjJU8J7RkptBdkUFyVIbJETAWSIC4nHGlFodhVEYLD+kAcrAjG0apA7C3bhuO1fsi0bWDmWY3EjnVIalqLNNsaAjJnCz6dtw3zvgikzRLsVfB/B+S1xRJTQQRApD5AVm6RMawrMX9lON75MAQzl8vxBVUl5XQySt1ZKHdlIt+UhApbKkoN8aghKC1th9A3eBodAyfQQAVp7zuB6QkBjgt4dvs8XjCgf/PgMtXjCtXjGi3VZfzhlVBXCMll/OdXF/C7r6/i4ddVGL5fjKePjuHxo1Q8eZ6CR8+T8OBpLB4+ZLh+wIaeVGOS6tFDn9rvkWCK9ZRK8oxwPGpX8gAqMeClhepQ0r5o8Zz26j6zx23CMdasRhfVwWmJhMWgobXQoItN12lUw0ZAzDU6OE20jvTBBlqbBobPNi+XbGI732cnQOZaJWyUckeNhE2kg9esgZVwWDglHWUqZgQVxpo0mKQqTAgAdMX4ssbXVI6nA7SGHcw5bK5ptxzTdjkmTUJx+zxRhD0aQ41RnNK0UVx3n5uAuGPQTMVwcz1N3IYOVp9VgyHC2c/qZSbp5ffppz3sMDF8czJ7jAS2To76CjEVREpllKKdob2Z6+qsjyF4SRhppDoSeOF3RzgURhriaNFo1ZhD+hzpXH8m6qkETcwv/dZwjLmkuMPh85AW9UGLnKVAv4PgWUQERMGAT8vGwVlSq0YBFbWKmeYqP/eQKRpHKuKRWRCD3cZoJNZqEXtLgticCKS7QpE1HIY9U2FI84bRdomQmSfHzgoJkmr8caRJgqM8pgc9ShzgENzXKOPPUuwsVCD9phwp+XJEF0l8VmxPqRKZpRIcqI7AfkJ92BCIo4YAHGGo32PdjAzrOsS7ViKmhRarawMSW9Yg0bGcGWTuVgKyFXMX+zOcB+HThUH/HZB5yyMY0gnIWgEQOVZsFgCR+8L6x7Rlb32wHTPmyjDPLw7itHhcpdUqMmWg2JTG7CFUKgz2DHibTqLRe5bW6yTaek5haPgCHk9dxZOpy3h25ype3L+G7x7ewA9PWC9u4ttXOXj5bT5efXmVqkH1+OYSfvX0Ksbul2H0lROPqDIPHqTg/pf0/c8ScO9BDO5MazA9yZzQK0dfqwz9nDyjnDx3CcjLbjWedcqZP9h8TQzRDSrfwXzZp8Z3BOQxA98IrcdQPT0zA3U1/W8BfXB+qQblVRpU1KhRwSavqNKhvJrBkwexuFINA6e1y6akzWDwrWEoLWP4rZDDzrzhqhHzszSoJyyGUjlMBMRQooKbtmHQrmTDa9mEGow2a/CQuegrhvT7AhzcjntOMZ7QojzmRLxD/z5aH8WQH4th5ohBrrPPKJwdo7K4opgxIn0N765ToJX2rpPr7GJwFqBu57rb69Ro4WstRglaDZzkDMCWcgms5VQ5LuurJWggzA2VUr5HTYsWhWGCMc68MWKNxjBrnHlrjDXALNNrJiT08wON6Wg3c59xeyfZlNPNCjxop4XlsHnWQUCapRiwi7g9EVQ4BTNKDBoMcahlGC/TR6LMkoDThO0QQTlWG439ZdE4UBWLvaU67M6XIakoAql1oUhtDMKuvhAku2mrqsOwM0eKdFqlZKM/jnWLcKpfioPNYhxoY+NzKO7nMc8slSGrQIrd5Xwvre5e5qIjtHTHaXmPG6VcZzD2Wvywz7ENe+o3IdW1GnHu5YjyLEFcC4N6O+FoXoU050q8MXs+LdaC7QQkALMXBsAX2heHvAZkGQFZKZzFeh3SfYBsfQ3I+7O34s0ZW/DuJ2LMXhuHHZGJOF+YiCJDBvKqMlFQm44yw05YrIdgtp/DteITuFRyAA0t1zExdAt3x67j7sQN3B/PZt3Ao3vZePgoB8NfFaDxJwtafrLj6ctC/Ehb9btvsjE+cAHNjecwMnwDD+8exp2HSRijcow9oA+foC0aUmNoSOWr/i4C0hiBce6shy0yfEMQHraK8LxfzbDLXNLMBuXBHGuS4VWvBq84hcZ84VeKXqpBPf18cUUkrhWoca1IhWzmj1sMh4XlKhQSjIJyOco4CWsMaphoqUyExsx8YmTz11UqCIgSzioxGqgm9mol6kpkMFM9zKVqWCvox2uUtCVKNqwc3WzcEZsUU4RlwqnAXacMX3IiPqOVmuS2DDL/9FLNBtnoQ9VS9JeEo7sygo1K++KMRBdfFxrdQVvXxEndTpXo42u9JgU6uW2dAiBsjEZOzkbB+tVKUE2boS+IgKU0nICI4KrmtgqWkGAPEJAhQjdI9ezT03ISqv5afqZeOBPHrOVJxJiXuach1mefpptluN/GEqDgfrzfrmLmk+Fek4iqIkIv8067XQUvFcRex6KK6PVxqDSm45w5GfvrEnBMn4BD1Trankicqo7C4RIqQHE4dtWIkG4JQ5I9BJHMDJr8UCRcpXrcikCyOQhH+8NxYUSM88MSHO4MJyS0XB6xD5CMHBkyawkLt3Ef9+cpZqcTVjkOW8TYawtCpms7djdtQrp3HaLtixHlWoTYpkVIaFqKpNYVSPGuxE7z6teAzFnoxxzih0/m+/sAEU77+iyWcJqXgCxZ898AUTCDvAbl7Q824ufvbcAv3g/AjEU6bJAn4MDVZOy9lor40xlIPJmB/ZezkF1xEvk1V3Cp6AqO557E6fyTuFh+Fsa2PAwM5WNq+BYmWVMPCzD+qgqNvzei4J+8qPxjC8Z+0OPJvZt4Mk1w+m6ir/M67oxewcPpvZh6nIieBzp0TnFajtMajWrRPcx8MaHC+KgSI90CJGI8aKNSUCWmmkPwlErxuE1OG6PGkyEG3wHhjJYCD7lTHzBQTjEANxmoBBUqlFVHIo+h8VpRJG4UanEzX4UcSndBmRo5DIsl1VQUlp6euqZM4QNDXylHFSezhQ3ppB2op5pYK5UwEiwrP9NK0CwMpRYqVH2tirlECk95BL1/BLy0O4NmGcO4CpMMnH1UpX5TJIYI2wCD5SSbdJyAdBbS7zOT9DFztNVpUXZNgkO7/WDnZ3UTrh6HxKeEg04NM4cO97rSMOyNpr0R4FXixDERjmcFwpAbjiaGXKEaK7h+Wq02bpNgp8Yb4zhcOHgI6BCBG9AzpxipvMxZYy0M/wRktJk5pzEcU95w3GPeu98qxu1mrtsHRShVRcTPkNCOCZkmhoAwo1ZFw2xMhNGQTKuVhjPlqUi4FY+E3ARkUEH21mlwjPv/FLfjOAfLQVY6ty2eyhHHZVyBBLuva5CeLUY613G8T4yTvRE4PSjCoe5w7OkJxZ6uMGTSPmYx6O8lmEf7tNhbL8ER7ptDVLR99lBk2HYgw7sFOzs3ILVtJXPHEsR7FjB3LEZa8zKktyxDWv0KZqIVeENQj88X7aCKEJB5/zcgwlms14CICYjMB8jKLSqs3qZkLonAm4Tjb99eh1+8twXvzZFgoX8sApPjEZyVgs3padiakYbQPalIPnsQh66ex4kbF3Cl+CL2Zl+E7NIFnO6ywDldg5E75Rh5XI3Rl+Xo+MmKxj+6YfmjA/X/YMHkb6px7y7V5XYu7kwQprEbeDB9CXcnMzF1NxG9dyPRfVfnW3ZNaNBLUIan1BifkmNkRLjYFYJJZo0vx2i/uCMfdxMQKsaDnkg8Ho7C1KAOd/oZmDnx7tAmjDdo4DDoUFqqRWFFNG6UCCqiQTYBuZ6jwo1sGfIYIPPpZ4upGqUMm9W1tAvFCpRTYUoJUFGBDIYqhQ8Qe5kYxjI2ZqkKtnJmEAEOKpCFod1BtXGxKZ0Eo64gHPZSEdWEimJS0iIRdqMOA8weU1ZmJ4brx1SYSVqzDlq3bkEpaIfMhVLYaOsa9BHMW2xgfo+hJjEGmghVEy2Rh9+vLwEDLSo0u2Qw0rvnXeD6csN8Z686agRIQtFYFYKGijC0EbJhM60fs8uwnYA5CIxdgQHapGH+/oA7CoMtGbSwmehl9hpqDmcmCse4V0JYROiwBaLDEYwOexh6nSLmFQUtoJbPpaClPgMeZxoanDthsmSgwJiGUxXJSL2V6IMktSoGWVStoxwIJ2wyBm5OfsKVySGTwe+ZWBiO+DwRsq5rkcx9nNUchjPDMpzokuNQmxRZrRHY3RGOzHYxdlJV0wnXbo8cJyeU/CwxDjpDsMfBTOMIQoZjOzJaNyGjew3SOpcjuW0RElvnIrllIdKaliPFvZQBfRmSaxfijTkLhYC+gyqyBR9/vt6XRz5jvpi3NAwLhIuHPgWRvr6SvlmNNVvVvlPBb/6SCvLOei434N2P/DFziRyf74jGAnEclqhTsD4tA0H7MqA5sBdx+47gyIVTqNJfQF5DHg42liF/2Arvi3qM/7aJIDQwV+Sj71d1aPlHL6Z/X4XHPxbiya8L8ezBKTy/dwrT4xdxf+okm3oX7o3vxP3pNIxPJ2DiIcMkIRm4zSA6walLUPomaQkmxOgZkOHuaAweTkViclCCR/0KPB3W4dFAFB4OxWCkn4GXuWSyk43ITDLSHEkLoEUpVeIG7dVlVg5hKaAvvsWfs3MVuJkrRa5gtziNsznRbtySIpuhMptTrSBPidIiKfQVUiqHmJYq/LW9KtdxwkfCRZjs1QztBMRaSaWpksBUIUNlvghWBsg22iEvA2yXiVnDRiVkSH/o1uAJ7daUi43qoGWifeqyCdczqBJUw+FWBcbYIJOdtI29Ci6pMsxfLcwErcw3vW0atDdFwMnmaDFGoJNWq0MfzowSxnwSjGZDMDymUHgMYVQJfh6Vop++va9OSjgIHKfuaCMBaJajv16LdlsUAzfLSvWzEixTEBqNQfCaQhjad/B7beUA2AEnp76jWvh+KjSY0+Fx7EaLezectt2o0Kej0EKLVUfHUZCAzPx4JFOx0wjHASrdHsKV6g5Dio1KUSbFLobtpFwx4rJpuW5okVAgx94OEU5PSXCqhyrhUWEPId3lkiLDLkWmORr7mNtOshfO3hZgIxjWHdhVH+CrdNdWpLeuJxwrkdZKEJqoHp1zkdq6BOmelUhxLkOq+Qsk1cwjIIu2Yt7i7Zj9+SLMmPELzJz5Lj76+FN8Omcx5ixYg/lLt2PJ6lAqiBQrN6t8t5vMXRKGWbP98MGn2/DBJ9swc3YAPpwTig8XyjFrqQ4fM5MsCk/H5oQ0BCekQpeYjtK8feh272XTnkfT8HWMjufi3qMiPH9Wiq9elOP7r/Mw+Bs9qmmtWv+zA1N/p8fD72/hu6eH8PJBJq3VAUyP7sX0QCaeje/FU9b08G6MjaVj6HYcBm9Ho38yinDo0D0pR9ekGF2DUtyeSsLte8kYn4zBNG3V/UGqh3C2aECHsX4tBgjIMHfyACFpaYyCkc1ZxVCeV0LVKNaggFnkZp4aV24ocPm6FNeypcgvpgWjtcopVuLqTRmuXBPj+g0CkitDdZkE5lqGck5jI0OihZnDWqZjRfnyh4Vh31TOoFwlg4lVR0Bqi8Wo5/s7aKsGLcL1Ei2mvZG4QyCmrTJMcaIOmCXoZEbqNIoZeiXo8MrR0yKhOsgx3qTCdJsKd7uVmKZlHGBobaP1afRI4KWiOBoDYHD6o94cSLUJYiMHEooQtArQuELgtQehwxnOTMGJb2WYtwpnnghRfQRVgpAQQOEze53CWTAZwVAx84igLw2EsTKY3zOI3ykINcU7UMkqzPejqgZwGYycPAlqTMItKQmwmlNRSVium5KRY0rBmaoUZOalIIMWK5UWayfVNZM2cicVK93J7KEPRVJZGBKLwhCTF4bYnDAqjhwpNyXYb1bhRK8aZ1q1OGHW4QjVQgjjx2ifj3ricLY3Cde/3ImLI0occWzCXusG7HFvxO6WDchoX4udXauR3r4CyZ4vkNywAGltC5BJOPY4N2CXbS12GdZid+VavPHJZ/Mx5/Ml+PjD9/Dem2/46pesGe/8H5j5y5/hw1lvY/bsDzF3/jKqSYjvouFnC0Iwe34QQQkhQKG+WrgsDIuWy7BgmQ5zVyVh/ubdWB62E+tCE3GOeWSkcR9a7fEMden4sm8nfj16ED9On8Jv75/HT88YxL/OwcTXpbD+aEfDb4yY+PYWXn15EL9+nIJvGcgfj2RQPfZjYvAU7o8cx53BIxhqz8JQdyYmJzJw+04yJmi7Ru7Hou++Bj3ThGREjYk76Zi4n46xuym4Q1ieTsbju6lE30W6O8NxGOqj8nRr0NSsRa0hEpWVBISBsaCYuaNAhVuFaly6rsaJs5xWZyNwhSGxsETNjEJ4GLpv5Mhx86YUt3jQSgvlqCyRwkB1qKJlqmbYtFXp2PxRtFj03wTETFtmYlaxshGMtFi1BKquTERLRnvDcHyXNup+gxoPPGpMEox+AxuT4bKTjdtmjkCzPsR3Qa69gbAwO3U20PPTY497FbhNNZlskWLIw2DsDoG7PgQOdzBsjf4wefxgqt8Og2kbjDXb4aoLICBBBCQQbqcfLVgwbZkCXoLidAbDzknrpkVt9lJp2mmZOiPQTRvV6SJ0jnCY9YHQVwXAxiZ2UYk85hDYagJgqgui7QxARdUOlJaHoph2s9IaiRJWMfdvsTsGN6jU2awznkjsZT7ZWcfiPtrJnLezSIadVLrdrlAG9GCk1gQjsTwY8UVBSCwIQmpRMPZQbY/yOB226XCcn3GKg+UQB8l+rwhH+miremNwaSoV+V/twyXa6uOWdThoZPNbliOz7Quk9yzCzh7aqY65SGmZg7SWz6gk85DlWoP9tq2EbxsO1+7AiZIQvPH+O3+JD977t3j/nb/wgfEv1fvv/QIfzV5HMEJow4JoyRjimVMWLo8gOBH4Yo0Yy9ZJsdwX5uOwcnsmFq7PwsLVibh4Po3TLQtTHWzSVjZ7XyK+GU7GN4Pp+HZ4J35/Nwt/eHICPz67jKdPbuLOowv48uFefEdl+H4qAd/fTsDTQULWfQj9vRdwb+Ia7oxdpMXYj5H2/Zikqtyh5Zp8kISxJ7EYfhKFgfs69E1HY/xuGm7fJ0D3UvHgbjJe3U/Gbx+k4lvuwIfjiRgbTkB7SySc9ZGoqYtCFZu4gmG6gGDkF2lx9boMZy7IcPSkCGfOinD5ipQWLBKlFa8ByWXuKKQFKKF6FHNalvMAV5VIUJwfjir+3EBb5dFHw1GhYx6htaqWw0y1sFRKCJIEtcwFteUi2hHaJFqnZ7RSz5s0eNTIHGGW0pZJCZUEVuaF+rpwOCqD0FwnRquZcBCMbrcI7ZZQ9Ntpg2gxpgjKKPNUL8FpbgiDu5EKQb/e0haGRlcQPFSLdiEjMEx303q08jlnvT8sbIoWVzi8bMwOKobbQ+vkCUaj25/7XIzRQRmVlsUGHODj9rZw2OzbYbduh9sS6FOjThdh4jq9/FybxR9mcxjMDMoGhw7l9ijctGpQxFxU1kUbO6TF2WE5Dg8zIwzQWtWrsVO4xpGjwM7yCGTQumUQtpTKQAISgPj8ACTnBSCp2B97asNx3hKFo7RlB2tpo4xR2C/cdtLJnNEXgoPcvsN9UpzpluK02R8n9BtwuHoNMsu+QCbzRXrrfGR2z0N65ydI7fgQKU0fIoOQ7HevZ5D3wxFzAE4xl12ghX7j/w3Cv1Qz3nsbsz7ZgI/nBBGQQJ+KfL44hPkllKoR9idIIrB8vYQ2TIs121Lx+dIkfDAnEqFiLb14Ip4MpOFpP5uyLZbTKhKPumPx/WAifpxKwe8eZ+J3zw/g2wf78WgiC7cHUjHVyYxBqAbadxGOgzwwpzEqBPV7RZgcv4H+9qMYbN6L0XYhl+zyqcjI3Tj034tG951IDBCYkUdJGL6Xgr4xKsa9BDy5n4Bnd5Mw2hdHFUrAeG8cetpj4bTHwKDXobZaixpWKVUiN1eNc+dEOHdBiktX5Lgq2KyrCpSUxqKYrxeVEpISJcqK5KhgFRdIUVEqRxV9c1kpFaKW4dgUxYbWwl2lgYmKYqbtqitleGdOqWOI13Ma1pVzKhuYIaxKvGhQERA1phm0vRYqTIUIFnp5ayWbrSKEgT4A5uIwZpYwwiOCi+B4a8PQTWBGGGqFq//TXqoPffkkM0h/owzdrtcXTfsbZBjx8vlWFcZaFOjxiNBEr+8kJF42dk+rFN3NBKdVDG8j84k3BF1toRhnlpskIGNsuoEeCXq6aL8YiL2NtGruHWimWjW7A2lRA9DuCUV7YxgzRxAcVqqLm/bSzeFDMIqYh0r6NCgf1qB0VIXLQwqcpAU6PanAPpcSGWzIdEKSTkB28nfTa4ORVBqEuBJ/ROf6ISHHH6nFgdjHgXDao8A5qu1Jowb7KhjKuU8zvRHYM/Aakn2sE81scoMfLhg34lTdOhyrWY2DthW0WouR1TIfGR2fI62bgDR/jF3eub67fQ/b/QlIIE5VB+MKj+m/ChDBdr3//kzM+mwrAQnEJ3MDqCSB+HxhsA+QhcKNjqsisHStGCs3SrFumwZrt8Xj47lSvDNThE/ny7EvM55gpONedwyGObFbOTEmuMO+GYjx3fL9ijnhOW3QeH8S7I5UXC+KR2lVGvKK03Cjcje8Lccx0H8CQxPn0D98Dp2dp9DTcQwjnfsJUhbuMryPjyShfzwO7WMxaJ1gAH9IGJ8mYvhBMroFtaAFm3gSh9G7scxACbg/kcBgy/zSEcuDGQlDrQ415cI1DS6rtMjOUeLiRRmuEorrhOP6LRWusQqLY1FSEomy8kiUV2hRWcZMUkgF4QEuLhTTf4tQQxtlrKO9EhSkXAUnwbEUK6Dn61UM7hXMIdWEqJrvraW9chnk6DNIMGyRoI8BvLmZPt+pJLAErSICRlqMGk7Qqlv+qKG3ry4MRm0JbU7RDpjo+711wlVr2kqzcIFOjlG3yndz45hbjX6LmEslxhu5z1u0GCcgg81KtLnFaKDXt9oCCEgoYYhAV0sEs42YFYE2NtgYwbg3qsQ9TvqpfglGesMJCdWiLZA5h+pCUPpowZqbAmF1bIbbEYC2ej62B8LliICrMRJWQmvupnUd1KJgTI6cBwoUPGLOG9XgGuvKXR322hVIZRBPzZey2cORYQhBanUQ4gsDEZ3vj5hCf8QX+COtNAAHqIYHByJwok2Ck14qh3Dto1aCFHsIMroDaaGCsIt1tDEU52iVLtVtwnnjelqxtThuXoEDlmXY511Mi/U50vs/Ylj/CHuaF+Ooi3DYAgkI4aoJwUUer38VIL98+8/xwaw5bHh/ghHsA2M+g/p8wrFoeRiWrBL5LNby9VKs3izHRr9IrN0Sjfc/3oF3PvDDLz8Mx4qVlLwTCfCahbtBowmIcLNfpO9vG4bb4wlGCgYJh8GWiKyLsVAejUP8yTgcvxSLyppEOM3R8DRq0NEfh+6+JHS3p6LLk8rf3Y3J/kyM9zGsDySim5bJ25uKxqEkdD2Ox+DTeAzQorX2xKJjKh5d96kso5GYGo2mvdKhndsw3h2P3qZoriMSdQTDpI+CoS6OWSOGcCh9gFy6qmIY1yEnR0cIolBaGoUy2qaKSg0fU1UKaLVyJcjNjkDBzTBU5YTCQatmL9eioUwNCwGqIRwG4Yp8maA+ChTXyFDIxi40SlDBMjOE640iVFEN6pg5THop1Yght0QEgwBEfiDq8oNQmxuM8uwAlOX4oarQD5U521FJC6IvC4G1KgxNRin66lUM7zrcoVLf5fR+wO93x6vBnTYdJtupLASw0S5iQzP/2II5+WnJmpglqBptnjDuV7Gv+UeHpLgzKsdknxgTtC7jBGS0j1aqdQc8DdvR0Uyb5g2ChTar1ujP/BKEBkLiJiBO5iRrqw62Hi1sQ1TnASrHBAfMMw2ynzHf3VEj+54SV+6okGVUIDlHisR8CXOGCGmVoQQkFHHMHNpbgYgs3IGYUgLCht83EIpdt6kkYyE42h2Gw80RSKmNQAJVK7HdD8ndwcjooopYQ3C8zB8X6rbRhq3DCdMqHDWtREbJcmQYF2E3c0fmwCcM7B9jf8sqHHaE+OA4Wkf4qiNwlhn0XwXIjHf+PT78SDirxWC+iMF8iRDKI7BgaRjVQwAk3KceKzZIsXarEhv8NFi+ToH3Zm3F2wTkvVkyzPo0HgsWx0OnjkPutTj6aULCkNXhjEKHOwEN1nT6/jSkHs3AjqQEhOxKwJ4zMci+oUFVMRuMzdLUTAtAiR7gNBpsjUSPcK9QYxLh2IWJ4QwMDqcQoCQ0dCXBPZKIlmfx6H4ahy4G83baKc90LLrvRmGKCjM9LJzmjYSLMj3cFkf7l4Q+D20WJ351dSJq9RkoKErAJSrIlYty3LgejZs3YghDNKqq4hjiaRnY6OXlSt/1jxLmkMIcEXKuhSLvSggqrofARfvVTGvlFc5cCTasgCGe0BTTmgkXGss5NYuZG0rstGQMmbU2uQ+UGk5DM3OJPj8CeVfDUHw9FLUEojo7EMacYNTcCELV9WCUXQtACZ8vvhmAgus7COYOlOf5w0471uMQ7vZVY0q4C9itxaSL+8ytwLBXjqEWJYeLDPXWcDZyBIM+latNRlUIR1Ob0PzhGGynLesMR0dnKAYHRBhh9XeFoq8tGK2t/nA0bIG5fhOsrq0wO7YT+C3ILd6GKtMOmK07YLMFoc7N79SuhGVUC8ukBnVTatTeVaH2eRRyv9Tg+pcE5BVtqwBInRIptxRIzBMhsTCC1iqccIRSOYKh4PdT5flBV+SPBL0fMnuDkT4dgN1TQTjYF0oFESGqPByRtJuprQFI7QxEWhtVpJavM7Oc0m/HWcN6ArIa++tWQXVuMWJyFmJn/Vzs6vyMNQeHvdsJhxSHmfOO6SU4QVU/XxzzPwdkxi9eL99/728x5/N1WLyUgVy4gChcZV8qlGCvQrFkdTgDugirNkmxfrsKG3eofLnk3ZlbqCA7MONDBWbNTsT7nyZj5qcJWLE6FtExiTi0Px6XL0Tj2rUEpGTEYVNQIuZsScMKWRISjsTgEuG4dZPenk1od6kwMsTJP0bF6Yzy3VTYbKFVszNDNKdjsCcd/YOpaO6OQ2N/NBpux6LxSTy8rOY7cfDcjkcDlWNgKgaPGP4fT8bgwUQkG0HpU5CHzEK3OwiuORa1NWmvASlgSL8oxeWzYkIiQ3Y2gaigolXFIq9Qg9wCJUqKGcqLmT3yxSjhwS2kguTdEKGoQOy7cdFjVMNj1cFcw+lJiCoITTU9c51eCaNTBr1TBLtFBicHgFsvh4MHxlrC380Nhz47HLfOBuPG6WAUX6VqsGpvhKD6RigrGBU3AlHK6Vqcs4Pr9MctApNDr17DYNvJPDLqUWOoXsZSMchrYDNwHQ4Z3G4J9yezDb28lwoy1kE71s/920t7xhDe0yVmDqHFIjAe2qxWgtLTL0Irm87t9iPIG1DpWI9a50bY3dtoBXdAz8meS7uXXeyHouodKDP5Q98uRx2tWS0BqKWlqqFq1Lzgz9/pcOslM8hLBbJ/UOIM88juSlos2tfEHOGCYARic0VUjnDockMhvhQC2SVCwsEQpQ9CcjshGPVHxlAws0YwMh1hiKTKhp2RI5l28gDzx96WIOytpPW6GYqjNdtx3rwFJ8zrsatmKURHFkF9YSHSjXOws3kOdncswpGGYBwxynBYL8IRvcIHyMXyqP81IDO4nDVzBhYtCcLSFVIsFe7NWinGohUin3osWhlKe0ULtUGENVul2OivJiBq5pQdBGQz3p21De9/IiYYMZjxcTx/jsPMObH4ZH4CAUvGsjWJWL42HrOXROPTpXGYuyER2uR43MjW4cYNme+06s0iCVy0C6PDsXh4J5FeOYoNrPGdlrVYYmEyJcBsiKUFi4enPQaevig4p6JgfsLXnkXC9lgL150otIxGYWAiGncnI/HkthaPp3SYHlTgzhBzSGsMJ6kQ1KNRRGtVWBjpu/B367oM1y5xG65LkF/CJq+NQ1lVFJtQy0DO7FEko3rIUHBLjNIcvoeg5NE6lTN0GhiILQzdTpcGLlcUrJySLoNwY6EMjXXCNQUJPKZwBmwJuivZgCX8ngUimHPCYMgOg/5mOKqvh6HkUhBKrgSj5CqViSpVydcq2CyVt1j05mWl25BfvB0387fjVvk2Wp0gDg7hVhslOqlQrTaF7/6vkjwJSipZtHDlNqoU806PR4O73VG426vB7X6G+z4lRnoIVZeUikGr1iWjYtBGdYahsYlWyk6VMBMQ60b+7AcXPXuDJQT1Jm4vfXsZw22pIQjl9aEw9MpgGFGhkoCUP1Gi4rkcVd+oUPq9GpeeyHDmkRwXn6qxt0GBjBwGbVrY2GtiqM9JIT8tguRMBEKPB8NvdxiCdoVBfCQU0cKt7p5AZAwEYldXkA8GIYMkGcIQcU6OrVky7GmU4nijCFkETrxbDs2ZEJwybmOgF/70djkUp5dCdX4Rcw4VxD2P+WMdjnA/HTMqaa8kLBlOVYXjcqn6XwPIn2PWrA8xd4EfLRJhWCHG0lUSLFoWTpsVjCUrQ7BsbThWbhJh3XYZNgdqfIDM+HgzrdUm5pAthCKMj3WsWHz6eSzhSsDcJQn4dFECPl4Qh08Jx6KNWoRHxyAuKxZnL+lQmK/ArVsSXGVjXr8VgSpS3dwajYnxNLgbY3CrVItc+v/SGjZyRQxy8uh1C9XozA5BUwO9/2Q0zF/GoO45A+IjLZpGY9FGW9VDSMaoHLfH1bg9psH4oBwPRqhMXdHodhEkE8GrUqOEtqm0UOnbjpxbUuQXEIRKJcrqhNPBWjaExncru6uG4btCAbNw+4iJFoLWpoRWppLTu9ajhJVhudHBQEwF9JhlaDCL4DCyoRhC24zhrDAGa05rZofGkgh+BwbyvHDUcnpW3xRzGQFzqYT5I5zhPAymste3iug5Wc3lYTCyGSurtzKnbUNJlR8b1J+Qc9Izz7TXq9Fo4zqF2825vdWEOrtajpu0ElU2je/ERDeV+F5PFB73a/FkUIN7gyrffWxD3XKGcQLSTYhbg2FnCHd6guBwBcBk2w4DQRGWRpMfLOZgLmn9CEq5lapm24HqNqrgiBKmMS3Kaa3K7hOQR0qUP1cjn0py6bYCJwfZkF1KpFWokHJNg+TLWkRekCOITR2QLkPALhG2xIdhW6wY/ikRCN8XDvHRCGTow7C3IxQHaPmO0mKdouLtoRJqOZw2xGqgOBUJ1Vklkk5FQ7FHi1U6MWKvMLRXUUVoteJvrEDMrfnINM/DbicBoQoesalw3KAgHGIco806U+WPS8yM/1NAXte/wS/f/Rt8MPMjzP7sCyxYuAkLl/jTZgX5Lg4uZkBftk6CVVtkWL9Dia1BGqzZrGAw34IZHxEO1owPg/HLj+QERQc/BvhD+3YhMCQZ85dHY1NIFKJ3xWDfyRhcyY1BfqmOtkVDiyJHLkPvzVwxbuSxQYukMNGqNDBw1tFaZZdH4hYBKayIRE5xFC5eVqBxbyCeb/0E/TkR8PKAu+4xu1Dazbcj0TaQgLa+aHQN6tA7QusxpsTUpBZ3JzT4imrz/XgcnvbGYoIK1OLUwVKngZEgVFUrUeMr2gUqgMkUCSttU6dTjX7ml05Omw6zCq2uSLTwd50dkahy0z7VKxhSFehsFG5j0frCsXAqttUc7pu6brs/2h2hBCaE0z0EzrJQWErCYSoUoU4405UbQVslQjWVSbgL18Nq5fo7LVSl8ggqkBgNrnAYHIFwUTHaTKG0aRGwMFxa6MUbaRfaHDrf34o0W6LQaoqDrSYBpdVRKDbR8tGa2i1J8DIHTnao8axPhZf9Gjzu475pF/KIFG0dzH1sdAtDsL4xGI4mrsNDm+ciiLYtqGHpqSJGRzC3gwrH/JFj3YaC+u0ob2aGoiLpua/LhqiotFFFBCb3tgY3WZeHNfT9Suw2qRCXq0D8LRlSOIx0PI4h+wnHTi6zpNiWIMLW+HAEHAyC6GIwVBfDqAJiHG4KwelBBumBCFweEuNMhwzx+hC+rkZQihbLJBpskMRiiy4KHwWqsVwtQuYt5oyqjdhXuwqZhsXY45yPrPoF2OtkVjErabGoHoTvRG0gFWQjzhYG/suAvPfW69O7Qs3gz++/9Wd4/+2/xgfv/QyzPngHH3/8IebMXUhYVuOLVVuxamMINvrJsYUKIpzRem/WFp+CCPXLWUJQ9ycw/lDJJfTYKTicFY2D+6Nx/mIsw3AMbUIMKssE68IJLVysK+X0LpCioIQZRLgoR0Dq2Jw2hnq9OQqleoJEm1VRq0NpWTRyrqvQlrIdv3vzP+D7ee/iZdDHeKb5HD1FfnAQDE9PAlr7YtA+oEUnD1r/uAYjwpX2QTWeUlleDDLbtNCa2TjxymmdCF+lAAgtUSUbs5wKVkSfnFsm3KRIhTKo4KpjswpT+YqGVpDvZeNV0NaYuriOViUGG+jv3WF42CrGk04VJhmM++upGi6qhzsYLTYCYoyAW7ixsVwMo3BNpFACQwnDLadhJQO6kTarmXA2VUkw6o7EaLMO9W4x7STDr4c5xeKPVkMES0JVUsBilMNmZfZxRsLrioHLyjxmYh4jHPayBAIUD6uZsNgSoa9LZAaJxWCLGuPMYne7VLjDGulQMqgTyhYZTMxIRfpw2jKC20hr5/FHtmszck2bUEPILY1BMLuDYKgPYC4JQB5V5aaVOYQqVWLRIZfHqsDO49sYjZK2SBQOUu0HonDOo/XddZtYpIPuuAzaEyLoaKclp+SIOCRD2D4Ftu8UYVNKKNYlBWPLwQCEXNkBTZk/DtRH4Dyt37leOowRGa4OS7CfFinBEAr5RS2kB6OxLV6Dmauj8bMvdPjrJVr8cg0hPE07Vr0RBy3LsMe2EFnuOdjfuBxHmMsOO1U4ZBczfwTidOV2nKpYhxO0rv8iIEL2+G+g+B7/KbD76q1/Q2j+HDPe/gu8/+6/w0cf/AJzPvsIS5ZtxMoNEny2IAjvMH+888EG5pCNBGQzi6BQTZYv244rJ+nHS2J9N/HpS6NhrIqEsTIKpqoY2I3R9Opa1DLIlhbJX1sdBtsSNk11DcOtUYs6MyEiINUGQU000DM36G9p0RuxAiMz3sXk0k/xZcgC3DmymRNaiuomvqdZC0e3Fh4C4e6l2nQo4G2TM3hq0OHVoo12xGqkZatS4RYhuEXZz6VvL+aEK6CNyqtSIqdci5ulVK9iHvgiTsRiBYqpdgdPqLD/lKBoWpTVM2O0CDf3EY4G4bbvYDxi2H3SFoG77WL08nEPp/FwYygm6JUHqTYtJrnv7zmEC4ZVBeG+i4kCMK3VtJVlEjRx6WZGGaEajbZQldqEK9kaTnMJnMJ9U0aCSshMFVLfPWAmbrPFEQWjlTnMHAsnM1p9dSIclUlw1CbBakiCoS4ZxWV8zhxP9VOjmQ3W0yxjFlOit1WBtlY56j1S39+uFzNXFNWFoIT26Wb9FlxybsAVNlCpYTvsDUGobwmFifar0hWIHEJzhUqSR4UrreFg4zEtqI5jJSKvNgXX65Jw0ZCAwxWJyCqLQfx1DkqlHw5JNyMhLRjqjBAEZtFSHRRj48FQbDwaiA1HA7Dl2HYEngmEooQhvU6EE9xvFwjxlR4VA7YUSVTPZOaH7VlaiPdHYr1Ghb9ZqMUbn2lYkfg/P1EgMCkE+8o2Y1/dcmRZFiDT+RkONKzGCSfVjFb4gCsCR2gVT1f64VTlBhwr8ftfA/L/qf8nKP/De/8C786YQ6VYRyg24e33N/r+ZsQHyIesWRt8yw8+WY9Nm/yQdyGSfjrSB4WpQgdDGS2NcA2iRgUjLU11qQIVDMDlhXIUMPyWFdP/C2eAKtVsgGgfIFW1GuYBNWpqI1GfHYPm1fNxfOVydKyeh8notWgoEqPIyAxBK1TokaO6UwEbZd9KMGwNMp8FamjUwMPs4eT7jISjqpKBkge2qFaJUj5XQektrJIil4qWy+0tLKd6EeZyQl1dI1ws1OF6vgbXC7UoEf7mQy+lDQrFOJVjyBWEIU8IpjtEuN8iwmRzuA+QIVcwxk0BmDAGY8DJSW2RcyjIfDc52mukaDTI4WUT9NoVaNXTSvGxo5Yh3hrhO0V7m5ZoipO+r0mCdipeO/eHozICVn5fWwmL+0XYR/q6KOaROG5TIqzVSdATEJs+HRZTBi1jGvJy2bQF3GYzM4pLiVa3DD1e2scmKkgL19kQjgrmiVLmjTI2vpAv8hzbccm4HleL16HM4A8Hv5+zORRGbxAKXTtw3roVh/UbcKoukINFifwyZkU6gOKqKFwvScSJnGQcz0lF1rV0ZGanIP5EHArXrULDwk/Q8flMmJZ/guD4AGw4zlx7PACrTgRi1Ul/bD7uD79DzCA5QRBfliDuUiSu0eae5PFPLpBQiZQQn9Rhfngk5u2IxZuLo/FnH0bijdmE5FMt/vJdOZaGhWBX8VbsN65ClnURdhnn4KBrI05zQBwX/vFDYziVZAeOmjbiqGEVM8vGfxmQ/z8lAPLem/8Wb/9yEaHY8BqOP9U7Hwi1Hu/NXIf3P9yAmZ9uwpyF2xEUGIJz/EJ1lbFo4KRzsRmdNUKDsEGpFqUlwt9YSAmGlAdSjOJ8qohwWpU+tZo7vJwKU1LGBqbdKa9kQD9NRfh8NhLXbEXfezNwd81nqKKk3ihX4oZVgYJWflYnw26LFAanBBaLGPV2CRqcCl+IFsKsgx7UwAatFG4VEYrTuIJVxKbLJaB5ZToecM3r6x8EpKxKh0JmpmJWNS2ZpVY4OxXBrBGCISdBoPUYop3qdoYy0DOY14XCQY9rrwiBozAA7WVhaOP66oV7rSolsAlnsjgFW+uEZQQ6rFQRmwQttFNeAt7aJEMfbcpUWyymOeWHCGGXge+h1XNRcexF/ByGeAsBN9dFw2aI5/qSuN5kgpFMWFKokukM12kM1emorU1FLfOJUfg/Vjbp69PNJgVcdmFdcjQL+4qNX9S4BVW0TwZ7BAodO3DNuhG51ZtRaQlAfVMEXITfymUObdZR22bsMqygp9+CQto+YWiUcF8VVcTiTHYcDl5LwNHsJBy+lY70ixlIVmvR89YM/PTnf45//LM/w9f//q+RFLwWG06JsexQKJbtDcXy/UHYsD8YmwVlOazAUpUKS4KjkES4lLt18Ked2syssSQiFp/5J+KtLxLxZzOj8cZ7BGSmDm/MICBvy7EoIAKJtzZir3k5Mq0LsLtuPo55tuFcgxJnmdWONYXjaPMWHHWspg1bjCN1q/73ACLUu2//R7w1Y/n/AIdQb81Yz+VaArIeH3y0ER/P3YbZixjylwVhq18YTh2nX3elYNwbheF6DdpomcqLRSigBy9mUC3iMjdHTBWRoTBHjiIuS/Je/3FSOSHS61WoMWhhvRiK7kUf4+JnS9D97vuYXvc5iq6IkG3QIN+lQmWbAiYecGsDG8nJgyrcDkFL4fUo4bTLYKDHrmHphX9+RrtSXhyGylKG5TKRb1nqO9Ba39+oF5epmIvUKOLjIk5I4dqGjdPfywZrIgB9lnACwu2xBaGJAdpWGYKqokBuczDK8kNRkR+MytwANnQ4vNVUkGopG1yEBobvrspw3x28fRaJ7/byHsLR1aSiFZShu1uOLk65IdqhMYcYQ77/3KimyvD3ywT1EGyW2HdPmZ2h3GVIRH1tMhrq0phD0mHXp9FepcNs4dKcDpsjGa72KFhoL0po427kiXCrIILKHMH9IkUrw7qlJZiBeztDeojvmk2+yx+5DVtQbGcQdwbC7BExvMtg90qR76THd25Bhm0lrjmCUE3rKPzpQEVNFLILY3HiWhz2X43H7ivJSD6TjoD4XUhaEIhnf/Hv8M9vvOGrX//VX+HYhqVYe1iMFXulmKuTY7ZEhnkRCswN0OLTTVF4a14U3qRtmrMmHp+siMYHX8RiFuvjNYn4ZFMyfj4/kY0dgzfeIiBvE5CfK/GXb/EztougvbCFAX0lFYQZxLgIJxr8CYgM56lGJ9rCcLx9G4671uGgbREOmRb97wTkHbw5YxXefP+1grzzgWCzhJ83+BREsFizZm/BZ/P9MG9JoO8i40dz/LF2XQhOH42Gi1bALdilEglhEPnuaapkcxbnhCPvOoPiLUJBMKqKqCAFMlTlSdhoIlTT/lTSghiLOI23zcWZj5Yge8Z83P98BmqvBiGf6lDCCVHbyOnIg+j1itHsFcHDaVHPKVlDBclnAL9MxbjKkFzCaV5TxTBaGuaDpLw4ENUlITDU0oIZ1DASSH21CrVcVuvlqKDvry2X+6yVtS6M1igEw/YQjNJGdVhpQfQB0FcIgIQxX4QR7mBUFBCQvCBufziM5TK4CElTtQjN5aHoqxH5/g1PDz288Bd5bcJ9WYSku1uFnn45w3MYOth83YZg9Nnj0efe9VpBKqkctFl6qlgdJ7arhvuT1spjSIWHgNirkmEpo8WqSIWN9spekw6XMx7NXTq4mtQorJQh7UAYdp8NRrEtAuYGWqfWcCqIP6qad1B5w1Dr5nFwhyLfG4Bitx9KqJA1HDgml4yDh/vSJcGpen8cooqUmzlomOmM+ija1mhcvJGAtCPJkGWkYK0iFQsDd2Pmmj3Y8KEC1v/wER6/8TcY/qufY/Cv3kQEB+gnYVrMJBDvrIzEm/Nj8PPZUfjbWTr8XzMj8bdUhZ/PisIvPozB25/G4b25ifhgQTw++iIJs5al4GcfxuKNdwjILwjIf6TF+hkB+bkYC/0CobuwFVmm1chyLsRe2zKcagjDObcE5zwKnOgMJyQBOPZfuXvv7ziv+9o7tuxItiSKBb13gCABAuwEQPQ6vWMwg0ElwapmxZJlq7KT6CB674PeewcbWNUsR3FcEjvlJvd917o/vH/Afvd5QMqylZXkrivrSv7hu54BQBBTzufsvU97JuNptfbhZ8OhXx0grq4+BCSKgAjF2ARDqIcI6h6+zB4BCQjYKfa/ZyB8v1Jax+UdmAq/EAGJBq//iH61ko25lpaGPVlHhx59/VpaLDXaGglDYyY6qRhdbRZ6aSutGTMFLUkHvXkLLcnohXh0HQhHVKQaRYFxVBN/dFUqcH3YhAZaKTs/xGn2vPNUj8lxPW0Fw/twNipaTbhUa8QF5pyr9UYGdALapkNzC/92kxLdbXL0UwFG7bRlopgVBvozYe+n/RhkY2Rjtvey12avO2xXYX1cbE9V4da4nLaKKtErNhUpMNDBxsZqoJJU1spRfV2+ufuQWatfQELY5gjJOnvdGwReXFeYnWYns7DAbHCH+enWnUys3tBKCwEXu2S4M34KtyZfxUKv2OKrk3Yoit2QXS2FmOwoYodzCvP9ZzDadgw9Tcwk/N4wQRnp4veYSZYmCnFrLRfzDLotzElvDdFiMBc1LlA9Z/n85lLRS0AG5vnc+Tyae7PRxkzWStXoYD5pJUSD7HSGp9lp8bl2jWXTzhpwhf9HdZ8WjUMmaQvBhStFUFhOYVfCWfjHvAS3/a/Bee8bcNrzY7gGnka8Zyb0riokueuQ5KaFR0Aetocew7aQY9gRWIQd/nzslYOtHlZs87Bgh7cZjr7ZcCIwrgH58N51Ar5hJ+AfcRJevP7Ajarh9BiOF7LxV1uy8d0XdPCKSIX+9RT8eCgKP5regzdmo/E+X9uFCQMujFtxftmA9xcVeGcyFj+b2EsV+YoAESNdLq7BcPQgIJ4xhCOWcByVru4+cfDyT4Af1SNolzg9JUOaYAzdo5AmEb2D0+AfqkRsoh4/fdNMC6InEDraGg36epTMBPTtg1b088O30wZ0d1ENehnkGSyH2MN2EoCWJhluJATiWFgy5daK1/0OY0W2C/UNKlzlh1Q2qkfrtAG9o1o2aL0UxLvY6/YN0R51M1O0Z6OWNqmcgBTX61BOJanvMjCQ69DQwp6TuWB02IJxNoCJSeam8Sw0DYtFhuJ8Wz39vgrTQ0qsTNAezbJxj2kk5egZUqB1SI56AtLQpEcdQb9eq0FlhQK1FVQUAt9D4JuZHTqYuwY7GZZpFxcHbYQgB3NjVsxNWPj/GnF3xYT7twgKG/LCoJyWSobFbnGulQHT3WoMdqnZgehQUc1G3HiSANBeDZ7CRP9xgpmDgd4CDI6cgH3sFAZosWYHT+PWdD5u3WZ+e2BB6ad6vPOZEmW31eie06B7XomW5XSCkIIRKsfIQC4uXbWgoiJbGrjoZ4NqHtdK661G+ByFze0cPoZyBvPawWx0jvF9msxnfjuBVD1D8+7TbPSvwHH3K3AO/xs4RbyBHbt+hG0BZ7Hd7wy2+Z7GCz7s/Xnd6nuKdZLfK4IDVcLRj8rhacQL7hpCouRjBRx8dAQkE85+ZniH5sI/vABBkcfgxkD+lIOJcGQSDl6f5/U51vNpeGp7LA5pj+LHfbF4dWofXl+Jx9urapybMeHiUB4uE/ZzC0q8P5eAt2f2482J3V8NIG7Oz8HZNRwOHtGPAWF5x8DN+6hkrXwCE+Efkkx7lU57JUP4AbGnRCZt1/UNSWMuSUfYXhUUOj2Ky7OoGlr0EJDRXiXmBtTYmDRhjZRPDRGSXhGeCRADYIfooapSMXV2P4aDgnFovx4+EVa87XUQvwx0wY3svSijTTo3okbJlIK2gI2SPVw7QesdoS1izyfWeHX2EMxOixQoqxtNuFypwZVaFS7VqHCxVo1GhthWNtZ69uw1DPxl0yZUTBrRPMLnIxSki/6cMNvtOoZfMQrG3NSqRCnV53Iz3/AyGa6WqlFWYUbdddrGCvr6Kp00+z7axQzVyt9pFYdA56CP2WakOxujQ+JAOgsWxo1YnzVig0H4Hnv2jWk5NsTGpFE1Fvo10pGfI70a9HSzUTPwt3bmYaCLVqrvJHMGFYMhfHyykKAdwxQb8PCwgOZFLA2dxo05G27dzcXQoyxc+VsFzn+mQN26gqqgRtd0Blpn09A1mwH7jBFj4/nsXIrQ1UU16ufjgXy0DWSjge9Hz0gOhvm3RibOYGDsBEZGTjLwn5ROMHnzvZPwYWjesfNlOIa+RFBY4aw9L2N78FnaIQHGKWzxPsk6IdVWnyJsZ8jeQZVwpAUTMLzgISMgqVSQFOzwSoWDdwaVJB1OfjJ47dIgcI8BgREm/p4Kf7UtjXCkstIJhgx/9Syvz8YRlGiExBzF6eo4vDEWhXdvpOO9W8JW6dk+bChmJr2wosJ7ywl4a+4QfjIZ9tUA4u78PAHZBUf3A3D2OExAoiRI3Jg9PP2YPYISERiaStUQ9krkDwWtVTrBERYrjcqSgV17ldKiR32OAdfK2fBpGQZ6FOzp6Ofpcx+Q7iV6xf5BWjBakfJmI94uZXjXHkHNznCcCE/EkUgDvMKz8SP+7V89txX/FOSE9uIkXBln42TIbJ/XYHhWjwn2iItLWZhftmCYQbi7T4RJcUKJVYKkuIqyW6zEO5fleK9UjlrmjfrBPFQye5QyUFcMZKKhTzRGA+rrVCiukOFCqQznCMEl5qVzJUpcEFWswHsXCcg5GcpLtCgrYw9fzufBXDXUYsJ0jxUThGSghYrWwl63RaxcFscO0XYx78yyZ16dM+P2upmA6PBoVo0P51T4cMGI5TFxyLQaI8O0OUNqjA7o+JiqOFJIuE5iePIEpqePE7JC2spCrE2dwMrIKUz1vYQZ+2tYnTqNuzfzcedhDgY/NKPk52qUf8DMtarCEHPOwKIavQvMSfMKtFMlBqkGg8OFaGeeaOspQOdgLnOGDa3DOegeKaAqUbEmzmJp8iw7sjMYHDiLgb4zeOv8GQQcPku1eJHqcRaO4SfhGHmCgJzEVv8CbPUuwBavQmzxFJXPyuP3bGzoZuYMPa2UGjs8U7HVLYHqkYAdHsmEQwCSSkBSqCKpVBAZgiKUCAhXY4tbCsGIJxixvMZuXp+NwV/9MJqAHCFcUUgriMHftCXg6irzx03aqhs6lC5koZyAXGQH8f4aM8jiQbw5u+erAcTT6ftUkReYQxzhxizi5r4Trh4RcGNP7uUXTXsVR8VIor1KJyBiLzvtlX8qLVaqpCBCTXbvVSPikAYH43Qw2Mx47yqtU4cGE8Ma3Jw1YYVPfnSOcHRSBq8akXPWjCi5CfEH1Dh8yIDMSBmUu5TwDM9BeqASdS7h+MzbBfb3Y1A6rkQNe9++RbHgToMbDJ8PNtj41oVNM6GP9sk+QJsgQjfVpbZBh8pKLa4Wq3C5TEm7RXXpy0UDrVl1swmlNQZcLFHhHH/+3mUl3rukwrusc1d1OHdFj3cvqOi7NbQkGly8rKalMlI5jCgr0eAaf6e+knmh3Sod/9NHm9XZYEFbXRbar9NC1mbB3mZGJzPWxGg21hYs0oLBNUL+gNbtF3wNnywamT00WBhlNhqRY2hUQQuowSCB6pwuRMdcITpv5GNqNh9rtFU3h05QgU9TdV7G5MAb7OHfxtLyi7RXOVi9k4XxDarAhhG9t5gn1kyY4fsyTUs3scIATuWyU2W7h3LR0p2H2sZCNDHotw1STcQq5dECTI1SrQbPYHKKyrRCCOdo5QjMYN9p1DWcRaLpZTjveZHKwdpDOGiFHMMKsM3fQrUw4wVmihe8WJ4mlh5bvbTY7k0wfNQEgBC4s/N12QkH1wgCchAOXkepKglw9E6Gi286fAlIMAHx26XCX+8gHFuoFlsEIEd5JRzPRRGSwxIg4mvviGjkvS1D5awV5StZOEfben2O2WoqG2W0XOdvJeKttQP46cpXNIolzbJ/PoH4XdZTVJUtcHd1gKeHB3x8AhAYHInQ8FiG8wzsDJdLS+Hd/ZLhGZQKnxBxaJ1cAkfsTjwUb4DMYMWZV204d8EonTXVxIb0brEJmXlGRCUYEBxpgk94JgIPWRGakIPwuFyERubAa3c+M00O4naZ8HZGMhuzFpXMHh3zeoyxF17lh36PvcY9Bt5FNrQh2rf+UTZU2id7Vxa62rPQwqzQUKtH5XU1KsRQM8GoZ6OtZai+Xm/ApWtKQqDAu+epEBeUOHdRjfcJRXGpCeWVFlwtMeIK6zLrIqG5VqxHabEOJbxeu0b1K2EmqrehviaLYZ22rdqKuspMtFYQkkoTepmF+joz0cfMMz9vwdqyEbPDSumYng/n1PhYUhMtbo2o2FsrCLiYo9CgdZlZiqG7c9WGvqUc6QjU1cHj2GDeWKbdWR56GRODP8PU1Hmsrp3C+k0rltYzMbtsxQx/d3bViulV5qA1AkLVGl8zUE0y0UGr19TP59plQ23ncdR1n0a9/TgVhMGfijUwcpzqchITcyexdLcQi/eOEa58jI6LXaFnYHvtRexMfBVeB1+Bx/6TcN3LXLHLxgBOSxRgwI4AE4O4ETv89FQOjWSTHHyVtE8qOPvEsON9TmpXbs4/hKvLNn7tClc3H7iwI3bz2c/2E4+gcCW8ghX4q60EY4sA4+gXADmyCcjzVJHn4/BDh1hEK2mfe22om87FtXl2YFPsLAdy0Dipw8W1ZNqvw3jjZuRXA4hUj5fGf+n7YqmK89PwctsCTx+xbfcovAmFq08y3PyT4cEcIiDxDk6FP0N8ULiwWwppGf2h2ExEHkpHdFwy4hJl2B+tgt9OHVx9dfwdE/zCsrA7Nh8HlScRmX4KXnvy6EcLCUke/CLzkarNxvvVbIi0ZSPzViyyt7jJD/4ue83VdSOmZmjjxmnnhoRyULFoe+prdKgjVLX1WlQzsFc3ZRIMMx8bcL3OwB7RiMoqDUrLVKjhtaHWiFLap0tUipJyo7RNt5KN/hphEWryznkN3mNduKjDhUuE64oRJdeMqK3KRlV5JqoqCV61BXVVzEGEpK+Gz5U5aLYjE5NDDOmzWVhfNOCWOMFkzIA1WquHi+KsKjXuE5AluwLj9nTmC2ahsXypV59kJpi0Z2OqNxfz/QVY7GQG6TiGxf5XMNH3MyxMvIk76wW4edOC5RtmzKyYMbVoxdicEQPTKnTPyNmhyNG5qEAX37em0RyU2fm82YlUDOXgOu1mFeGoHS1kBslD82geeqgkE0vHMHe/AAt3WWsFGJ8uQGXzCWS9eApH5K9gX/Kr2Jv4IkJjGL6DMwkHwQg0wpGPnXdmwjPMCrcQE9yD9XANVDFwq+DhdxAeLk//oW2JNYKPlz95OD3NTngLrbwfnL0SaK+SN23VE0CkegLIkceA8Ovn42nFtdC+QsXozkc1c1Q9O8qBbjF4Y0QFc9f7azF488bBrxCQ/0YJC+bszXxCOFyFgjwGxCtYAJICv9DNwB4cLkNIpBwBtF7bXaLxwg7mGs8EePrLGewN8N1pRkiEDbsO5GF/QhHiNC9jf9rLfIPzJAXx4dU3sgBpxlycq8lG60gmZhZzscYe8uY6e+RbFkwvUznG9fTSRrT0mtHQYUZ9M3vzOh2qCEh1A/NNq5FvmJgtz0IjrVU9laWOkFRWMtOUKFBTLkdXIwN5OYEp1fB3qXTieFLapRLmo/cva/HOBTXh0BIKgwRGMe1heXEmFSMbNZVZqCMc9YSqhgG+s5q5pJ2qwRy0zOezSGu3Om7G/QUzPiTct2fNmB+iCk6ocW9KhdtUlfUhKsuQDKtjVIJ+BnGG9LnObEzydyfsOZiyF2KEFm6+7RhmBCADb2Jl9iXcvmHD8poRc+woZmmrJmmp+uaU6JhOZVZLQutCMhpmk1AxRkvJrFHSR6CZNyqmclBMy1U+m4M6WriG8Tw0Dueha4pA3CvCxM8LMP2oAPPrRejsO4bCl4oQI3sRUWkvISbjRcTJT+NA4nE4+BsIiBHuYdnw3ZvLBmuRTuh0DdJKYLgF0S6HsPzC4On8vc2O9k/ak9dj1+Ls6oJntkdvqoekIDF/qBcEEMJiCUCEirDRb4snmAZ4HsjG8Z/ZpMMZapnnWlp0aKFLaBxT4OLqUbx559CfHxBpNbB47PwUXN0F6XGERHjHpM8VRADiEyIUJB1BYRkI2SOjXVJQbVKw3ZnByplQecTB3ScN3v46hnoLdu/Pxd7oQkQnn0aC8hXsiTlN9chn5cA7LBe7o3Nx+vUCVDD82sdtmBcHRSzRcqxmY+lmNsYXGYTHjOjuN6Gzyyyt4G1pFkeHGhm8+Wa16xjejegfziY4BlTXisPhaJMYtEvLtbhyRYEL5xnOGcArSmjD6owM2ZtH/zQRlOJSLS5f0xAUPYM51YfhvUGcvlhpQBOVouW6BY3MHPUEpLYqC23VZgzUE5BWCxYFIOzNFphDbg0TDvbij+YzcXNSj/kBJQO6ArcnFdiYVGJDLGXh1zcnzbgxeQxr7NVnmReGB7Ix2G3DKNVjuD4XU43HMdr9I0yMvI/bK68y+NuwSPs0T/CmeR2YVaFzJhWd88noXUlCz3IKOhbFnMiPUDn9Csppl2omctE0w3A+R6VaKJCqcdSGttF8DC+dwPT945j5qABzD45jYr4IV+qKoMg9g0MpZxCTfoaf0xnEy4sQcTQPjrRXrruy4LnbAucgPVyoGi6BWrgEqCX1cA9WwSskg67D9w/t6E/WAUqAOH4PO5wCN0EQ6vHEVn1eQjWiNnPIY0CecUjANlo7h51WRCSa8MrbWaioN6OKnVQFq4ZWtnglDm8/jPr6AHF3ZpD32AMX78RNBWH4cg9IeQxIGlVhUz02AWEeiVRKw8MOLofh5BoNJzd6Uc9EAqJGSJgFEQfzacGOIzaVgCheQvC+AniGsieit/VhUI9TFTB/FFIB8jA8kY+ZefasczlYWKHXXstG37TYNGREc5cO9fUatFE9mthAGxnARQbp7OLP7QYM0F40t7HHZ8MvJyDF5YSEAV5YrAsXFXjrXTnOMYtUEIhK/uzyZRWuXRWKQiUiDDWEoq7WhBqxnqyRYPD/72L26Kgxo5VQ1NNiVZdRPfj1cBN9cAPDOW3dAnPPSq8F96az8fFyDu7Pmmiv9FgZVWNtUi6tCL4nFj4uiLOtqCITDPJjeVhibz5BGyTAtotT51uLMFBznICcxfTg21herMKDm29gYyUXKwu0WOwopheolBPp6F1IR/9aCnpXk9C5kISWeQ367l5Gw/IbuL5wEpUzVhZVb9qCtolsdI/Z0D7IGs/FIDPHrLBWGwR0+RQa24qQ82IRjshOIyr1JFI0L0FufBWpmrPYdSgbDmygTkFGOLHDc/DT8KqBMz9blwDCEaSB504tvNlBeni5/qEd/Qkg4mt3x+9jy/aITfskgJAslIDiSQkwnjwWgBzGD12SJQXZHpQJlxAdklR6XLlUgEvnbDj/PjNkEz+/mRScu/MVLVb8r0oA4kYf6eJ5+HM43PxT4R6YKgEiJgv9dqYTkDQJEHFLOKEgnr4CkCNwdo9iERCvePgGKhC6Jwt7j+TjcMIJxGecQVzGy/Bj/vAMFSHdBt+IPChteWjpzMUE4RifyCEcuZhb5JU2a4ohtocfdOOIHtU9VIQ6JXODhlaHDbpKvFlyXL2qRE2TDu122q9W9vxN/BntVUUNf6dR5BGhJhqcuyCTALl0RYsLV3R496KGj3W4ekUtzXm0ME+I3CLyS32jAJCq1Uiv20BIarPQWkXVEfmDsPTw+718DmMEabHDgg1mio+ofD9fzcXtKdohqsetaT1uEoz1GSVuTMlxe16BpVk51mYJyGg2lgn0/FgOIbFgpEccFkEFqS3CbMsZZpK/Yaj/CVZni7A4JZaw2LAksodYtTuRiu6FFNjXkmix4qgSCaifUbCKUE/FqJ21oppBtpqZqHKWnciklfaUqsuqIzi9N/Iwu8G/s3YC7b0vwZx/DFHpxxGVcQpH5SeRqD7NhniSufBFBERasMNXz9JKI1UOvio4spz8lAREwTYhAFHDKzAGHu5bv9SevliuTs/i+1sObCqENFr1+PrF+hweMYp1BM+5pRIOo6QiO3w18I/QQ5+djbOvZuKVH2fi5XeMeK9FhXMzsq8HEFHurtupHkcJSMofAyJGsR4DIvaxi/wh4BBXAYQDM4izezQfH6UfFctVZAjba8K+6DxEJZ1EguwlRKW8BB8Gcy8qiM/uHATuz4ftbD56+nMxPUXloC1YJhxLtFdTy1m0A2yg/FAbmU3E7ZAr27Uob9SiolqDMirDpQsZDN0K1NEy2YfYE4vJvy7+23q9tLOxqd2MunoqCq3WtasKXCtWUzEMuFpMBbmm4/eoMASsgRC1ifVdzUY0UpUaxbZdqklvowWDLVZ01wklyUQnv9dyPRONBKWn3iLlkNu0SQ9mC6Qjej7h811jCF8cUuPOtAYbC1osjCpopWSYGUvH5KQMK2IzFl/j7eVc3FzOJwT5tGIFmO1hLmkvwkr/y5jufRmjg2cxM5OPKTb26bksjM8b0MeG0DaXgvblJHSsxaNtOQENzCE1kyq0zGSjfdGG5hlaj3GjNEFaMWNA1YQFxUPivhsmlExnomehCMOLr6K+/RWceZ15Q8bskXEasfJTzB0naK9OIVFBxZedgHsI7c0XRqx2+Cgfj1opCIiS7UIDj2DmD99IuLs886W29MVydnLE955jVvjhEzjEfMcTWI5sXj/PIvx6azSe82S2DdRjq59amnB05d8LPaKHwqaDzGpCjDoL+T8lLFX/zWN//k9LyKObqyezRzyzx2NA/AhIQKo0guUbkg5/AcjuP+SPwN3pcHKPJSBUDg8BB9UjSCxXEXMpOhw4mo3oJL7xspex9yjzx+4CKYP4MqDvpP06/iMC0kvvzRC5MM2AzpC+tGLF5JIZQ4sW2NmD9gzQ+3eKgL55n+/KZj3Ka5gbyqggJUpUNxlhZ4/cQz9f30IgrutQy0YuRrQqqA4VFbRVBKqR9quhPhOVVQbmEz1KCEp5iRrVDPMNDXpJfUTAbyRUnbRydmadIQIi4GgnJD383dbrfB7MIh11Zmny8CYB2ZjMxQdzVnzE57rao8HaoBZ3xzW4Ma7GSGcG+tpT0dOZjKFBFVbFDTNpm26s5WB5mVZrvhC3F07g9mgRlhiWF4fPYHLwRXTOHkfXsg1D07R0zDRDs2r0LyvRspiMluVENN2MR93NOFTMJaJh0oAOgtQ7T0imCAgtXvmoHu+xg8g9Z4H5qhmnmJF+VG/Dz66+ghd/+mNo816lYpxm5hBwnJaASFSdQpr2LG1WEfaL1biBm+oh4Nj+GA5Hv00FkUav2GDdguRw9wz6/Kzo/7AY3B0dvQiIgOHJCJUYtfoCJH8U1o/gqR2x2Oolx3Y/AaecgKTBNSADfvvUCDqsQMB+Zp9IPdJPWGF87dTXCIhbIJyk/CEASZUA8QhIhqe03CT1MSAyCRAxq+7PTCLgcHQ5CjcG+83FjsnSzX4iDqqYP0yITSlAIhVk98Fjj4d3CyiXBQg9XIicU3lobc/FyGAuZkdzMT9O60FLMbuWi/FlCyZpScZHs9DXZ0NrB311ux61nXrUdNBCtWpQIaqbgdqeibYeC9WEIa7OhKoasRxGgyslKpTwWkVImmif2plTWts3s0aZgISZpLRcTVVi4CcgXeLghVYthsRJify3E+KsrDYLbZYJ3dX83XLmITEHwgwyzuczx7+51m/D/RErHgyZpRMXbw1qsNqvwIxdhs6mFLS1xKOzPZF2SovbzAWPlnJwcy0PKysFWBSAMDg/XDiN+zOnsDR4HJPDp9BBu9awqkP3hAb9hM0+o0bfkpqBW4bW2VTULMaj8mYsqhbS0CbgmLJiYC4P3VOEhLb0+kAu8l7LQbIlD0dtNsTkmHFIlYNDtFKR7LAi449jf9JxRKedJCQncJQ2K052XFKPRFUhdh7KgqP/prVx8H1srwiGk7+KIV3kDzGKpZQ6Tzf3zQPV/7Q9fd6uCMg2hyA8JYZzxYy5KOnx4xzyBIytAhLx/Wh8zyEe23wUm3B6PV6u4p0KV3/mnZAMuIXI4EL1ipRl4UjWS18PIKLcxeSORySt0mG4+cQQkHh4+CdSQVLgszMF/lL+SEdIRAYVRAT0FGx3ioajq1jwGM+vk2jBNhc7ilPmD8cbpQPqYtOLEBiZC0+qh3d4AQL2FmLXkRPQWAtQVkWV6GJDZGMb7rZK8wNiNGtqKROT8yaMsBftnWBPPmpB8wBVZECPyj41Knu1aOg3oo4WrLSH+YHqUt1ioKIwh1ARqqq1KLuuxVUCcJVKUUXlqKc61DVSLRoFJFSbKg1/rsLFMiUqqrSor9Wiv82A8R6ztMR9uE0cRZqJLob4tjIDWkto36g8TQz2A80GzPSZaatycHckGw9HrRIgG0PiNmoyDHemobUxCa3N8ehqTsBonwZLIyZsMNDfWsrH+sIxLE8XYE3cJm1x8xbVN8YL+fqPM3xb0Tqvhn1cjr5xFbpoo/pp2ezMNS1TMtSOp6JyKpH2KgMtYwzvBKSHHYt9IQd9C3m4UGeD/ngeDqdlIzTaioADZgQdzMGuo8cRdvQY9sTmY29cPg4lFOJIciEOJ+cjOjWXn1MeEuWF0l3MnNhJOvikExKFpBzOhMOZ2cM1SEFACAcbqUdAPNzddnypHf1RmyIgDo4e+MG23fjrF/bie1sOEoRDUs6Q7NQLT0ooCQP6lig87ZSE7d4ExFuGrR5ibRcDuwc7bu8Edtaby1Y8QtUIPGLGQc3XpCCbkzzfhZvTU9Kkj7urMzw8AuDpE8YgdlCaCX0ySbgzQoGQcMqrTwJ2OMfA2UOs54qHX3AKggmQOE1lX5RWmk2PzxA3Fc2RbiTqEWqFd0Qu/PfTYkUdQ6K2EO9dzpYOoe5sy0a3tKnJQrtlpnqoGEw1DPAGDA+xR++3oLvPgoZeAyrtzCG9GrTSOjSzUZYzpBd3UBWoLqVitSxVoKJJhaoGHQFkBmEOKWd+KKsy8TGVg4pSXkPIWvQoq1cTJA0u065dKVaguVqHfuaRLgLQXkub1GBgmdBRqUcHf7e+lEU16Ws1YX3ShjvMTzeZf+4M2bDerceNbg2mO+QY6RL34UhGe00sOq/HSit5xdm+q8xLt6cLN29VPX4MNxiw7y6cxKOVkwTlGGYnCgm7CtX83bbORAbsNHQw03RPK9E2L0fTnAK1oxmoGk5B/VAGumip+uey0T+fj/6lXPTMFeCli7kIi8uGb4SJHVIWrxYEH8rD7tgiCZDwowWIPJqL/YTkQHwuDvHziUrNQWwaAUm3wdfPH64uDsyVHnDxCIMrc6mrn7A5MrgHKzaHeINU8PSPYlv56/948vlJOYuFspvtytXhaTjucMD2bd7YsjUUz7wQQSD2bwLzZCRrWzS2uKYw8whAMiQ4tronYYdnAgGJhUdgMvzD5AjZZ0SCKgtZRQV/fkD+eBnKF8r5O+wBGMBcn4OnuxN8fLzhH7gLQQIWhnYBhlAPV6/N5fL+tGE7CVDEQTWi4rMQm2pBQoYVe2PM8ArR8E01wD00C14RVvgdzkFEqg1nf5bFXpyZ4TqzhhhGbd88rHl0SoHuETk6xHlOA2I1rplh2oo65oPr7OXrevXSku6GbuYKqkYlG3JpPYGgepQ0aHCtQb15rdWgVBw32kTrwRxRxsdXxBwJIblSz5+1qFDTSIUhJDXVRnS30bLwb/WITVa1ekyx5gjaINWll3mlhxmno5EqQ/VYnLDh5uxprI+dwq3xV7Bsz8Vih1a6l/lIWxrsbSnoaohDT2sS7P1aDPZmYaY7B7eGjuH++EmCchK35k4RkNMSJLcXT2GRKlJRK8O1awmorYvD1bZYlNhT2QmwRtOYORSoHslAxVASWobk6BzWo2+OKkxlqh0pwMm3crAv1QTPPYRjNyssC/6RNoJRhL3JZ7EnrgjhMfmIICD7jtoIiO0PgKQTlrh0+Hhtjkq5S5//02zgzzKfbqWd8oC7Vwg8vPcwnB+Ap1cQ28h3/3NARD1pX9KQr6jvwM3xabg4Pgsnxx1w2OGBbdsD8Oz2A/i+QwKBELaKId0zjWAI9UiSrL8H25hwMmLRY9ghDTOTBW9eOPPnB+SL9cUb9IgSL37zDfiOBIyryw8YunYzd8RI6uHk9gd7FUQLFhohx74jOvZEuUhIz5Fq9wE9yZfTQ4rRDx2VhB9cZDZCorNRQK/8xjkDLl8zoZ42qL9dw2Aqx+C4DD1jatSPKNExrEFHuxaNbKx1NbRJYj9KlwE9VJWOLgtqmRHE7dVKytTMHWpcvKbA5XIFignHxQo1ATGjrs2G2pYsgmRCaTUhqRKA6HCthXA0UXFEVqnUYYh2qZ+WpV/cM4OwThOGGSrNOHPPYLsag1Qme5MS86OZWF8qwK3Vl7A6cRJ3Zn6KpeFj0hbdqQYFxlvSMWZPx0B3Iob7ZBgZMGKG2WCxN49WjLaKgKxPn8CNWUIyfxZLU6cxOylOMLEREAJQlsDXmYBLrUdxqSMJl9sSca0/jflCQWBScKU7Fk0D4gA4HXoXstExnodT53IQfFQP990GeBIOr10G+BCQwH3Z2B19DHsTT2Nf4klExFFBYvOwLzYHB+MJR3IuYqgecRk27Nm3H97uP/jSfMZmERi6DHeX71I5fsj6wX/wb/6T+pOZ9iftyp3lSgh3uB3AC+7p0l6SHV4CjlQ4eNLqeYpVHZt3SvPfzU6Y9j78iIaQm5FV+F8cPfp1l4vT97B9ewS27jgCB2dKr2ecNBci7FUIvWsYw/v+KANik62IS7EinhkkMFwJF18RstIZ7GTMNBp4hWYiIDILMks28l8x4b2LRtQyLA/0E5DpDAwNZ6B3UIlWhtTGUQ3qaDvqapX8N0pU0x7Viw1bXeKg6Uzp0IhGsS++VkclYPYoF3MmatoqNYpLGeSvZ6OyLpu2ykSbpZcmEYsrqS5Ug6v8m8XXxbotZhAG/JG5XNiXrWgcy0I/A++4OCiBNTSiQ9+MCm1jCvR3EBBav3trVANCsjzB0D2Yj/keK4b4fMa7ChjwFVigFVoYlWFx2IRVcUfc0QJssJf/mDbq/tgxrEwcxwwhGZ8somIWsUMoQFefDrXMLg01BKQxHqVt8bhKQC52JqG4n9ljIANXepNxtTcRDcO0hCNiX0g23r1uw950M1xCCUgoASEcQkH8I7IQfIBZ5EgewmIKaK/yEUlA9iUwgyQye6QU0FqxMgpohy0ICfaTzlj7jwH585Wr8/NwoCPZ5imjraJ6eDDf0lo5UD0cPJPg7J0Ez4Bk5qN0aYAonJ1wyAErYlJs3xxABPEuTi9g+47DDOdRcBL2it7Q2z8JATvTpBXA4fvUEiDRCWYGdCuiEy3w3akgIPSw/mlUkDR4BckplQb4hVsQyX9nPaXHexc0qGbD7eiR046kod+uQmePCh29SjR0EgralpoGNvwaVhUfCzURQ7NNJjQzDzQxMzSxt2+QQriOvS/tVoVGGuatb6B6EJAq5pBSBu0ywlBJkEr5s8vFaqqXEqWlWto3E9oXs9CylsUgTLu1mElfT6Va1KGZcDQt8HnMK1BPRRibzMSNNRturNqwPFdISPKxIG4bPcDHM29igllpbkiGpTElZpmhZgdpx0ZycZ+Q3B0TxwDlYoRq0Tyciz5xsuL8cbSPiuN3FGhsSkY91UMc21NiT0SFXcYrFbE/A2WDwl4pUDdOMGZoA6ey0GDPR5rFCNfdergJQHbpJUB8wjIRtJ/qEZWLXVF5DOeF0hqr6LQTDOXHaKmOIV52nMpRgDhZAY6maOHv+59P+v25ypmZZ5t7CuFIJxgsNwZ1t0QCkghHz0QCkiidAhocJpMOZd99UE87aMZrrx375gAipNDJ0VUauXJwOcoQFwd3PnHvgBQEhqZLt17Ys1+NA9EEJJGApFuxL8ZIIAiIXzrcAqgggelUEBl8QnXs3SyIklnx4uvs0a+q0UwAWnsZbnvS0d3NRtmjR2O3GtWtcpS3KZgX5MwVcmYJNa2VGY2tzCN1YmQqU5rDqGa+KCcUxWUqXLkmlrjTal2jharJkm4PXV5hlJazlxRrpYWLJaViL4gSly+pUXPdJM04t61molssI1+xYHIxG6OzJgzM6dEySyjXFLi+xIA8w1y0YJUOU1i5SUBW8jA/bcHioAnTnZmY7c5j1tBhqieDYCgxJu4pYqeKEIi7w/nSyNfCUB6G+XX7gAXTEwVYZXDvGeDrqU1DY10S6hrica09FmXMG/XDWtQM6FA+rEIxVaNikO+V2JjG59c1WojCVzLht18HlxDDJiCSghilG7aGHsrBriMM7VSO/YlFOCo7i3j5GVqqPwYkgYAciU2Fn9ezX/rc/2z1ueV6ip2tj2SvthKQbWJXogRIApw8xehVMtz9UqSb0obsEdstdNi534R9UUa8cvYbpCDutFeODoGb2cMlnuoRDw+fJPgGphKQDOyKUCCSAf3QUQNikrP4xmdj1wEt3PxlcPUTcGTAIyiDgV0O311aBOw140gKg9a7maipYNjsYt7oT0FrVxoBMKCxk9miXYWSHhku92XgfG8GLnbIUNWqlk6Ob+vMRkWNgY2K9qreiBpWGdXl4hU5LlxV4NxlBc5fUeJaeSaziQHFvJaUm3DpsgqXCE+ZWAJ/SclSoZnhv38hjz2yGWPixPVF9vKzeZjsM2BsmD5/WoumNQ2u3yag91WY2LBg5XYObhCQ9RUr5meNhEGLMbGBjAo20iin1crADMP52KBZ2jO/KEawCMZNqsgd2qvViWNYmKJFmzmG4X4bWtuUaGxIRlNDIqoZ7ks6E1E6KEddP1+f3YySXioi81jloAatU2KlQR5eO5eLYPamroTCmYC47jQSECPtFdVjn4WA2BB6OFdSkX3xhEL+ItWjiLmDikFIYlLz2ZHlI1mejwOHo+Hj/vQfFq/+OUuE9ceAuDt9H46uu7HlCSAeqYSD4ZwWSwDi5pNM9RDzcGJ6gYAc1iEgQksHYqCS/G/co/DPXeLgOUfHMGaPWDi7xsPNKx6efsnwCxJbcmXYFalC5CEtDscacTTZTG+bjaAINeHIkO7TvgmIDN60XL67NQiMZC8Qa8aP3zagrlqF/i7aqoEUNLUnsaHIpUMUalvYcxKS4jaqB339tS45qnq1aOsXe9SzpBnz0mpmCIbucl5r2ThLGcwvFSukPeYl5QaUV2WhuCITl0rFCJYBV0uYPa5qqSQaCRShJuKIoNG5bAwMGTHExjwn7lo7RlVgr74wnomhCSPaZ/VUEeahRzqsfpiLWxs2bNzKxs2lTCxPGbHAXn6qX8ewbsNIi5LBXibdcu3WSB7tlhVzg9m4NcxgP1KIW6PHcHuiCHfnTmFBzH00W9DAjFVZmSiNXlXXH0VFZwrKGcqr+Xqv2wn/oAEVI+wI+NxaJwvwo4s2RCYZ4EIoBBxPAPHabYZveJa0nip4vxU7qSI7CUpYdK40/7EvbjOcH0nOk8J5fEa+dKD5nshw5o/v/qcTf19ZPc44Iuu4OT/NgH4QW9w2AdkcvUqjtUqGs6e4A4EI6KkIkNoY88cBHTOsEm7Bar7O/9bp7l9PuTk9A0fn/XAgHC5um4B4+acgICQdwbvl0l2txAjWkThxk54s9lIWaYuli69MCucCDqEePqEK+IdpELLXhLBDZpx5PZOZQYN+KkX3QCpau+MZupOkQ9xaW8TGKA3tERuKOH+LXzcN6VE/rkd1vx6VbXoUE67iKjWVQo3rNSKo62ixaK+uKqkuVkKTi7LrZlws1eH9qxoqi9j/oSMcvJ5Xoapcj3H27vMzVukUxwn21pME4+F87ubE3pw4uSQTg2J1MTOJ/WGmBMj6BuEQdduKpRFxWzUtgdJgfSGfyiFOUCQgA1l4RBt0k7ZqZsCK1X7+3qDYZluIFQb1peET6GksQItYNVyVRlhjaRvjUFUfy4CetAkIoavsp3UcJNgDRhT3WfGTsgLsTc6EU4gOjkGZ0qpb5xCqB5XDdw/f9z1ieNeMwH2bIX3nIQZ1VliUFZFHs3Hg8ehVLNUjgeqRJDdj927/zc/66wjoj4d9BSAuztuw1TVOAmSbZwZ2eKUTjjSqR4pkr4R6+AaLVeQy7N6nwq79WrjTtjv5yaXrNwYQV6dtBCQSzm6b4VzkDx8BCO1V6J4nAd2II/HMH6lWHGSI8g4m6f5yeEijV1QPyV4p4b9Hg+B9RnpJK6zHddLI1EBfOuy0Ut0D4j4aBKVZjvZWDZraxDwG7U2zGnWdGrSxR29lQL02osc5ZpSaboIiJgfr9QTCiAoCUlFpwOUr/J3aHNowm6QgF5k/3r2kxVvvq/C2qPfEYQ1qXL2swXBvFlamc7Ayl0M1sGCBtujelA0PF7JxfyELG/NZWGYtrrORP8jGnY+ZG+7nYI1w3LmRhTszVJFhBvMeJVbErZ9n+G+pROv9VgbzfOn+6ncZ0jdoscSI1hJt1ozYBttVhOqybDRf16OhmspRG8PXEYPS5hiU8D2oYIapIhSlPVq806xH0UUD5EUmhMZRLUJNcAw2Ew4TXIJN8AozI4hqEUQgQhjOgw9YsPNAJsEQKmLBrsNW7InKlkavolLyJXsVn5GLFCUhSWOHFby5bP3rLmdnBnSx6Y65Y5sY2iUgTl4ExEsAksK2kyotlBX5Q9xScOde2nY/BZ2JaFOqbw4gIoO4ObvA1SUQ7u674em9D74B0cwfyfSGckQc0OAgQ3mMuEloejYijxj5QkT+yNgEJJDhPIRw7FYjMEIAokfIATNUmSJHqKkg6ejtyEBnH5Vk3MKwbkVDgxq1bPxVnSpU9LK3H2FeYHAW9/e4zl79/WEZGidNaOo1oooNSEwKipnyMrEnpEycc5XHXGJFCW3WpWtanLtAMN6V4533FHjvfSXOn1fj/EV6+qZMqkAObi4weM9TNQjHo0krPl6y4YNlCzYWzNhYzMKtVTb4eznYeJiLpVss/uzuciYeTtBK9dB69aoJgIq/L27rTJCmacPGCNlINj4Zz8OHEyKD5GOsLxddrcxRjdnSAEFtNbNNXRRKm6JwtTUWl7riUWKnnRzUo6rfhHdrTFAcUyMoSksodHAINMIzLAee4TYGc6pGhBitKsTehBOIjD2GvbFFiIymxQqPYUUhaE8CQvcrEcEO7FBiNqJSbTj6WD3SNYWIiU2En/cLX/rMv45yYwZxcnaHI9uVo1s4nNwP0lpFw9mLHbFPAryCxEa9DOwU+eOgFkHhajh7y+Dsky61rW8MIH+ozRlWD9fn4eXhAF9vTwQGhmNX+GHsPZSMqHi9dB/EUJIupNLZWyx8TCcgtFchCsl2Be1RUz109Mjixj4GXKT16e+Wo6dbhpaRNLTNGNFiZ3hvVqC+RY3mdi3q2zVotOsIRxY62WPXTjF/zGlQP6lFq92E6hb2tNfFSJYB1bzWE5bGOjNKywgLvyf2j5RdysC186m4fD4d58+lM6hTQa6ppYMaxH0M1ybz8GA+Hx/SXv180YZfEJBHVJDb8yZsrGTi9loWHtyz4d5dWqs1G1YJzZ3VTHxExbhHK7TBEP1oTIvlPjkWR414uJyDB+MG3OhT85qJe5PiTlJWtIh1Y41aVDdT5ZoUuN7CvNEWjSudhKM3DZftSlzt4XPrpiVsNkKZZ4TrLvXmoQl+9OBh2Qg/egZ+kblwCtDBXRo2Z+6IsGL34RzmjBPSmQFeXtvh4fYMPD22wtfXFYHBQfyc9mHvwXgciVUiMd0MmdqGgwf3wtP1e//BZ/11lsg/P5BO33FzcYCbmxs8PIPg4xeJwJBohEakIpyA+PJ9cPDKgKNPqjQ6+o0D5Mns+pMlKuKxl/N34OP+HGFxQkDQTmlTlSdVw9EjbXMlpl/a5vBuiAx+zCA7Gd4jDuux72gmDieYcepFFewExN6rQPsIrUV/AipaUmmr6MFblWjvJhhdOth7stA/mIeecRs6xMrVGS0qJ2m9RnVoGcxEfRuVpI5BtsbI7CJOMNHj0iWFVFcupKPyUipqLiej+moyii8koLI4hRZHgZIrBLDaiNmxAtyZzcUjZo9P5mz4bNmGTxYseESl+ID2StQndwjORg4+YkC/s0x4GNLvj+lwo1+JG0NKfDqpxyoBWWJW+pCK8xHD/Rqt0s0JPeaHDOikGtYwgFd3M2u0xVMdmTV6EnCtNx5X+wgvlfJKlxaX27R4t1EHw0taeEdqsd1fhx0BYp7DgoPJryIs5iSc/PXSgW3Pu6Vhq3s6w61YscCsF6yFX+ABaV3dH31+YhLQlZ+Vx7MI8N2BnSFe2LMnBMEBTl/6nP+vlhjlctpc7uJBcL3ct8PTJ5Svi47EXyHZMEeftG8mIKKkYcAvAPJk5lWstXF2cYeTR4IEh6NHqqQg7v7pzCMy+O6UIXC3gmGLeSV6czj4YHwmjCZxADWrQ4EuWqySvjj2qEm0VwoG8Qy09mjQ0yOOEM3GcH8B+vvzMDCei84pM2onxOgO88ewEdX8NxWNRukAuHKRQ4ppq84r8c476XiXdfH9NJRfSiMgaai6koKKy/wbpfy6lNatzsAcZMHiVA5uTefiBiF8QJv0ibjfxyqhWM/FbzcK8fu7BfiHO7n4O+aPR6u0WEsmqowB92d00l6Q+6O0WWMarM7oab+MuDWrYeZQYmncjP5OIxo6ZKi1x6OxN4aPY1DTSzj6k3BxKB1XhhS4zBxzkdnrpxU6mE4bEEglcAjUsMRwrhnhcWexP+kVqkYmXnCX4zmXNFYytrC2uaRIk2wO7lRtNz8C8V+oAoHxcv1reLl858s/+79ZfzJQIGBxcPHdHN3yYsfrJVYcC4v1DQXkT2tz7/HmC3F0CsQOMQvqLkYiSLm4DztfiLdQj11yBO9RSnffFfMlcSkWyqYGpgMxmP3xEfQ0y6gUChTbo1HTk4yGNhmq2tPR1qtFl7i334AFE8N5GLIXYLivAIN8XN9Dq9VuwPkWFa7Shp2rUDJvaHDlqg4XGcDPX1BK+9J/8rN0Zo90XL4kx7ULtFqEpex8GppK5Wgo06C2TGzp1WK034Zp5oSRoQIsTeXiwUo2Hq1l4+PVXPzTvZP49/tF+P1GPn6zQYVZ589WTHhwk2qxRkimNFjpl2NuVIHVORVusubZ8JdpA4eofk3NFtR3KtHSH4fO3li0dh1FNR9fHk3BlVkVLo5l4HK/Hj+pyEGyyUS1UGCHv4pw6KRh3NBoZouEF6UNTVvcZHjOmXA4p+B55yRscU7EVtY2lwTscE2AK8Pvnza0b2VJ7eppArILOzxorbzkDPAZUgZxC/gat9z+H5ejCFw/hIPTXuxwT6F6pEuAOBMQj4AMApLBsCVHSATD4iEtjsSJ/SJW6XZwVt9D+HWMO6aK49DVK0PlcBzqupJR18Kc0JqGGipLS5cGgyMWjI3mYbC/kHkln0E+Dx1dVnT05KC8wYRLdRq8f10hLVI8T0jOXSEgF5V49/3Nw+PE3Mjly7Rb5wnJefbkJUp01xO+Oj1qSjUovaKEvS0TU8M2DA3mY4oqNc8MsrBGpbhpwz88OoXfPTiB394v5LUAv+T3PlzLxI1VHe6s0GbNaDA1oiBYatxZZBaZl2N+Ph0L8wrY+xRobtOgqV2Orv4U9A2loqkvCWWDKbgwnoF3mV9OlRkgO2bErlihFrRU/lpJOZyCjXDZKQ4wMMHBT0s45IRiE44tfwLHdsLhKA7QcNny55/w+zrKUYygPgcHtyjsENnDS0HbLqO9ksEzWPntAWRzTPt5flDRBCRVolwaz/YWOxMzpPwRuEsc9qBC5BECkmBEdLIFvswkKR4x+Ketz+Dm2Uh09DKDjCegqisW1bVsQISkuCmNSiE2EWVhaCQXo+Nn0D9chC57HnoJR093LmobzCi5rsO161qU1OqpJASklBbrilo6XVEcHFdGCMpKVCimilQXs9E26zE9kIXlkWx0NelRdU2JsW4T7okRqElRNtwaNePuTC4+Wc/HPz4qwt/fK8Df3svDbwjIb+7l4uMNC5bXdViniqyt6TC3qsXKsho31zVYuCPH5N0MjN+UYXghA/bhNNgJ0NCEAiOzCmmH4PkxBV6nQtreMyI0QQAhsoY4zdAgjVY5B2fBJdRCQMzY5qWinUonHCynVDzvSDicBBxJEiDbXZIISDycXPcy7P5vrrb9ptbjuRIHtqXtzB4OAhBfGdyCFPAK/QYN8/5nJc2+8oU4Oe/AViHxQkFEkBLj2QKQwAwJhOBwJfOHBvui9YhKzMT+WJPUC+z1TsSUhycWXztINUhF7RADtD0ODY1JqGMOOd+Qgktd7PEZcsWdaicXXsPwxEnYaYe6qCC9BKSt3Ya6enF4nAk1LZkoadDhcjUVpFScyasiIHJUEACxKaq1XI1eqs2k3SCdV/XLW/m4PWXFdDdt0nQWfrmajV8tW/F3i9n4YCILH9BqfbZ+DL96kI9f3MvB3z3Mw68/IjCf5OEXH2fjxoNMrN/l/7VhwI0N5o77vN4nKA9UGH+YgZ4HqRi4k46hlXR0zcrRM6WCfUmGtjsKvNqrRupLBnhF6D4/ydAhSJxmaCYUFrjuyobr7mw4E5AtInMQDFHPO6ZIgLzgJOB4Akgi7VUcc6DYK/69r2dW/M9e3+HrcWM7Ukj7RBy9lXBmUPfepYH/Ht23AxCpHJ+Co7M3Q2IaaU+VPKI4uFis5BUjWH67xE5ElTSWfYD5IzrJjLCDev5MiXC/FLS7+uJWXhjVIA3NA0mosSegsSUJVVSQc6x3ujNwiY2pvs+MvukT6LDnoL3NjOZmE1rbLBIgLeJuu038Hr9f325GZaMeV8poqYpVKKdy1DJvTPYYsWLXYsmulyb3fnU7B//64Bj+8WYu/vF2Nn5/24Z/vZOH361b8WuC8tmSDbCvhaYAAFFESURBVD9fyMEvGc4/+yAXn36Qg7/9MBe//kUB/uVXhfjN3+fjzn0zFmizFsS9QZZprW5psfaQQf0DFaY+kqHngxR0LSdiYCkDTbRcDdNK1G6kofhjJYo6mS0yMrE9MBMOhMIhJBOOIVlwDhVg5MAtLBceYTlw5c+eF+rxBBCnJ4CIcJ7ESpTslYPbUbi4uEifyV8CIAJ06d42BMTBm/nDVwWPEA389hgQFPkNWov1X5U4eM7ZNYTqISPtadJMp7TEJDAdXsEZ8AuVPwZEh4NUDmGvxHyIRyBVJTANVS478YE8AH0NiWjqTWJ4jWf2SERxWxoutqbj2oAKl1nlgxZ0z51GfXcWAaJiNBhwvUbDEntCMtFYn4XmRgvByZL2oYtVvk11OthbtBhsFffvsOCXDNc/F6NT8xb8P4TjX+5RDdbz8Pv1HPz73Xz82/08/NtdAUoO/vk2v38rF/9AOD6iWjz41IJHHxMaAcknhfiU/3ZpyoAJBvTxeYbxcSVmlzVYvq/GwodyjH2oQistVs1IBtrnlKi5mYHylVSUfpCKt/gza48Be3Nz4LDLJp0k6Myre3ge3MJzPwfEbbcNjv4M5l8A5DmCsUWoh0sySwDCchP5I4r5Qxwm/eXP6NtYYq2Wk1vk5+rh4i/O5NLBJ0wPvzDttwcQN2dBugec3PfBxStaWqIslMMrWOz/EDPoKoTsJSCHNTgUb8LhRAu/LwBRY2eoEq+57cfPY7zRVxGP5o5kBvV4lNnjcbktGVdbM1A8ZMS5YYZv9voV4xYUiyXgfVpU9WgIEqtR7PFQ4Ho1ganaPDGxvFxspVVjdTILP6ciPJy14BerNnx2Mwe/v1uEf7h9DP/E+hUB+NWtAvzzxnH8+8Mi/OvDXPy/BOB/fZiP/3k/H/9OiH778zw8eJCHG4t63GJwXyVoy2MWrI/ZMM0MMTKkwoA4pb5PnEKixdRtBWapIk2E5u3WNLxRpcT7nam4SDgurqXgZyuJKJrUQFeThUhLAZzD8glELnz3HZdueOm5Jw/uVA6XUCucQszSMTxb3TKoIlQPaeQqGS+IcO5KQFwZ0Fnb3RPYmPazs/rBX4R6iHJ1fAbbnA9hm2e6pCKuAVp4hhCQXXr47v4WAbI5sfN91rNwd9kCDzc3eHoGwdtvD3yDDjOgJzKgy6QZ3sOJJuw9auSLZeDykcEnUI4Czyh8tssV429HobUlGVUDCaggIFfak3C1XUVgClE5ks/KRv20GeXsqcvG5CgfFqVERZ8KFU0aVNeJY0izUFtjRm2VCR1NJjxYycUvqRJ352xYm2TDHjfjw0Ub/lmox/0i/CNV43ePCMgHx/E7wvHbB1b8j0fZ+F8fUUlowf6N6vLbdZt0p9tFuwlLo5lYGLNidiiTj80ExYRx5qPuXqpVnwm1izq03dZKK4B/Vi7Hq8W0Uu/L8dL1VPx0MhU/mU3Cmb5kKC6ZcCDfBq8jOVQOK3NIPvwIhzjcwkMsI9ltJSBZUkD32GWGZ2imdACGV6hJOgJUTJo5+4gdeKnS8nAHlrNrKMQS8r8UQJwct+KZHVF42kEMSIil8CLX0p3QeYgO9lsDiKgvzrJ/vm1TrPt3eQbeHk4ICPDD7vC92H9YsbkUhR+u2Hvs5KtAbGAq5iP8MP7WJiAVffG41nkU1/i4vFWPhoEzaGd1DOShe9KIllk16iZVqB4hKEMZKOnPwNUWWrBGcWMfZhFmk+HObKyOFeDjW8fxCYP4JzfzsTJqwVhvFht4Jn77yUn85tMT+NsPCvCbnzNT/IJK8SHzxv0s/PM9K/5tw4JfTxvx64lM/GLCgNvMCx9M2bAgdgkOmKQMsz7DTDNnxki/kZlIj8YhPaof6VHxUIu6aT0qu3S43KqD7XU15KfSYLsoR2GVAvqf6BGcZIFTaA6cAm1wDrEQihzmjWy47xbhPIuAWKTyCMuSTlcP2JuDkCMF2Jd8FnsTTyFa9ir2xp+Eb7gJ7iFqNhoZXN3FqtynvvTZfFvLwcEDT+2Ix7M7aCkdUiU7uZ2q6eiRAg//b8lE4X+rBCiiXJ+Fq+c+OHpmYKu72HucIoESsEuHHHUKmmrS0dyejLL+BFzojUFZcwJq2oyo6aaCMIDXsYdumKKXn6Rq9CtQyvBe1ZOB+h45rjfK0dxikO5C1dNpxfRgNh4u5eOD+Tx8NJPNQF6AR0vHMNGVg4X+bPzLp2fxb789hc8+zsVnn1BBPqOC/CIPf3/fit+tMW/0azBblYaFZgVuUx1udVI9OgwYY4Of6BBLR3RYW6aaLJsxNJyJtgEjGu/R4v0zlezv1GihvWqh7Xq32owomQ5BB+UIjVIhLEaFoH1iFyBDeUCmdJK6s1iZK+7DEUJ1CDVL6uG1Jwd+e/MQcvi4tLQkNOo49ia/hIMZLyPB8FOkmN/GgZQzOJh8GkfkL+FIig2BAd5/MROE4rrdIRjPOSZgC23ldtc0OHgw3zLjegVkIIC59i8HkMfl5vwMtjsfoFymMHQyZLolw8Eng8HLgKNpClwpT0dDTxJKBxNxYSgGJd1H0dCtRF2rFk0NCnT2KNAzIkf7oBoNrWoCwRDcKkNPWwaGujUY6zbCTlvV3ZyL8Z5sWqkCPBi34c4gM8j8MdyZO47pbhtWe3PwPz95Ef/fb0/jHx/k48N1hvCNAnz6MA93F81Y6zZgoCQNbedS0V3O/7teifEGAtOpx8KAGSvjWVhbyJRuUTBOlWnvMaGmT4eWhwTkN3JU/1KB+lUNrnUZoLAZ4MOcJZZne4eo4CduRcce30HctcnfREiMEiSOYt6DgLiJ2w7QYvlKcIgT2H+MePVPcCj9FcTpfoKj2teRYTsPdeFlJJneRGrmT5FmeweHU40I8HWSVjX86fv+ravHKzO2OUXgBXHau5tYuiRWZqTDwy8dvsEZCN79DdoP8lWV2Fey1SlGGoHZ4iwCprjpYzrcgw0M8Qqc+pEctZ1pqGAGuTR8FMV90aizp6KhPR194p7obQrY25To61Whq1eB4V4dBjvkmOiRSbcfuDOVhfUhs3RO1Uq3Bb+cy8evVo/hwXIR1maLcHO6EB8vHsMH07RS6wX4/f1j+HtmjJvDNkx2iJvcZGG4TYeRJh3GalToLJWhs1qGsQ4VlgdpsVYKsLFgwyOG/fsrmwfd9dNuNTbq0dWmxvq1aPRS9UqXNCie0ODsRT1CD6sIhwI+wXLpEAu/3Uq+Xi12+BkIxyYgTkFCSTZnzD3CrHAXFouZw4v2al8iVSP1ZcSqfwxZ7nnC8D7keRehOX6NkFxCetZbSCYke2OS4On+1196z79t9SQ/iZPhtzsfxjZxmJxbKhzdU+HslUpA0uAXkiEdYPgXA8iTTOLk5E44EvCcWCJBFXnBNRXbxJIUfyWzSDr2x2fgp1dkqLQn4/JwPC6PxqJyKAnVHamoqUlBXVkqmqgybbRT9h4VhtpU6KlTob9ZhZleNmAG8d/dseFXSzY8GLDgs5l8/OJWER5snJL2gC8N5uHT+QL8/Q1mksUcfLqQgw+ns7Fit2KyMwtTrZkYJBgTzWrMdmgwUEcImxRY69PSqllpv07g79bz8SmD//psFkYY2NuoNi3XlbjzRiwehnrgrUOHYHpJjxfLzEgwaRkmVdJKVAGH7045AVHDLUgPRz8qBwFxEmAEi6s4XG8zkIv1Vs6BYim78f8v772j46zOrXE3wEV9usqo9957Gc1ImtHMaKRRG3XLBZteDAZsmokBY5yE3o3B3ZbVq9WrJTdsHCAJARJCQkJC6uUmIeXu73nOKwMXcm/u9631+60r+Y9njawyXu877z5773OegtCUdRTNyDDdKoCgq96O4uZHULx2JyxrH0IeMUpG8fWISkj4otZ7oYfIzFCoiEGy4M4MQqHwMkCtNRBAePoyNwpZRADhEI0flEGCPZyIPZx5L/8LgFhEs2J1UBGq1hVj13MmPH6wELv6C7F7WI/nuww4dKyY2MOEjhdNOPwdMw7xyObdxXhlVwle32NDy3OVGD5Uiw9mmvCrcw34BZ9jzDbh0pmNOHfhepya2ETeg9jiaD3eHVuL98bX4v2xRgJTI8511osS2bHDDgJGOXrJbHefsOHYc0aMHSrHubYqvEOg+NHsWvxkei3O9NThBDHKviMVeGFfGbquS8fhmEjY1GkI9ylEcFIpkotLEcgTg4PM0IYYxXZ3UCTXxNjoesukMcqBFeKMQxNK8irITq8V9Eo/8+MFo0TUmIenrUdM1kYCwa3IKb0DeRX3QF/7IArq7kfJhkdQUHMfcko2IyzyX3RbX0Dho1gOpTyQ1EaOBBBSGkoCiEb7ZROH8NjFILG+sqPFlClTxcJZVSgBRMUAKfgCIHxSys3DErOtuHV7CXY+W4jv9BXjkRkDnhzPQ1uPET3HCzH8agFOPG7A8d3l2P+QDS/tMOHA46VoeaaGwFOL75Hv+OW5JnxyoRE/vdiEH/zgepx+YzNOT2/EWAcB5DixSG8zPppYj9+eWYs/XNiID6Yacb6nEqcJCNMdDvQOVKK9z44jLxTiXKsD7w3X4/2pBvq9Svx4gjzK8WocP0js8Rp5o5dsOJUagCqSA3Jvi9iAUPmZ4RVkg3dQCYVRdHThhhXB0RZ6tdK1lsDDt0zUdMj8SqAkUCgCbQIYHnQPZFo+cOWUimrE5mxCtnUL8ivuRm7ZXcKgGwgUxsYdsN/4XZTf+G0U1lyPkFCvb97/BRhSrdFVpDZixQGohydLLANU3gXw9C2gBaeIDDpPGlgMDCIuVvparfKAhyadzDkbdA4DXHmaEAMkwAx1oJRv401a3VxbjPu+XYQnyZA/Mk5yayQX+1r1JKNoRX/dhMFXjeh40koAKcG+b5lx4olSDLzegL7XGnG2eyN+SA/8pRky55NNOH1uA2bnNmKWvQj5j7dPbsLF1g34Qd9a/PY0AeRME346UY+L3RX0tw5Mk+Qa7K/C8MkqdL1uxff6a/GTiUZ8n0Dzs2kH3h3hbolV6DhQhaN7y9CzNROHQoIQo8mDzIdPfItEmo0nNxYILKYwEYOYSF6ZEBRtJrBY4E5AcvMpoeu1SR0FCRAeHDw8xpuLnziXrRgh8fVIN94CnX0r8ux3IZfYQ1d9L/Q122HdvBt1219F/bYXYKrfBD9fp//fuyL+fxGifEJ1NVTqdLirOJWGfOoXACkkgMy3AYpbDAyi/NJ0qdQqMuV6Ias4XJk9yHjxWQjnbrGR9Qq2EFDMiMsx4t7dVnz3hBE7hgqwvTcHT+zLRc8+I8YJILNHzOh7rhh7txfh6KNWjL5YirljdZjiNp8djTgzXouBkUp09jkw2t9A0YyJ7vWY61tPIKBoWY9L7XX49XQTfj1Tjx+Q2b7QWY1zJ+l3O2ox3lON08PV6D1ow1x3Jd4eqMMc+ZC3+ivJs1Rgkpim55AdXXuL8V6hH64NSIKneLA5k9kIlS8DxCTKjblgTMsJm+HFCIziqjgz3Lw4LPOvJrh5c0idBeV88MfFQQS0yGQHEvXXIsPCO1h3Qe+4F3nldwk2qbrlKWx69Bia7n0RBnstvNTLF8UWLwNEo3SDhyKbPAiBQ/MlOLz9i+BLAOFWU9GJC+yg8L8KARDVCqg8AyXm0BSJEAbdkxsUF0LtVyQaO2jDeAYFGdnYIty8w4JH2/KxbTQL24ey8MRruTjynB79LxVi5rAFw6+YcfQhA8aeK8G7rWTQT5ThPK38787U4r036nBpjh70tgp0vWpD+8v0eqgeY+3NmCQfMnO0Du+Tp+Dcq59MNuKNTgcudtQTeJrIyDvEIeDpk9UYPFSKqbZyvNHjwJk2B073VmOupxxneivpvWwYOWDCh7GeMHmnQcEFPaIOhgFSBA19mJ4BRQQQvjZO+ees5mKo/C8DxCx60brT3wnmYGnlwzUPFFzz4JsG/8BwhMWkIDbdhNSCehRU3Y7ium0U21Fx/eNo2vYSSjY+iITUtK80G1/gQQBRKdQEjlxhztl7qH0keeXjXyiaFYbFFItJAosCIGJPW3UNVF5xcP4GQAwCIFw+yY0dtDyDgpMcw4qRbS/APft12DqQhpt6k7DtYAq+83IGjr+Qh+HXSWrtN2LkpQK8ebgE73fbcbbLhjN9pbTal+MXkw78/lwtfj7lwPl2NtkOnOqowxliktk2MuXtBKLJenw4x3lYazHXVYdTbQ04S3HqaC1GDlbi1AB5jROVmCA2uThUjwvdVZjstGO8w47ZHor+Mpw6Xoz3U/2Q65VB0ogPskxfFIpdBgh7EB8Kv1D2IcWQa78KjmLRD8qDviej4J8pfLkpgRFq7zCpjly9BFpvFwQGeSEmPhrpeXnIMJihs9ahqPYm6MrWIyRM+837voBDpQyAm4oAosqHwlNPADHAi/1HQCGCwo2IjLcgMX2RAETqoLeKLjQNzhr2HiyvJPaQ0eqg0PLQUBNJLAYImdpQG/yiysWOVuVtBmw5kYvrehJxS0si7joUj6f2JqHl9Wz0HTOg/7Aep4+Y8HZPGS6cLMP7E5X4oI9e6QH+w5la/OXNOnx6up5YYq0473h3phmn+2rx9sha/HiWvv9GIz48L80aHGupxlRrLSaP1mD0GAFlvAGzBKLRfpJfY2txpr0Mg0dL0H+sBBNtVsxw5WBrMX5W4AebdzKtdIXzACEGIZml8ZfklQBIsBH+YexFJGC4eXHwkBieh2EWU5zkYiafSZwLKf3oofD0ke7hV2WTqCNfAV+v1QgMkCMs0hfhFL7eKxcHeyglxSFXRsBNkUMA4QTMfIk9Apg9jPPyyoqUrIVUD/JfBF+sAIjaCQqfPMl7EEDc6VXOaSa0MvBcRKHT53d6guLKEZO+lh44K4ISc1F9bx7u6knBba1x2H44FnteS8DrB9PR2pKDruM5ON9qxPc7bZgdLME742X4zYQD73eW4lejZfjbJQf+dKkOP59twAeTdfjl2SYy2XX42dx6fHy+ET+9QAAhkFwaJTnWWYeeI9UYPlqP4XYy+6fX4/vvbMApMuuXyOyfH6xCb4sVba1mDHSS7yGAjPdY8MYDydgWGkkPrYGYgJueGcWJL3sQvi6WWMKkh/HOFrHH1wFCZpzBIfOVZvIp/EzQ+OZAo1ZI9/Ff+YpFcvZxOcQBoSIWHqocegbo2SD5zd5DmPMwI8KizaKJXGp2+eIAiHj18oan0N5GiT3mAcItJlW+PFVXeogCo6wIS7AjNL4aTiTDVqvzkFyYjzuJMW7vIYC0xmDPoQTsO5qGltYMDHbl4RI9pG912zAwZMX4lA0fzFbho+Ey/HK4FP82V4nPv1eD352txS9Pkewib/LHC03409sb8Me3mvC7txrxqzcb8P50Lea4zSixyBBJrMFj5DdG1+Kt8xvE7PNzJ2sw0VWFjlYbWrtK0NlbiuF+O0aHKnBs3IpNtTr4+nNf2QJRD8Oeiq/pcmhF2yMeBcEAkUAivIcAR7EYsXx5zLJnSAm8/NO/GFKzWM42/qehUSkgV6dA7aWHhtQFBzexZoCwvIqItZD/IIDk/C/qzfv/GiINnkLtGUJsUQxX7uFEDz6nLXNboMsA4cm6vvQQBUcTQOLttNJa4KTQY6V7DhQBGSi/PQ1behNwR1cUHj8Sjf2tqWjpSMdwjw4X+qyY6rfgtWkjXjlrxPicBR+OWvCL0Qr8ZKAEf7pYh397owZ/OFeJf/9eLT5/rwl/f28D/kTg+IziN2824lOSWe9O1GF2oJYAUUcMUonTA404P9KAub4azHYRcE5Uoe2wxCDtxFCjBJC+wQo8f8oO642cTUvySEvXRNej9isU13R5YrDYgAi1Ejvw9i4HM4ZZjFb2CS+HNkIKv6hK+NKrd0ACfLhBH/u3f3JfF3V4+hEo8sSuldIrX4TGVy/1go6Q/EdCmtT4Y8EDhMOTJIBCEyeYw5XA4U7g4MYOcm+WWDxByCABhEysBJAysU3qJMvHctdsrJGnI700Dbe0JeGmnkg82hKPl9tTcKgtFV0d2fQgm3D6pBUts0V46pwObbMmvHOyBO/1l+MHHeX4ZFoCyF+IST7/YQM++2ETPv/+OvpeA377Rj0+ofjZTD0+mmrAD8fr8PZYHd4aqsU7XJNOBn14fymZ9QpM91ejr8OGY0eNaD1Rgl5ikY6RSrw6VYP8Sjv5CJZXXK8gyUYJHMwgPF3LBM8gHqdcCnlgORRBdI3BZdBGVyMspXm+4XQNfV2PkMQaWi2j6N79i75WizB4zJtGFQiZmnew8ui50ZFB15PEKoAfj9qINCIqoZgMehkyddULHyBsHD3VqyHXpIlTczdPiT0kgBi+4kGK4MeN5WJKEEQyy11jwDL3XGn66Zp0BCdmYNOrybipOxy3vxiF3QeT8crxBJI7WTg9ZsGlsRIMzRTh0Ew+esYtOE0P7xyB42xrHb5Pq/9vThFA3nLgLz+sxR9+UEev6/DZxUb8gXzIp+fIn4xV4+OZBgIJmfozzfj0VAM+ObseP54hc95RhdEWO4b6bOjqNePo8UJ0kKRr67Wia6QaAzNNyC22iWZmarGDdZkVeSeLt3wLSVqRrwgphWdYtagvV4dWQhNWAf+4OvJZTdBGVYu5HgFxDgQnVEAb4H/lMYdS6tWrkIfDXcEAyYXKUwdPAohWDNEpRGh0EeJSLUjJLkOOwbHwAcKhVrvTA59LAOH6acl/MEAUfEAo/Ad3PjHCP8Is6tR9Q83EGjosceXh8wSQq9Ph4ZuOmvsycFd3DG58Jgz3vRCP51sScWwsGxMzZpyaJAaZMaB90IBxklvnhsox112BsaN2zLVW4MNpB/78VjU+/0EtPnt3Lf7tnUb88WI9/v0SA6WJQFGPT+fIxJ+qx6/J0P/ubDM+OrcWH7+5Fj8/04iJ4zZ0HDbheC9P3zWivbsMbd3kQwggZ89tQOOGSiGjlOKgkINBMv+1qNE3E0M0wie6CcrgKmIRTi0pFblXnmGV4pUTE8UAnAgTfLTzjRfYgP8rk76IQqNwgkweJ3avFJp8qLwIIFqWVwbyH4UIjzUiPs2CtBw78gpqFwNAlhNAtKIdEBe9cIo7py9ze0zR4t6PW5NKBp0bO4TGlkBDBvcaFwZHFpa6ZGPJ8jSscEpFujUbWw4l4U7yIXcfDcfu7li8eDYDh0/no2PSSB6kEG09Bkz2mPDD6Ur8cKJK5FdNnrDhbfIjf3yzCn9+u4bMeT1+f6kevzpXh9+QzPrDBZJaZ8nIE0g+ma0V8VsCx0dnGvCLN7k+fS0u9pSj/WUDXj2gw4GWIpw8WY7B4SrMzdTg4tlN2L2nGcFxZnEKLk1nZfkotfPnbuSeXHufex38UjbCM7IO8iA7ZAE2SWrR1+qQCqjCiV3Ij3gHZpEOl7qtL5bs3H8Vl9lSrVDAQ5k+v71L8spbB296RvxD5kf9EUCYQTLyKqArWgQA4QxepSpMNBjgmuIvAEL+QwKIJK94l4czXbnzCacWLLmKmGNVJpzlJLV40PySFPhHZmHzYym4dyAWt7WF4Z62aOyeyMQTY7l4rjsfe/v16DxZhOm+Yvz8dI0AwHtjDsy0luDiQAU+PluFT0lm/fYtBoYDH89W4WcUn56j352rwu/OETDO1+JXBIxPTjfjVxfW4dNL6/FzYpZ3hrke3YjXX87FsRYjhoYrMDxRjdnTZOhPbsJ9j9YjIMYEGc/X8+L53gQQPufheRc+5K30m1D5QjtMj+5H/s1PIsJ0G/wyroV3UjO8YhugiagmgHC7Ubsw6F7/t2OWF3gIgCi4HMIbbkod3FScwZsvNnF86PngGSHhcSbyHxYkpdvFmI184yIACGtKmSJeYg+F1CpTpJfwFq/2yzMQvzCSV+Q9giOtcGV5tSSdIo38BwFlNX+dCmdZCupvy8SuvmTc0RmBW09E4/6uTNxzPAtbX8rCo/uzcbCzELMjVfjpaXrIiR0+OlOL8yfLcIY8yQdz5fjxuXJ8cLoMvzhXiZ+dqsBPJu34+WwFfnO+Br+/UINP36gm0DTiR+O1+DmxyE9ON+Hd6SacH6pC7yETuo6Uor+vGj0DZTjRY0bvaBVe3FeHyqYqaMO4ZtogsgP4Grl2ml+5MUXa7Xuw/ZPfYvdnf8FDn/wON775Pmr755C/+yCSr9+NYOPN8Caz7p9cB18y6FcKc1wOvl5PxVJij1CsoYWUg8shnNV6seho43WIzjcgItEiBjVl59cSQP4XDfH8fw2N8hp4KFJFPycXrv/gLoCc30+r7OXtXc5T4mIiHo7iH2bB1W65EjgIFF9GErFKEkrWZmB3RzLu6YvGzZ2xuLsjHXeeyMSdB7LwUHuRmB3e300r+1AtTpM/uDBZi6nBcowP2HD+NMW5UlyctePHpyvwwVQZfjRBMVmKD0/Z8cuzBJq5ajLm9fT9Gvx0bq3onzXVWYVxkmoDrQSOEzyyjfxIlw0t3WacGLThaGcN9jzZCHOZlXwWt+IpEOGq4VRt8lrBVphfOoEHPvsTnvmP/8DTf/s7HvrzX3HvZ3/G/b/5A7b/7BPc9uaPcP3oWZQ+9gJCE6K/cR8XezCDaBTOcFLEYYm8ECvkBVhF6mEFLZZuvrlIXp+N7Jt18AjOhYKeG25lG5Gw0A8KOelMqRD9el2URpJZfIquFxm9EkAk/8GjEbjzIg/99Ao0Y/mKrHmApMyDI5kiUbzml2Zi5+EUYo443NIRj60nUnFHeyrubsvAY4PFONLJW7E16O9xoK/HjuGhanQQe3QNmzF42ojRsxaMT1jxvQkbLg1Z8NZEKd4hgLw9asYHM6V4d5KAM11H7MPeY4PY7h0kUIz0OTBG0d9egQGK4T6uGSlH67BdjIo+2taA62/jrut6sZ19OaXfg75WhpeibuQ0tv3lc+z5+9/x7F//it1//Tt2/8c/8Oo//oHX/vF3vESvr/z9b9g60Iuo1NBFkzbyfxNqhTvWyOlz9yCJ7ZGPJTJSErJcyMKzYf5OJnK3ZcM5IBdL5bkEpFxRmbqwAaJkTaklYOjpYSkmcBRJ6e1kZBVa3vrkPCXOcpUaywVF20S6+JLlmV9jEAZKkgBJXEYmtr+Qgm91JODu3nTcSxLrTnq9qzcDDw/ocLCrDL0dBI6uCvT22dFO7HF8yIbhOSvOXLDi9PkSzM4Sk0zSv4dKMDdSgfPjdrzNTDJdivdP1ZAsa8YvLzbhY3q90F+D4bZyDHdXig6KQ/Q6OeDAmbFGTI014ORIPdoGavHywQaU1ZTA1ZsTMbmx2zxA6Hq94+uw8fS7uP8zAsgvf4dnf/V7PP35X7GPwNLz+3/D0L//Be0Ejo7f/wE3PfFt+PuuufIAwv5DocRqj2wscSdwuNPD78GRA0VMBuyvpSN3eyZWeeZipTwPzgqO/AUMEM6/olcFGXRpNeU2P0YCBxcCmaD0NZG8kuYX8rBPf1G3bYaLnC56CQNk3oN8ARCJRbQhqbh5F8upNNw7pMP9IwW4YzgHdwwQcAay8FSnEa3t5ejprEBHfwWOk/8YGC8jeVWKt86W4vxsCU6fImCM2TB5kn6vpwYjPARnlFhk3IafnmnCh2ebyafUielSoy0EtFa7AFw/xdTJOlycWodLpzbg9NR6MuhNaO2sw5N7m5CqMxNACqWMZQKIG70qAoyIsW/F9Rc/woO//iMemHsXe977JfZ+/jfs+/h32NVzCq9deg/H/vwXvP7+T1F1+42LLrfqX4VUQbgccoUfVjIwONz4NRfLFVnw02ei5IVMRFRkYLUim9gjT7CHMz8rX3+zBRMCIGTQVfEie9dFw0PiTaLiTs5TgrjegdvYc8VdkFn06OUKvDV8c5b+FwBZkUheJgGNW3Jwf0setg8VYTsB5PbhPNzck4m7u8mftBtw4HgZ2tprcLi7Cq/12TAxUY63ZoglTlfi7Az9e8yMoX6KgQp0kX8YHqzG2TH6+Xg5PiLf8SGB5N2ZOkx1VKLrWDnaOygIHG1tdkyNNODi9Dq8MbsR0+Pr6H0aCSAOfPflBoQnkUn3lnbqGBy85auNKYXxkVew5dd/wJaPf40be85i94e/xRN/+hx3DF7ADfsG8eDAG3j6t59hxxuXoKuvukIPCK+Guzwcy1laMYO45VHkYGVABtK3pKPkuWyoErOwmiSXsyIHrso8OLEE+/obLaTgeSHuKi6xNQmAcAYrp3p7+Jgg92EW4WmlPB7ahuDYSpHIt2RN9jyDZGDJSgLJSgLJ0lQsXZOGlc4pcPFIQX5ZDrYe1GHbkAl3jxmwZbQAN/Tn4rbudDzcmY/DJ+zo7qrDiZ5q7O8rwyQxyNszZThHDDJxhkz8mBF95ElGxkoxxjUdQ1VCap0ZqsTbYzzqoBFvjtRggtil7UgZWg5ZcPyoFf29DpydaMYbU82YmlqLwclm9A4TQMiDPPJUNYJjCkT5sNilI6nlRQwZmFKNms5RbCFA3PW7z/DQ2x9iz2/+iJ1/+SuuG7+Inad/hEcufIjdZNq3TE8hLj/tG/fxSgi1ciVc5fEkqfTzEmseIH6ZyNiWhtqWNATkZ2ENA0TObaO422LeQgeImlZSPkEvFgDhIilO8ebKOWYRTYAVAVEV5CuaEJ/ZCDWBZcnKeXBck46rnDNxtUsGRTrWuGbA2S0Nzu6p8AlJx7XfMWH7oBlbR/W4ZaQQm3qzcENXGh5o15NhrkZ3Tz3au2txqKsKY8QM06etaL1gxNFzReiaNqF3tBijoyWYIQN/btCO0yPlIq393MRanB6uw3mKCfIWJw5bcHi/EYePmTE8Wocz082YJe8xRB6kb2YdeqYb0DZVhWvvKhVTtJR+XBFopGshbxVcjHD9Omy89C7uIEn1ILHEwd/+G459/jm++7e/YdevfocnP/w1dn7wK9z3179hXUcr/EOlE/QrLdTKNXBRZGC5rADXMEiYHTzysMovG7odmajrSENoIckreTb9HjOIjgCyUCWW0JQMkCDRGM5VAOQyi0gA8QopQ0RiHQGjCVEpNQSUUsho5V2yms89MrHcOQNObtlY45YJJ/dMYo5MuHqkw1WWTCtNJkwb7bi7w0YAKcCNgzps6krHzXQTHziux5GjlejprkdnWy0OHK4UW7HtZyw4dL4Y+wkgnadMGBw2YZRk1mSbBac6SjDYYsFoZyUGR2rRN0omfLIJY31VOHbYiNePmtBOfmaUvz/TiBkCRd90Pbpm16LrTD2OnWpAfqUFniQVOaWEmZB34/hsJ7l+K27/6BM89Ld/4KFf/gFPfvQpThB7HPnb39H79//Aaz/9BLt//xlu+dOfYHzuSWi4gvAKSi0RoeAUdzU9+PnSGYjcgCXsLwggawIyUfy4AfbXs+GfxTtXDI5c8btOBKYFCRBpqOdyuMvCcLXMgKvlxWJsmKua29lI6d3hSfUIS6hDIDFIcHQZgiLL4KHSSweDTkSlrtnEFhwSONxkmaRRM+GhSIebKgchWWW47vkqklnFuHXYgJsGcrClJwf3HM/HE/tNaG2pRC8xySAxyMhIGXqnKWZLKSwEgGIMdhBAWs0YPExssq8YLa8YRdf2k2TCe4eqcWq8FuMEkK5W+pt+B8ZG63F6gmK8EdNTTRiabUbbqUYcGm/AdfeVIjhOasagCSCgBHIfLAsCI6xIbbgbzf0zuPOtD7DlwvvYculD7Pzsz3jqr3/F0X/8Ay1/+gue/Pe/YMunv0H21pu+8B9X0i4WX6uXd5Co5+dGHjx78RoCwDXEIu4hOpgfK0fRLrq/cTrysDn0+etE00FnZdECBYiSD31W4CqXKHrgOaeK9WQeVtKqoPDmDoPlYpa3Z6ANvuEEjphy+l4pXOiGLCVwrHQhKiX9yQBx8cgi5iCAyDMgU0gg4Z6+yrAymG6oxr2dZbhnsFj4kNsH8rC1PQ87Dujw4j7yDeQfBtptGB6woWewjDxDGfonS9E1YMZYdzHGjhOQXi7E0eeK0LaPJFRrDfpb6zDYzXMKqzHJZyotFejrrcbwcA3OzTRjeqQJs9PrMTqzFm0EosdfrUFiLqezW8RGg3cw78bxrpwVQcSK/jF2BOesQ0rTfdDf8R1UP9eCjd0TuPXcW3j4px9j7+//iFcIMNt/8hMkVxZ/kXKhvaJYZCm8fGLFzqbcxygSWWUaKRMhMKcQ5c84oL+1DOFFdH9idGLUtSvPSFmoAOFQyZ2wwiWJAJJLkSVYYYlztiiAclXkCi3pLM+DwtMgunVzDbeTey5Wu0rh7M6RTZKKI0sAQ0bs4UxM4kySzSOQH7xKrHusFNtabcQkRdgylIfbe3TYftyAnc/q8fyLxeg8VoJT/Tx1thRT5EV6hq043KFDX3sheo8U4rUX83HgxSL0HirHWEs9OvY70HmkAkNtlTh+oAT7Dhbj9Q4rOoYrhLSaGm3ABJn07tFavNpVjcYby0gemsl/WBEYaUUIASIysQJRFDFJ1fANtojaFh6HzR3Jg/n7eU1Id9wO0x27sPHp13Fn+0lce+wEQpKCvwDIlSSzvJSr4emTKTY2xPhwb+7ByxnQBqSs1aF4jwHRegPS68oRnMw7nyZRdOesWMAAkcsUWO7CwDBIO1MCJNkiQ3eJczp9nUrfS8UyitWuaVhDwFntRsAhplnD4CD96SLLJeagIIC4CYCkEbiyIQ+wQx5SA3lYFaKLyrB2VwXuarfgtgE9tgwWYlubHttfyMWep/XoOWjB2Q4zLpwkr0Hg6OotxMsnUnD8cA4OvKTDs8/m4KWXCSBHqjB+ogH7X7fj5VdL8NqrZrywrxBPH9QTECzoGa3E+HglRscc6KJ4fbgSD+61I8daIhrBcff24OhSMfckPq0KSZkOJGfUIiDUBi9/kgeXmy6HWxAeY0NMoh2xqRVIza9FXukG5Niq4OO9eCZD/d+El9odnr75kDFARKVpgVhQNBF6klZZMH83C0FJBYg3WBCVVkqqowSunrSgKhfgfJDL2lkm02I572U7s6/IkUByGSBODBBORGSQJOMqZwIJSarV7nnEIjqs8dCJA0M3hU4UzjBAXGWS/+DENf/4RsTob4VXbDOUEdVIKK1C0xOluL6zCLf2F2FbRz7uO5SPx/fn4/AhPfoP5uN0hxHnBulB7zDg2ePpeP1gJp7fm4GnX8zG3pcKMNDiwHhnM14/4sCrB8txeL8NL+wvxDNHDTjQbUXPUAXGxsjPjFeg/1QVDk1W4ObddkRnkqwKMcM/ogTBMaWITLAjLrWSAFKN2OQq+AZZCRxGUT7qQwAJJOMeHksASbIjgQGSXY3MvCrExCbCW714JkP9z2M5NGof0ZiaO0oqvIwiy1vjXwCvUD2se/JQSgDxjzUgKtmC6FSS5sFmOKt5TvwCBAiHF2lKN1kElvF2nUvePEB0BA6uEGQGkXaplgsmScEql3QxrdVJpocTgYODAeLOac/yHCGxBEBU2fAije8V04jA9OsQmHY91JH1UEVVIWtdOTYdN+PGTgNuIx9yF7HIo/06PNOVjgMHstB30IDe44V49XgOnmzNwPPHM/F4WxZeay9Ce3sZJnsbMNLdjEPHanD4MDeuJhAcL8XhzlJ09FVS2Mm7lBFQSjEwQTJsqhY3CHNukgASWYKQ2DJEJVUgXgCkBqHRZVCTXFDzNCR/o0jbDiQGiWaZlUwASa9Eek4tAaQCIcEB8FbNT4a6QuSVyOBVrYDGMwwqby42M0FFHsQ3ygRtVCH5OgOyr9PBdJuB/FyhGCEeTQsLZ0c7cV6f5wIFiKfCibxCApbwNpwrAcOJQOKU/yVAXDJxjUsGSat0XEPB27hubLrkeqwi1lnBUotklivJKxcPNupkzOXkQwgg/jEOhGRcjyACB0+BVYbVQhZcjaC8Gth3l+O6NjNu6bdi24gN35rMwyOjSdjTkoBnW5Pxne4UPHk8Gwf6i3F4rAgvjxtxcKQE/Xy+MbYBE33NOHGiBocOl+LIMRteP2bBsc5ydBFAWrvKcJTLbIfLMTBZj4G5RjzwRAXiMiVTzh3bQ+OIUZIrxYOflFED/xArffCFoiuglnQzS6wg8imJmXVIyq5BUpYDGXkEkFwrtN7u37iPiz1EBq/qaqi94oX34PkfXLLsE2qEdyhJ0kAdYm0GxBbraGHhWnQbwuNLRXM9PluTaRdob161QoY1Ms7KLMQSNwYGSy0GRw75kmwCRgbWuHGki1c+73BREINwmgEZdC61Xe7Ku1jsRcjMe2QR4KQDIv+YOkTl3Q7vuPVQhNZCSaEIdkAeWo3kuiqsfaUUN/fY8dB0NR47U4B7T8bhwZZwYpMYPH4yDYf7ijBBZn1qtgwjs8QKkwSAqTpMTq7H3OA6DHTV45WjZjx/lORVSxFeZYN+sgIdvQSQAQtOTNrQTQzSPl2LZ49Uw1BaAW1YCQKjShEWXy4AkphBsi/NQaAwi7aZKm8DySuSWX7cmMKMdMMGFJbdgmx9IzJ1dUjNLLji6j84pB68qyBXp8GdU3O8CohByH9wmx9fngOSh8gcumfxuQgKLyb2YBnLCa3c/NtKTFK6MAGiVHpiNXmHJR7EIG4sswokL+KURbIqkwBCjCCTzjic3BkgvLNVQOacACJKbbPnAZJD7JHzJUCUejFLQ8iq8Hox+FLFc/1CKqEKrkJQVg2qv1WO22jlv2/QiMfeyMe2sTjs7IrDd9tTsJfk18BIBQGkElNTVZim14ExO47PVKF1phaDo/U4ebKeZFUZDnfbcbDLjtfayNiT/xgYsaNz3IruOTt6ph3onSOm6atBWUMVGXQbgtigk3SKS6tGCrFDQloN+Q8zFJ7cOlMHLz9uvMw+pBChMSXIM21CfvF65BbUIyEx/Yo69/hqcImtTJ0lJkgJgGgLoeE+BQIgemJnPfyITcKiihGbQpI2xg6Fvw0eWivcPRcgg3iR6ZIpAsXY3iXuBmIDvQQOwSIcOVhJAHF2Z1/B8omBkkcSyiDk1VJmEBeJaZx4S5h3sQhsHqo8uBMNc8scVXgNNBF10IQ7oAmroqiEZyiPL6uC6aZK3HqgGDv6DXj8vA47z2di52gKnujIwAEy6t095TjZX4WTQ1UYpgd/kCRT71QNuqca0T3WgP7xOvSPOOj7NRgdrMUA/d7IZBX6J8uINWzomqtGJ4Gp/0w1jtHPy9c6CCBlBBA7IpNYXtUQQGrJhzjIkJcSIMyibQ0PfvHy596yBtHbiXe5cgoaoSusRVRU5BUMEF94aHSSxBIzCDmHjYPuVUgB/MOMUi/eOIvwbUFR5ZD72UTzPVf1ApkP8tUPl2d0u8ki5zMymREkc77MJRfXCDbJw0qXLHr4yXD7GaEk+eGq0GM1/T6DYw2BZRWZdD4vYZaRc2cLb6l5MWcAKwJ5ClOVGFUmxpVFVNNrNTzDCSAElozaKty0z4LdA0Y8e6oAT50nsz6Tg+8O5GJ/ZwE620rQ0cWHhTYMDJdhbJSYZKIRcxPrcZr7707U4NypGkyfqsLQDLf0qcbJOZJYMzYcm7KjZYoM+nQdTs7WoHVgPSqbG+AfUSoZdOE/HEgmbxFCkktDplMbaEVYLDeCow/dj/vLSh96Qno1cgwNyMmvQGCAz5WX4s6vKh7zHAq5p57uiwV+wRaxmcFJnj7EGslVJkTqTcS4ZvIfJYgkD+IZaIGzqghOyiKRnbEgACJOfec/YE/FSri4x0v5/K550i6WiFysJIZYTdJpjStJJjLeCnUeMQPvWuUTe+SKrV4nDzLm8jxxmMiswasv0y1LFB4o48pjA0iDyolmxQy/sAp4h3PLnAox9DLSUIXNz9nw5JAZL08W4qXJArw0YsTz5D2ebs0n402+orUIbUNWcarOUuvsdAPOUVw6VYcfnKrFD0k+vTnnwOSsAyPTlRicKiWGseHIVAX2T9YQk9RjjEx69+ANcKxvRkBUGULIoAuAZDiEB/ELJgmgYHAXEqM004dbJUAiGjCHGJGW14hckljpORb4+jh9454u9hDpJcqlcPeIoAU1m56FfKi9pS6KCorQjHw0Hi+A/nY9olKIPRL5ENYqtoKXyQxYLS8gkBQuDIB8ceqr4LkObrjGPVUCiIg8YbyvYXC4M0Owt8giEKXD2TWF/EcmriJwcAdFZhX2HEJScVc90u4sTbgvKzcv5hR5Z7UUnDrP48pUATzvrwTqkFL4x9UiPKsRju01+Ha/FS9MGPDieD5eGTHgmZ487GrNxlMtOjzfbkDbsBn9U1YCiB1nSDLNzThw6Uw9Tg2W4fRQOd4Yr8JbZxtxYa6WPIsNfeNmtBOTHCUQDZ7biAvfuwGjU7ejcfO1CI6rQHhCBaJT+ICwBrEEFE+tUQBEwekSYTbEpzeI1qq+3KAiqAgJ9HtFFTcjPZtMqNeV1cHkcqgVq+HqHgdX8pgeihwy6zmiWZyzRwZ8YnKwsc0G3eYixKZaEZ9iE5kKq5XkZ+cBskaxUJIV5wHCQFHI1fSwZwn2WEqyaY2HXhRBuZAn4dQSLqnk3avVa5KwbFm8ODBcRn7jKk4roZ/xuYdMlQul5zx7CHBIrV9Ufha4evIWH3dFNxM4SgVAeNilKqgEwZwdnHs9UqyNuP9YCfaMF+DRiQw8MpJCRj0RD7clY9eJFDzZmoljQ0acmDChdcqCHvIX48QO58/UYYDztnqtmBgpJ8A04A1ikxFij37yHyfP1ZP32IBTF27BhTeuR//JzWjctE6k60en1CAmtRrJ5D+iEkgn8+hilV6k0nj6FJI/qUZYPMmpcKtooRkeX4KsgmbExiVBq7n6ikotuaw2lDIPuLqlEIPkwEOZQ4tJDpQaUhVqHXyC8pFWWojYLKMAR2o23bvoUmIPPVYpCoXEctUsEIl1ObjE1l3uSwabjbYkqfjwz11dJJoXXO3GqezELiu4vjyOIh4rnTJJcjGrkKziAn2SVTwPgtnjMkB8gri5g1HUkIjZfvPDZ8TAGV+LYBBNcAl8I8sRGFsDr8gyrHvUioeHjdg1l4Mdk8m4uzcW23tjcF93GHa1ROGJo4nYcyIZe/qz8MKoAa0TJTg5U4HWIRNODBZjcKQUs9NVmJy0o3+C5NiMHYNnN+OVEzfiwV2b8a2HNuGRXdejtGYD0nTXEUgaEJfOAKlBCH2Q7sp8kojS8BcVAYR3uaKTq0WDvJBIC7IKNyCnaC1CQoLhrb4Se/CS//DwFkpCWhQJHJ65olEcp534hxgQkWAkY25GcqYd6bpKUVi3hsGh4hF1PGhpgQzQuZweoVGsIokUTowgeQ7ejVojzxclqCu5z+4qbgDHteUMjhhRY76aDbsbHwjmidQSuUYvZkIovSRj/iVAuBCJgXF5dIA0Cfby6ACekusVaoN/dCVk/hbkOMy4p6UQu2YNeHQuA/dPJOKu8Ujc2e+Pe7uCsO1IMLYdjcQT/TocmrDgyKgNr/abcJC8Swd5kyGSXpPT5RgdKyF2IbC80YiRs3fAXN2I4Ng68hxrEZ+xgVhjPYFiM33dSLKpVhz++YcQiOU6ARBxPd7EgEEmcU4SEEaGM65c/G4mfeiB/pr/dA+vhBDzYhTLIZOFSqUM8lwhr1ReeQIgXr56BIRym1ET4lNLkEH3KV3nEAb9cnWq0t8qaooWBEA4+KLVCheSU6mSKeeDQadsLCXjvZTk05LV3MonZ77OnFv4xIk+V6vZexA4nGU60TBOmknHAJEGN0rbowwQLkSywcOHJ+GaafUohXdYOYGilNjDKsIvyo7AmCp4kD8JoNXnxqdteGy2CI+ez8JD51Nx90wkto4G487BIDzQH4nvDGTgyLANXeOVaBkvxwH6um2yEmNnanBqrhJT03ZMTJTizJlKvPXODTgxcDsiU2vgGVoP7/Am+Ec100O/DnmmO4hFriVw1JMHqRO7c+4EdpYKDBCWWeyhwmPLkZTTjHz7LYhJq0JCsh7+Wrdv3MvFHqKhufJq8h3x9Jlnk+qQ/IdgDy13cteTbyNZGm9GYkYZMvMrxdmSJ4+KCKuAZ3CZGFmnCVxgB4UqhZIk1ZfgEGkl3ICaQLBkldTnavnyJIoEAZClq9OEcefuFPx3LhT8YMnF2F9+sIhFvAko3KKUWEHuU0IAMdMNsiM8ZS1CExsQFFcD3wgGRgUikmsQkVQLpU8x1IGFKN1ixf1j+dj5ZgZ2XEzFtrFo3DUQjrtPhuDZkTS8NkxmfciO7kEHOsZrCRy16J2tI4A4cGa2AmeISWZmyjF3thZj0zdiw03NBEKScCEN0IY1IIAAkpB9LSrX3Yfa6+5BvuVaJKTVC//h6kEAUeaJ9plytbTZEEPgKmm+H45bH0N+Ccmy+DT4eX2lxc/XfcjX/72IQq1wI++RRLL6S/8h9eHNh2+gQfTh5TFrydnlyCCAxNGCEhBZieTczQinz11N/tMzYEEBZDnk5D9Wc4KiMycncs5VthTcoX05dyZJwNKlHJL/WMWVg8wecjbzfGLOiYm89ZtPDxYBhOUJn4Noi8QN8SD/IddaCRDViExbL/xGDMmc4NhqRCTW0I2rQTABReZlIpmVj7x1RtzZqcfOi9l44HupuGc0Fvd0R2FbfxSeOpmG53vzcKC3BCd6ayjq0X2yHhOnGjE4W4mZM9W4OFeLOd7FmmvE9ocb6f3roQmpIoAQKMPryJg3Y/Pd9+HZ9ifxfPtu3LT9biSmb8RKjyKxaydJB/Yh+QQQvTDx5RseQP1tj6G8aSsiYxLho14pAeGfnYMsUoCwnFTK1LSIpMCdP28BkFwxNMfHXwe/YANCo6Qptmm5FQSQKmJqAkRQCfwj2YuUw4cWSd/QhTKjUMEXvYIuNkhKTvyi/oMzd7Pme+uy9yDmWBovyavlidK5B0krKXKxxo1P1bPI4OZB42sUyX58eMTNHORaCxS+POCzAsHxDUjIvQ4BMaT3o6ooKsgEVxI4KskEl0jzR2glynIU4ZZ9Ouw8l4cHv5+K+87GY8dQNO7pCceDPVHY1ZuBvQSQlt46nOhuRFt/PcYJIOOzxBinHBieqkTPRCVePFqHPIsD6mDSwUG10IZWITCKPIRhA5pvux3X338b7n3yJjzyzFbUrr8Jrt42LHUuwCo3Xh11IheLvVRIpBUl1Xdiw5bHUVh2HbQBaZB5aKGSKUlyOItDVm/FCmIUzupd+s37vEiCAaKgxdRVlk7yijdmJP/h5auDNlAy6OGxxcTGNuE/MvU1CIm1wyu4lBbKEviQ9/AO5iYZC8iDCIB4+GCVayKucU4UaexSzQeBYzn3tmLfQbGS5VUsfS+Z2CZPJCle3gLm1JI1blniHMSTdHx4TBmiEyrIsHFFHpm3wGIExzmQlHc9UgtuRqJuMwJiGSSVonTXL9wOT5JiHuRdZN56JBcXYVuLFTvP5mHHO2m4950EbB0Px/WdgbilNxy7RvNxeKAKHX1NaOtbh5a+tegfWYeR8QYMzdSjk3xJy0g5dj1fgzRDLfmcSviEOggg1YKt0vKbkVe8EYayRgGQb790G/a2bkXltRugIr28wjmfHgKdSMDz9OXT4kJRZZhn3CiyfZUkvZxc0uDqlkTsmwilMgYqVTC8NL7w0ajh5yOD1pMkmGrZN+73Qg7BIEpPktMxkCmSoVCnQ+OdQ94tTwAkMKwAEQSQpHSb2MjINtQhIp7ve7koyVWSB/UMsEDDbaK+/ub/m8OLjbrMCQoPD3i4e8LFNRgrVkWR54jB8mUxWLaSfMfKywySJqTYMtc8rHLPw2rBIiy3cuGqYO2uh9wrB770UPn6hsLbUwVfvzBEJegRn12B6AwH9KW3EpOsF6DRhpUSe9go7LTClMBdY0JQshG3vFqJb50txEOXMnDv24m4ZSICazv8sKkrEk+TKW8faEI3gaO9fwM6RjeTzNqIk6Mb0T/djK7ROhzuceCFQ+tgb2gkv0M+J8VBQKwlUNYgKrla7EYV1zpw78FaPNNTgWcHzXikowylm8pE637e7hW5RcQgvCsXFlOO3MINSCA/4iHXYTXJT2daFGTEmiwnlSQ1tH48C6OYjGkFImPT4e+jWoRyaxmx5hqolXKo1T7w8gqHj288fd5pCArNRVSsEcnppcjSVyHbyKMl6H76maXREjxbhoCi4TZR33zj/8Vx+UPkV8VSeJJc0MivhsrdBXJ3OTzcCDQugQIooikc72zxHBCSYks5xZ0kCXeycCajfpWMQcNNGpLpJnpI76taDh/Pa+Dr4wZfrRpBwcEIDotFYGgKfAJJvwbbvtCmTooiuJKhL9zkwCPTNXj4vA4PnEnE1sFo3NRLPmQgFQdH7Dg5UI+T/QSG/o3oHt2EnrEbiEluwd4j12Lnnjqsv6kaBWVVSNY1ICylGlHp9GFFNiEsoQmZBU1IzXfAYLfijlcK8a32PDzQn4YdJ9Ox7XAh0q2F8Arg2Xom+PEY6BCLqDbMN21AZHwFXLiKkgDi4p4tpinxhgSnW2gDjYjPakBR5Z0osGxAUKD/IgTIki+uiRnFS7UC3uqr6fP1IOb0QkhwCKKjk0hi2aBbuxY+aUXwIFB4cFkuD3/lEuaghQqQyzFvPC+fEvONUCtdyWfESf6EvcoKBkjmvJmfD65l5xBZvzH0N1f/5/f+Tzd2iTRsRhtNEqwEKj8y857FWMXZxDI9glJtuHVfIx6a0uOhmUQ8MBBPD3E6vj1qwAmST+OD1RgfqkdvXwN6Btfh9Y7NuHF7EwzmMiSkS3XmvK2oDiyTtpZDKohBHIhIaIDOXAeLowqbtpfgriO5uK87DfcNpeOhkTQ8PJIHx90FCI3Xw48+SD7/iEwopw+8nlbFRgKMmeRVNpxcuWtLDuQqPgMgcPDIaIpw+t00w3oYihvg76f85r1dDCEWUim+mknAu3o+9LlqNStpIclEorURnrFm0baWm4Fz43OfYDPC4hbJlNuvBg+JX+meItV98FawMPOZkpln0Fw29rw1LAASKnr8/rcPiOoq+AclIDCyCp48RZYTGtUmLJPlQ+5XBMsNdtzbo8OOMwm4ZzQGt3XH4DtjBWgbKcPIcAXGRmrQ3etAe089bt9Ri+AEC3mgYviFFot5Jfye3AXSK5Db+lgIIBJwYpJL0bC5GjsPGbG1i8BBrPToWD4emcjC7uls3HdMj+J1+QiJKhS16FGJdmTmNyA9r5FYwkLSKkewByfrsVHV+OhFrpZvYBFCSGJFxpchKbUAWq/V37zmKyB4OrJvaBZCkurhGcb+o1iM7lOTPw2Lr0RiVtPiA4hSrsRyMqZLnHIkibWKwMHN4tZkSIbeKUN4EielHlcrsuEu8xU1Jv8dQLxUa+Dtn0KUW0b0Wyyaiql8S0TTbGeVHoGJetQ+RCv8RAruGY/BzQNR2DGejVfHLeQ7KtA77kDXcA1aSG45rqsipjCL1qH+YcWiOyKDQxNQIg4rfUK4r1cxgqNKEB5rRXmzDfcdz8V2AseTUwa8OGvEnrk8PDaVjZ19WeSBcpBTYUJYlIUe+BIynhWIS64gMBQROLghRQ48uFOLOCjLhzf5D7+gQgSHm8h/lCAiMkHkan39mhd7iLMhz1XkKQ0EkAb4xTqkcgf2Hv4mkduWnLvIAMKSyF2mxVKeObgyR+rDu5S+Xs47XWnSWcnVaVgl4ylCfHJugEolF37m6+/11dAo3cnYp+JqDz5w5DMVMrsEEJ7RwX5G7pWLWEMOrnspC9tHknDnWBJ5kWzsGinEoclK9EzVoGOiGi8Rm2RXWOlvjfR/c4seM61gFmhIunkGMoMUi1mK/vT9kAgbIuKtsGwswpaWFNw/mIpXz5fh0HkbXjxXiGfndNg1nokHyI+s22FDYgYzghXxqXZExZdD5WUUO1zuijwCh5ScqfFhgBjgH2pEeLQFsYk2BAeFQMv6/J9c9+KOZfD2UsA33ILA+HoEJtRBFVAseox5+huRkNGADMO6xQUQjagVCZV8xspcCgLHMgLHUj5l53OSJLH9u8QlHcu4o6I6FRpih3+V6aqQK0SVIqe4rHLTEQPpiIG4XsCANfI8yNQ6uql5yLLrcMPr+XjwbAG+NW3CrjETjs3WYnimDkNTtXippxIJeitp3CJ4hRgRFGElmWWDF3kPARCeZULegf1EWJQJsVlm1OwsxB29yXhsUo8j7zSj7dI6HD1bgX2zBdgxlYadg5m460kjGm8vRVyKFUmZ3NChAV6+Ur0In5MoNF/mIPnQosANCiKIPeKS6f/XetJquri2ef9nsQI+2kD4cOf/xCaEJjfCJ4I8IHkPT5KgPGyJy5YXPEBEn955s65WOGG1a8yXXoO9BwfvaIkJUgkEkCTp/MQtHc4eEcQOy/7rRD5+b8UyyDy8RZWiaG9KsZxLdrk7o1wHZ2IjPnhUkXzxCclHbqMed3XU4tkLzXh60oITU9XoH2vEEy/XoLSJD58s8AowIoA8QGgMfTjRFWTMuU2qVRhDNteBJL2i4szIKbNgw/N52DoQh6fO2XD0R5tx7NINOHa2Hi/PFOKBgTQ8fjILTw8WY+c+B0kCC618lcgpvA5B5Jc470yu5K1dncQeBA6/oAKERBJASI7FJpFh95LGQV9JIZn0q6D1T4JvRAVCCCDRGRuRatqI9OK18ONpyMl2hCct9BmF8yEAouCV3p0e5OQvd6s4BYUBwt7j8hxCBohzKla4pcLdg/2HJM2+/p5fvDcZeHePYFzN5ykyPVYTgyybb/rgxKkrfKailgDiRQ+gT3gRsqvLcfOLNXjgWDke31eNO7dXI6tASmXwCeQdJzLJkcUIj6MPIaGWaL6cfmYhgBSL7dpA8gfx6aUo3WzDba/l4OHhZLz8pgPHfnITuj64C0cvNOGJCT0ePZmN7w5n4dujBXi8swYFFaUiFT46uYH+fj0BwgwlgUTlxVWTemgD2MwbRZoFy7GI6Az4aK68YipeVH3Ua6ANMiAgpg6hSc2ISt+AvNKbYai8AdEpFShq2Ig4XdUiAQi/ypfQSq/CMsEa2fPbvPPGfDUxxjLyHyuTsWx1KrFABrFHGhQK5T+XV5e3eRWcNn0NXN0jsZRYYzV5DzHCi75e6c6zJLiXVi7kGk5d0cM3uAjePNEqhAxzTgky7WVILSxDUJRRTNrVBhuF/ucmASFRPJfbjuCYanHwyPLKO4jTX/jnBJA0Kyqut+L+Qzo8PZaN/W+vx/EPb0P7j7di/xkH9oznYddgDl4cNeCVCSNeGnLgxh11CIk1QxtmR47lVmQU3QhvTtX35pP2AvgGFooDwrBos8hkDQqJpAflSpRX9Nlq1KKla0BMPbFFM+KyNyMgzgE/WmAybE2ovf92FDRcuzgAwsGHhm7uvpCmR311QCcH/XtVqmCOq9zS4MIp0MoUMuhu/xwgl4N+ppGvIl+TgGXi3IR7alG45cJVqSdwcOIjGX4ywCxf+OHXkHzi7UKVn1WMK+A2lt4EDl8+yAvl1qBGBJPECY02kQexiUNHHhHnJerJiwggRQIgUfEm1N9owjOdxXh11orWn9yCto/uwvEfbcErZ+3YNZ2F+wbT8PRwPg5MFmPvcAm+e7QRhtJyuChyicnKRCawT7BV9Mzi3Sve3uX3Do+xIJre389XK84DvnHdV0AoZJ5iipRSy2klJfALr6TPwSZAk1naBH3DOqSb6xcHQKRxCFfhGpdASLMH5w35/ORaEUtZXiXiKudkkdUrU8ZBrVr5xXt8tbHa5Y4Yoq5AJYfai+dFGHAVMcc1BI6VMh3d2GKRMs81zmofToIjug7jyU+FYoiPu8YID24142MU46g19IB6B5AHEADgbVwLMYpF1CBo/Iqk0l/6eQCBiAEUQR6kfL0ZT3facehSA45/tAVHf7wFB398M564SMwyk4EHh1Pw8ng+9k8Sg5Dk2jdSjtsedpBky8HS1ZlYuToH7rQYqAjAXlrO1eIOjHpiEd7iNcDXy+2KawckNXNYAjc3Xyx3SoUT9y/g9lAy7nKTCxmpAS1JYG1YIfnEBdgX65+FVEx1DVY4Rc6zx2VwcOIi52bN52eJV/5eIlxcfAXriPf4Got8ySrLoPUOQmAoZ/2WiF6+ztwVRZYn2ljyuYWM06iFvCok2WQl5uCUBTM8vE0EEGYTE5Q+RRTccl/q6ucVIJX48vf4YIo7bXD5L7MQJ06GRJrIRJtRtsGG7/ZW4AiZ8xO/2o5jn9yNvR9txq63zLh7OgOPTWThhbEC7OrMxItzRXj5VCm+M1AH4wYLMVwGnFzTSR6mQ67IIi+SBX+SgJ5a3vZNh1oTSYvCNf89gy7S0CiWwdUtFCuc00WfAncFNxDMmD9M1YmFhDc1+HNZFADhB1xJUmj51cwWLKm+Do6vAoRfo+DuohJTqr7xXsp5gDCjqFZBq40TLXYSUupFarwYlyBnauZ0DYc42NMG8wPNYwnqRL6WV7CdpJUNci0DhBuWERC8DfQ3XJxlgMafwOJbRCyjhwfXc2h00iGeP5eCsj9hE22Buc6Gxzqq0PbxnTj+m7tx8NMt2Pvp9XjkbSPuHE/EI1MZ+Pa4DrvH9XjqbDG+fd6GJ96pR/Mz1dAQizjLMuCh4FSTNCg12QgIIpNOIFF7ZkMhDxAZ0l+/9ishOOHVxTUaa1wyRL260lMnzol8/PkQtQBBYcViMeG5LIsGIDJ3NZaJtHcunPpnAPkqUCIgc/sX25sK6QRdpUmFhzKfWKSUHt4Sca7A27rcTj8qqRbp+k2Iy2pAWv5ahMZUkEm3ISFrA2JJ/6voaxmDxJun0upJbukJGAaSYQXw8OSGdtJ7cUUgA0ScURC9S7tMNuhKbLj/sAMtH2/Fa7++Cc//rhl7PinH/W+mYet4pDi13zGRgkemdXhkzooH3yjBox/acMdgDaKLCrBkTaIY7bDCOYWkRBrJygxo/fLg60eyUOlNAFkmpOWVxCIssdQecgJIApxJMvN0MS6o4hSc6IRyhEdbEUbACCEJnFexeXEAhHebXFz85utCGCDMJJKUkgDBETv/yiAJhtJ9zTfe5+uhVrqRREkjqcK5TPnw8jNJzR60Ukd19hWhseXINd2ApOwGMSKNDbpPmB0BMTVQkFFngMjm60cuA4SZxJUMvqucG0nk0YObC5WXBBD2IKHRxYhOtCHbaMP2/XXY++Nrsff36/D0bxux5+fl2HY6FltHw3H7aAS2EFDunUnH/VOF2DZjxEPfL8Jt/TbEmHhuShKtkqmktZNFrHFJhkyeBk+vNGiUUoLi5S3yr1/7Yg4lGXSuNnRx4+lizLI5xBhmpGU3ijQd9oBBtEhF5CyUisJ/EQyQNavC8eXuFYODg7+eP/8QIXmQVav9iWb/+/wjT+VyKJQaWmlyRWcUF/IenADIyYV+YSXzNRgF9EBzFi2XbJbDJ7QMCq5M9JOK/xV+FgEQDy8CiJcEEKVWehXjhkVf4DzRiogBoiXty7tcvMsUl1qG7CICw94GPPcjBzGHCQ//ohDfeq8Q98xG4q6xQNw5GYwtM2G451wiHjxfgJ1vFuGBt3Jxc48RsWYdljklYTWxhwDIGgKIcxLcPJLh6cmluDIBDE7Yu5IA4qNeQVIzQTT6VhBzy1TsQbKh5m6LxBohxB7BBI7gaDMCE62LAyBqxUosW00P/7LLALkMBpZaDJB0kYMlfT8JLk6+8JJ/833Eg6KQJIdGtYJW2wDBHmIiLgGEzzhiyWeExlaIeYB+QUYEhLCptpEfqYJfZBVU/qWiI4bMt1gU4MjIq8hIjsm9uDSWm0wXitaXXNnI3eVFzybeCaOfaQMLEcRZtnEk09LsSM61Y8tzdXjqRzY88ksDdv4sHw+/Y8X2mQgCiB/5EF9snQ3C3Rfj8egPLHjsh/nY8XYa1h/SITyXgE2AcHFLxSpnZpBE+jqJJGM6/PziodW4fPP6F3PMLwJar1WITTLSAlQPb78iAQxuUSvVyRCDh5sQEktAoUUqIMqK/wOwkHLWZ1hr2QAAAABJRU5ErkJggg==' width='200' height='133' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=a3e8eda445c34e95bdef7aa75bdd8a77' target='_blank'><b>Coastline_India_l8</b>\n",
+       "                        </a>\n",
+       "                        <br/>Coastline_India<img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/maps16.png' style=\"vertical-align:middle;\">Web Map by api_data_owner\n",
+       "                        <br/>Last Modified: February 10, 2021\n",
+       "                        <br/>0 comments, 164 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"Coastline_India_l8\" type:Web Map owner:api_data_owner>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wm_id = 'a3e8eda445c34e95bdef7aa75bdd8a77'\n",
+    "wm_item = gis.content.get(wm_id)\n",
+    "wm_item"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "037be242",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wm_item.resources.list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f631602e",
+   "metadata": {},
+   "source": [
+    "## Analyzing Resource File Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b3d350d",
+   "metadata": {},
+   "source": [
+    "Let's look at what we can do with some of the raw resource outputs from the `list()` method. Here we create a DataFrame object with the resources returned from the `StoryMap` object earlier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "b6fda0e3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(13, 4)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>resource</th>\n",
+       "      <th>created</th>\n",
+       "      <th>size</th>\n",
+       "      <th>access</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1584837341913.jpeg</td>\n",
+       "      <td>1610462633000</td>\n",
+       "      <td>3565854</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1584840733269.png</td>\n",
+       "      <td>1610462633000</td>\n",
+       "      <td>36384</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1584977960300.png</td>\n",
+       "      <td>1610462633000</td>\n",
+       "      <td>363718</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1584995889818.png</td>\n",
+       "      <td>1610462634000</td>\n",
+       "      <td>13850</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1584995908437.png</td>\n",
+       "      <td>1610462634000</td>\n",
+       "      <td>14455</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>1584996591808.png</td>\n",
+       "      <td>1610462634000</td>\n",
+       "      <td>11135</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>1584996631292.png</td>\n",
+       "      <td>1610462634000</td>\n",
+       "      <td>11129</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>1585069439012.png</td>\n",
+       "      <td>1610462635000</td>\n",
+       "      <td>6470</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>1585080995091.png</td>\n",
+       "      <td>1610462635000</td>\n",
+       "      <td>152744</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>1585081014377.png</td>\n",
+       "      <td>1610462635000</td>\n",
+       "      <td>143621</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>1596760258881.jpeg</td>\n",
+       "      <td>1610462635000</td>\n",
+       "      <td>148737</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>oembed.json</td>\n",
+       "      <td>1610462636000</td>\n",
+       "      <td>676</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>oembed.xml</td>\n",
+       "      <td>1610462636000</td>\n",
+       "      <td>998</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              resource        created     size   access\n",
+       "0   1584837341913.jpeg  1610462633000  3565854  inherit\n",
+       "1    1584840733269.png  1610462633000    36384  inherit\n",
+       "2    1584977960300.png  1610462633000   363718  inherit\n",
+       "3    1584995889818.png  1610462634000    13850  inherit\n",
+       "4    1584995908437.png  1610462634000    14455  inherit\n",
+       "5    1584996591808.png  1610462634000    11135  inherit\n",
+       "6    1584996631292.png  1610462634000    11129  inherit\n",
+       "7    1585069439012.png  1610462635000     6470  inherit\n",
+       "8    1585080995091.png  1610462635000   152744  inherit\n",
+       "9    1585081014377.png  1610462635000   143621  inherit\n",
+       "10  1596760258881.jpeg  1610462635000   148737  inherit\n",
+       "11         oembed.json  1610462636000      676  inherit\n",
+       "12          oembed.xml  1610462636000      998  inherit"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sm_df = pd.DataFrame(sm_resources)\n",
+    "print(sm_df.shape)\n",
+    "sm_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64361f91",
+   "metadata": {},
+   "source": [
+    "To return a single row in our DataFrame we can use the [`loc[]`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.loc.html) property by providing the corresponding index value in the leftmost column."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e51df850",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "resource    1584837341913.jpeg\n",
+       "created          1610462633000\n",
+       "size                   3565854\n",
+       "access                 inherit\n",
+       "Name: 0, dtype: object"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sample_resource = sm_df.loc[0]\n",
+    "sample_resource"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c20680b5",
+   "metadata": {},
+   "source": [
+    "The `created` value returned with resource objects are in the form of a POSIX timestamp, which is an integer corresponding to the number of seconds since the current epoch began. For more information see [here](https://en.wikipedia.org/wiki/Unix_time). To convert this integer to a more familiar representation, we can use the `datetime` module along with its [`fromtimestamp()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp) method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "bb7781a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2021, 1, 12, 9, 43, 53)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dt = datetime.datetime.fromtimestamp(int(sample_resource.created/1000))\n",
+    "dt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdd6d69d",
+   "metadata": {},
+   "source": [
+    "Our result is a `datetime` object, which we can display in string format with the `print()` command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9718e946",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-01-12 09:43:53\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(dt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0b85e7d",
+   "metadata": {},
+   "source": [
+    "This string format is also how the datetime object will render in either a Pandas DataFrame or Series. Using the `apply()` method we can create a new Series of datetime objects which correspond to the values in the `created` column. For more information on the `apply()` method see [here](https://pandas.pydata.org/docs/reference/api/pandas.Series.apply.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "2e8c55d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    2021-01-12 09:43:53\n",
+       "1    2021-01-12 09:43:53\n",
+       "2    2021-01-12 09:43:53\n",
+       "3    2021-01-12 09:43:54\n",
+       "4    2021-01-12 09:43:54\n",
+       "5    2021-01-12 09:43:54\n",
+       "6    2021-01-12 09:43:54\n",
+       "7    2021-01-12 09:43:55\n",
+       "8    2021-01-12 09:43:55\n",
+       "9    2021-01-12 09:43:55\n",
+       "10   2021-01-12 09:43:55\n",
+       "11   2021-01-12 09:43:56\n",
+       "12   2021-01-12 09:43:56\n",
+       "Name: created, dtype: datetime64[ns]"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datetimes = sm_df.created.apply(lambda x: datetime.datetime.fromtimestamp(int(x/1000)))\n",
+    "datetimes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96fe0897",
+   "metadata": {},
+   "source": [
+    "We can then insert this Series as a new column in our DataFrame using the [`insert()`]() method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "dfe246c2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>resource</th>\n",
+       "      <th>created</th>\n",
+       "      <th>created_datetime</th>\n",
+       "      <th>size</th>\n",
+       "      <th>access</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1584837341913.jpeg</td>\n",
+       "      <td>1610462633000</td>\n",
+       "      <td>2021-01-12 09:43:53</td>\n",
+       "      <td>3565854</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1584840733269.png</td>\n",
+       "      <td>1610462633000</td>\n",
+       "      <td>2021-01-12 09:43:53</td>\n",
+       "      <td>36384</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1584977960300.png</td>\n",
+       "      <td>1610462633000</td>\n",
+       "      <td>2021-01-12 09:43:53</td>\n",
+       "      <td>363718</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1584995889818.png</td>\n",
+       "      <td>1610462634000</td>\n",
+       "      <td>2021-01-12 09:43:54</td>\n",
+       "      <td>13850</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1584995908437.png</td>\n",
+       "      <td>1610462634000</td>\n",
+       "      <td>2021-01-12 09:43:54</td>\n",
+       "      <td>14455</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>1584996591808.png</td>\n",
+       "      <td>1610462634000</td>\n",
+       "      <td>2021-01-12 09:43:54</td>\n",
+       "      <td>11135</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>1584996631292.png</td>\n",
+       "      <td>1610462634000</td>\n",
+       "      <td>2021-01-12 09:43:54</td>\n",
+       "      <td>11129</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>1585069439012.png</td>\n",
+       "      <td>1610462635000</td>\n",
+       "      <td>2021-01-12 09:43:55</td>\n",
+       "      <td>6470</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>1585080995091.png</td>\n",
+       "      <td>1610462635000</td>\n",
+       "      <td>2021-01-12 09:43:55</td>\n",
+       "      <td>152744</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>1585081014377.png</td>\n",
+       "      <td>1610462635000</td>\n",
+       "      <td>2021-01-12 09:43:55</td>\n",
+       "      <td>143621</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>1596760258881.jpeg</td>\n",
+       "      <td>1610462635000</td>\n",
+       "      <td>2021-01-12 09:43:55</td>\n",
+       "      <td>148737</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>oembed.json</td>\n",
+       "      <td>1610462636000</td>\n",
+       "      <td>2021-01-12 09:43:56</td>\n",
+       "      <td>676</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>oembed.xml</td>\n",
+       "      <td>1610462636000</td>\n",
+       "      <td>2021-01-12 09:43:56</td>\n",
+       "      <td>998</td>\n",
+       "      <td>inherit</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              resource        created    created_datetime     size   access\n",
+       "0   1584837341913.jpeg  1610462633000 2021-01-12 09:43:53  3565854  inherit\n",
+       "1    1584840733269.png  1610462633000 2021-01-12 09:43:53    36384  inherit\n",
+       "2    1584977960300.png  1610462633000 2021-01-12 09:43:53   363718  inherit\n",
+       "3    1584995889818.png  1610462634000 2021-01-12 09:43:54    13850  inherit\n",
+       "4    1584995908437.png  1610462634000 2021-01-12 09:43:54    14455  inherit\n",
+       "5    1584996591808.png  1610462634000 2021-01-12 09:43:54    11135  inherit\n",
+       "6    1584996631292.png  1610462634000 2021-01-12 09:43:54    11129  inherit\n",
+       "7    1585069439012.png  1610462635000 2021-01-12 09:43:55     6470  inherit\n",
+       "8    1585080995091.png  1610462635000 2021-01-12 09:43:55   152744  inherit\n",
+       "9    1585081014377.png  1610462635000 2021-01-12 09:43:55   143621  inherit\n",
+       "10  1596760258881.jpeg  1610462635000 2021-01-12 09:43:55   148737  inherit\n",
+       "11         oembed.json  1610462636000 2021-01-12 09:43:56      676  inherit\n",
+       "12          oembed.xml  1610462636000 2021-01-12 09:43:56      998  inherit"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sm_df.insert(2,'created_datetime',datetimes)\n",
+    "sm_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a85aea6",
+   "metadata": {},
+   "source": [
+    "We can also use the `value_counts()` method in pandas to get a breakdown of the number of occurences for each value in a particular `Series` (e.g. a column in a `DataFrame`). Below we parse the file extension from values in the `resource` column as a new `Series` object and use `value_counts()` to then get the number of each file type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "63baa71b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "png     9\n",
+       "jpeg    2\n",
+       "json    1\n",
+       "xml     1\n",
+       "Name: resource, dtype: int64"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sm_df.resource.apply(lambda x: x.split('.')[-1]).value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fd01a02",
+   "metadata": {},
+   "source": [
+    "## Exporting Resources"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0fc6b6e",
+   "metadata": {},
+   "source": [
+    "Also included in the `ResourceManager` class is a method to export all resources as a zip file. This [`export()`](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ResourceManager.export) method takes two parameters: `save_path` which declares the directory to save the zip file in and `file_name` which declares what name to give the zip file output. If no values are provided for either the `save_path` or `file_name` paramaters, then the zip file is uploaded to the default directory used for temporary files through [`tempfile.gettempdir()`](https://docs.python.org/3.7/library/tempfile.html#tempfile.gettempdir) and given a random 6 character name.\n",
+    "\n",
+    "Here we download the `StoryMap` resources as a zip file in our local directory using the `os.getcwd()` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "311cd52c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zip_name = \"storymap_resources.zip\"\n",
+    "sm_item.resources.export(save_path=os.getcwd(), file_name=zip_name)\n",
+    "\n",
+    "# Check that the current directory now has that zip output\n",
+    "os.path.isfile(zip_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9457bd81",
+   "metadata": {},
+   "source": [
+    "If we'd like to download just a single resource file, then we can use the `get()` method and provide the file name. Note that if the resource file is of type `json` and there are no values provided for the `out_folder` and `out_file_name` parameters (which behave similarly to `save_path` and `file_name` above) then the result will be stored in local memory as a `dictionary` object rather than saved to a `json` file. This behaviour can be avoided, however, by setting `try_json=False`.\n",
+    "\n",
+    "For more information on using the `get()` method see [here](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ResourceManager.get)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "c1392479",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "oembed.json\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'version': '1.0',\n",
+       " 'type': 'rich',\n",
+       " 'title': 'Aufdecken von Mustern bei Flächenbränden rund um den Globus',\n",
+       " 'url': 'https://storymaps.arcgis.com/stories/0f5ef7b723cd410f8e4e298d716bcd73',\n",
+       " 'provider_name': 'ArcGIS StoryMaps',\n",
+       " 'provider_url': 'https://storymaps.arcgis.com',\n",
+       " 'width': 800,\n",
+       " 'height': 600,\n",
+       " 'thumbnail_url': 'https://www.arcgis.com/sharing/rest/content/items/0f5ef7b723cd410f8e4e298d716bcd73/info/thumbnail/ago_downloaded.jpg/',\n",
+       " 'thumbnail_height': '266',\n",
+       " 'thumbnail_width': '400',\n",
+       " 'html': '<iframe src=\"https://storymaps.arcgis.com/stories/0f5ef7b723cd410f8e4e298d716bcd73\" width=\"800\" height=\"600\" scrolling=\"yes\" frameborder=\"0\" allowfullscreen></iframe>',\n",
+       " 'cache_age': 86400}"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get the json file at position 11 in the resource DataFrame above\n",
+    "file_name = sm_df.loc[11].resource\n",
+    "print(file_name)\n",
+    "\n",
+    "# Output the dictionary returned from retrieving this json via get()\n",
+    "sm_item.resources.get(file_name)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Notebook sample for using ResourceManager class to view portal item resource files.

Resolves ArcGIS/geosaurus#7293

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS('https://pythonapi.playground.esri.com/portal')`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ mohi9282 so he can add it to the list for the next deploy 
