### PR TITLE
change geonet to Esri Community and add links

### DIFF
--- a/guide/02-api-overview/overview-of-the-arcgis-api-for-python.ipynb
+++ b/guide/02-api-overview/overview-of-the-arcgis-api-for-python.ipynb
@@ -99,7 +99,7 @@
    "metadata": {},
    "source": [
     "#### How this website is organized\n",
-    "The **[guide](../)** pages explain each individual concept of the API and the best practices. The **[sample notebooks](../python/samples/)** explain how to use the API to write Python scripts, incorporating capabilities such as mapping, query, analysis, geocoding, routing, portal administration, and more to solve real world problems. If you are looking for recipes, you may find them as sample notebooks. \n",
+    "The **[guide](../)** pages explain each individual concept of the API and the best practices. The **[sample notebooks](/python/samples/)** explain how to use the API to write Python scripts, incorporating capabilities such as mapping, query, analysis, geocoding, routing, portal administration, and more to solve real world problems. If you are looking for recipes, you may find them as sample notebooks. \n",
     "\n",
     "The **[api reference](/python/api-reference)** provides a reference for each class, its properties and methods in the `arcgis` package. The **[ArcGIS API for Python Community](https://community.esri.com/t5/arcgis-api-for-python/ct-p/arcgis-api-for-python)** is an [Esri Community](https://community.esri.com/) where you can share your thoughts about the API, request for features, conduct polls, report bugs, ask questions and engage with the Python community in general."
    ]
@@ -122,7 +122,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.11"
   },
   "toc": {
    "base_numbering": 1,

--- a/guide/02-api-overview/overview-of-the-arcgis-api-for-python.ipynb
+++ b/guide/02-api-overview/overview-of-the-arcgis-api-for-python.ipynb
@@ -1,1 +1,143 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# Overview of the ArcGIS API for Python"]}, {"cell_type": "markdown", "metadata": {"toc": true}, "source": ["<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n", "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Overview-of-the-ArcGIS-API-for-Python\" data-toc-modified-id=\"Overview-of-the-ArcGIS-API-for-Python-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Overview of the ArcGIS API for Python</a></span><ul class=\"toc-item\"><li><span><a href=\"#A-Pythonic-GIS-API\" data-toc-modified-id=\"A-Pythonic-GIS-API-1.1\"><span class=\"toc-item-num\">1.1&nbsp;&nbsp;</span>A Pythonic GIS API</a></span></li><li><span><a href=\"#Architecture-of-the-API\" data-toc-modified-id=\"Architecture-of-the-API-1.2\"><span class=\"toc-item-num\">1.2&nbsp;&nbsp;</span>Architecture of the API</a></span><ul class=\"toc-item\"><li><span><a href=\"#arcgis.gis-module\" data-toc-modified-id=\"arcgis.gis-module-1.2.1\"><span class=\"toc-item-num\">1.2.1&nbsp;&nbsp;</span><code>arcgis.gis</code> module</a></span></li><li><span><a href=\"#arcgis.env-module\" data-toc-modified-id=\"arcgis.env-module-1.2.2\"><span class=\"toc-item-num\">1.2.2&nbsp;&nbsp;</span><code>arcgis.env</code> module</a></span></li><li><span><a href=\"#arcgis.features-module\" data-toc-modified-id=\"arcgis.features-module-1.2.3\"><span class=\"toc-item-num\">1.2.3&nbsp;&nbsp;</span><code>arcgis.features</code> module</a></span></li><li><span><a href=\"#arcgis.raster-module\" data-toc-modified-id=\"arcgis.raster-module-1.2.4\"><span class=\"toc-item-num\">1.2.4&nbsp;&nbsp;</span><code>arcgis.raster</code> module</a></span></li><li><span><a href=\"#arcgis.network-module\" data-toc-modified-id=\"arcgis.network-module-1.2.5\"><span class=\"toc-item-num\">1.2.5&nbsp;&nbsp;</span><code>arcgis.network</code> module</a></span></li><li><span><a href=\"#arcgis.schematics-module\" data-toc-modified-id=\"arcgis.schematics-module-1.2.6\"><span class=\"toc-item-num\">1.2.6&nbsp;&nbsp;</span><code>arcgis.schematics</code> module</a></span></li><li><span><a href=\"#arcgis.geoanalytics-module\" data-toc-modified-id=\"arcgis.geoanalytics-module-1.2.7\"><span class=\"toc-item-num\">1.2.7&nbsp;&nbsp;</span><code>arcgis.geoanalytics</code> module</a></span></li><li><span><a href=\"#arcgis.geocoding-module\" data-toc-modified-id=\"arcgis.geocoding-module-1.2.8\"><span class=\"toc-item-num\">1.2.8&nbsp;&nbsp;</span><code>arcgis.geocoding</code> module</a></span></li><li><span><a href=\"#arcgis.geometry-module\" data-toc-modified-id=\"arcgis.geometry-module-1.2.9\"><span class=\"toc-item-num\">1.2.9&nbsp;&nbsp;</span><code>arcgis.geometry</code> module</a></span></li><li><span><a href=\"#arcgis.geoenrichment-module\" data-toc-modified-id=\"arcgis.geoenrichment-module-1.2.10\"><span class=\"toc-item-num\">1.2.10&nbsp;&nbsp;</span><code>arcgis.geoenrichment</code> module</a></span></li><li><span><a href=\"#arcgis.geoprocessing-module\" data-toc-modified-id=\"arcgis.geoprocessing-module-1.2.11\"><span class=\"toc-item-num\">1.2.11&nbsp;&nbsp;</span><code>arcgis.geoprocessing</code> module</a></span></li><li><span><a href=\"#arcgis.realtime-module\" data-toc-modified-id=\"arcgis.realtime-module-1.2.12\"><span class=\"toc-item-num\">1.2.12&nbsp;&nbsp;</span><code>arcgis.realtime</code> module</a></span></li><li><span><a href=\"#arcgis.mapping-module\" data-toc-modified-id=\"arcgis.mapping-module-1.2.13\"><span class=\"toc-item-num\">1.2.13&nbsp;&nbsp;</span><code>arcgis.mapping</code> module</a></span></li><li><span><a href=\"#arcgis.widgets-module\" data-toc-modified-id=\"arcgis.widgets-module-1.2.14\"><span class=\"toc-item-num\">1.2.14&nbsp;&nbsp;</span><code>arcgis.widgets</code> module</a></span></li><li><span><a href=\"#arcgis.apps-module\" data-toc-modified-id=\"arcgis.apps-module-1.2.15\"><span class=\"toc-item-num\">1.2.15&nbsp;&nbsp;</span><code>arcgis.apps</code> module</a></span><ul class=\"toc-item\"><li><span><a href=\"#How-this-website-is-organized\" data-toc-modified-id=\"How-this-website-is-organized-1.2.15.1\"><span class=\"toc-item-num\">1.2.15.1&nbsp;&nbsp;</span>How this website is organized</a></span></li></ul></li></ul></li></ul></li></ul></div>"]}, {"cell_type": "markdown", "metadata": {}, "source": ["The ArcGIS API for Python is a powerful, modern and easy to use Pythonic library to perform GIS visualization and analysis, spatial data management and GIS system administration tasks that can run both interactively, and using scripts.\n", "\n", "## A Pythonic GIS API\n", "The ArcGIS API for Python provides a pythonic representation of a GIS. A pythonic API is one which corresponds to Python best practices in its design and uses standard Python constructs and data structures with clean, readable idioms. The API makes it easy and natural for a Python programmer to use ArcGIS, and conversely, an ArcGIS user to script and automate their GIS.\n", "\n", "The ArcGIS API for Python is implemented using the online and on-premises web GIS platform provided by ArcGIS Online and ArcGIS Enterprise respectively. The API has Python modules, classes, functions, and types for managing and working with elements of the ArcGIS platform information model."]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Architecture of the API\n", "The API is distributed as the `arcgis` package via conda and pip. Within the `arcgis` package, which represents the generic GIS model, functionality is organized into a number of different modules that makes it simple to use and understand. Each module has a handful of types and functions that are focused towards one aspect of the GIS.\n", "\n", "This diagram below depicts the modules present in the API.\n", "\n", "<img src=\"../../static/img/guide_api_overview_modules.png\" align=\"center\" width=\"500\">\n", "\n", "The `gis` module is the most important and provides the entry point into the GIS. It lets you manage users, groups and content in the GIS. GIS admins spend a lot of time on this module.\n", "\n", "The modules in green are used to access the various spatial capabilities or geographic datasets in the GIS. These modules include a family of geoprocessing functions, types and other helper objects for working with spatial data of a particular type.\n", "\n", "The modules in blue provide additional functionality for your workflows. They include the `geocoding` module which is for finding places, the `geometry` module for representing the geometries of feature data and functions for working with them, the `geoprocessing` module that makes it easy to import third party geoprocessing tools and work with them and the `geoenrichment` module that helps you enrich your datasets with thematic information.\n", "\n", "The modules in orange allow you to visualize and disseminate your GIS data and analysis. The `widgets` module includes the MapView Jupyter notebook widget for visualizing maps and layers, the `mapping` module has types and functions for working with web maps and web layers and the `apps` module helps you create and manage web applications built with ArcGIS.\n", "\n", "### `arcgis.gis` module\n", "The `arcgis.gis` module provides an information model for GIS hosted within ArcGIS Online or Portal for ArcGIS. This module provides functionality to manage (create, read, update and delete) GIS users, groups and content. This module is the most important and provides the entry point into the GIS. \n", "\n", "### `arcgis.env` module\n", "The `arcgis.env` module provides a shared environment used by the different modules. It stores globals such as the currently active GIS as well as environment settings that are common among all geoprocessing tools, such as the output spatial reference.\n", "\n", "### `arcgis.features` module\n", "Entities located in space with a geometrical representation (such as points, lines or polygons) and a set of properties can be represented as features. The `arcgis.features` module is used for working with feature data, feature layers and collections of feature layers in the GIS. It also contains the spatial analysis functions which operate against feature data. \n", "\n", "### `arcgis.raster` module\n", "Raster data is made up of a grid of cells, where each cell or pixel can have a value. Raster data is useful for storing data that varies continuously, as in a satellite image, a surface of chemical concentrations, or an elevation surface. The `arcgis.raster` module contains classes and raster analysis functions for working with raster data and imagery layers. \n", "\n", "### `arcgis.network` module\n", "The `arcgis.network` module contains classes and functions for network analysis. Network layers and analysis can be used for operations such as finding the closest facility, the best route for a vehicle, the best routes for a fleet of vehicles, locating facilities using location allocation, calculating an OD cost matrix, and generating service areas. \n", "\n", "### `arcgis.schematics` module\n", "Schematics are simplified representations of networks, intended to explain their structure and make the way they operate understandable. The `arcgis.schematics` module contains the types and functions for working with schematic layers and datasets. \n", "\n", "### `arcgis.geoanalytics` module\n", "The `arcgis.geoanalytics` module provides types and functions for distributed analysis of large feature and tabular datasets. These GeoAnalytics tools work with big data registered in the GIS\u2019s datastores as well as with feature layers. \n", "\n", "### `arcgis.geocoding` module\n", "The `arcgis.geocoding` provides classes and functions for geocoding, batch geocoding and reverse geocoding. Geocoders can find point locations of addresses, business names, and so on. The output points can be visualized on a map, inserted as stops for a route, or loaded as input for spatial analysis.\n", "\n", "### `arcgis.geometry` module\n", "The `arcgis.geometry` module defines useful geometry types for working with geographic information and GIS functionality. It provides functions which use geometric types as input and output as well as functions for easily converting geometries between different representations.\n", "\n", "### `arcgis.geoenrichment` module\n", "The `arcgis.geoenrichment` module provides the ability to get facts about a location or area. Using GeoEnrichment, you can get information about the people and places in a specific area or within a certain distance or drive time from a location. You can use this data to enhance the accuracy of your predictive models or better explain the inferences you gain from them.\n", "\n", "### `arcgis.geoprocessing` module\n", "Users can create and share geoprocessing tools in the GIS. The `arcgis.geoprocessing` module provides helper types with dynamically created methods to invoke these tools, and provides simple types that can be used as parameters for these tools along with native Python types.\n", "\n", "### `arcgis.realtime` module\n", "The `arcgis.realtime` module provides types and functions for receiving real-time data feeds and sensor data streamed from the GIS to perform continuous processing and analysis. It includes support for stream layers that allow Python scripts to subscribe to the streamed feature data or broadcast updates or alerts.\n", "\n", "### `arcgis.mapping` module\n", "The `arcgis.mapping` module provides components for visualizing GIS data and analysis. This module includes WebMap and WebScene components that enable 2D and 3D mapping and visualization in the GIS. This module also includes mapping layers like MapImageLayer and VectorTileLayer\n", "\n", "### `arcgis.widgets` module\n", "The `arcgis.widgets` module provides components for visualizing GIS data and analysis. This module includes the MapView Jupyter notebook widget for visualizing maps and layers\n", "\n", "### `arcgis.apps` module\n", "The `arcgis.apps` module allows you to manage some of the web based applications available in ArcGIS."]}, {"cell_type": "markdown", "metadata": {}, "source": ["#### How this website is organized\n", "The **guide** pages explain each individual concept of the API and the best practices. The **sample notebooks** explain how to use the API to write Python scripts, incorporating capabilities such as mapping, query, analysis, geocoding, routing, portal administration, and more to solve real world problems. If you are looking for recipes, you may find them as sample notebooks. \n", "\n", "The **api reference** provides a reference for each class, its properties and methods in the `arcgis` package. The **community** is a geonet forum where you can share your thoughts about the API, request for features, conduct polls, report bugs, ask questions and engage with the Python community in general."]}], "metadata": {"anaconda-cloud": {}, "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.8.2"}, "toc": {"base_numbering": 1, "nav_menu": {}, "number_sections": true, "sideBar": true, "skip_h1_title": false, "title_cell": "Table of Contents", "title_sidebar": "Contents", "toc_cell": true, "toc_position": {}, "toc_section_display": true, "toc_window_display": true}}, "nbformat": 4, "nbformat_minor": 1}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Overview of the ArcGIS API for Python"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "toc": true
+   },
+   "source": [
+    "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
+    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Overview-of-the-ArcGIS-API-for-Python\" data-toc-modified-id=\"Overview-of-the-ArcGIS-API-for-Python-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Overview of the ArcGIS API for Python</a></span><ul class=\"toc-item\"><li><span><a href=\"#A-Pythonic-GIS-API\" data-toc-modified-id=\"A-Pythonic-GIS-API-1.1\"><span class=\"toc-item-num\">1.1&nbsp;&nbsp;</span>A Pythonic GIS API</a></span></li><li><span><a href=\"#Architecture-of-the-API\" data-toc-modified-id=\"Architecture-of-the-API-1.2\"><span class=\"toc-item-num\">1.2&nbsp;&nbsp;</span>Architecture of the API</a></span><ul class=\"toc-item\"><li><span><a href=\"#arcgis.gis-module\" data-toc-modified-id=\"arcgis.gis-module-1.2.1\"><span class=\"toc-item-num\">1.2.1&nbsp;&nbsp;</span><code>arcgis.gis</code> module</a></span></li><li><span><a href=\"#arcgis.env-module\" data-toc-modified-id=\"arcgis.env-module-1.2.2\"><span class=\"toc-item-num\">1.2.2&nbsp;&nbsp;</span><code>arcgis.env</code> module</a></span></li><li><span><a href=\"#arcgis.features-module\" data-toc-modified-id=\"arcgis.features-module-1.2.3\"><span class=\"toc-item-num\">1.2.3&nbsp;&nbsp;</span><code>arcgis.features</code> module</a></span></li><li><span><a href=\"#arcgis.raster-module\" data-toc-modified-id=\"arcgis.raster-module-1.2.4\"><span class=\"toc-item-num\">1.2.4&nbsp;&nbsp;</span><code>arcgis.raster</code> module</a></span></li><li><span><a href=\"#arcgis.network-module\" data-toc-modified-id=\"arcgis.network-module-1.2.5\"><span class=\"toc-item-num\">1.2.5&nbsp;&nbsp;</span><code>arcgis.network</code> module</a></span></li><li><span><a href=\"#arcgis.schematics-module\" data-toc-modified-id=\"arcgis.schematics-module-1.2.6\"><span class=\"toc-item-num\">1.2.6&nbsp;&nbsp;</span><code>arcgis.schematics</code> module</a></span></li><li><span><a href=\"#arcgis.geoanalytics-module\" data-toc-modified-id=\"arcgis.geoanalytics-module-1.2.7\"><span class=\"toc-item-num\">1.2.7&nbsp;&nbsp;</span><code>arcgis.geoanalytics</code> module</a></span></li><li><span><a href=\"#arcgis.geocoding-module\" data-toc-modified-id=\"arcgis.geocoding-module-1.2.8\"><span class=\"toc-item-num\">1.2.8&nbsp;&nbsp;</span><code>arcgis.geocoding</code> module</a></span></li><li><span><a href=\"#arcgis.geometry-module\" data-toc-modified-id=\"arcgis.geometry-module-1.2.9\"><span class=\"toc-item-num\">1.2.9&nbsp;&nbsp;</span><code>arcgis.geometry</code> module</a></span></li><li><span><a href=\"#arcgis.geoenrichment-module\" data-toc-modified-id=\"arcgis.geoenrichment-module-1.2.10\"><span class=\"toc-item-num\">1.2.10&nbsp;&nbsp;</span><code>arcgis.geoenrichment</code> module</a></span></li><li><span><a href=\"#arcgis.geoprocessing-module\" data-toc-modified-id=\"arcgis.geoprocessing-module-1.2.11\"><span class=\"toc-item-num\">1.2.11&nbsp;&nbsp;</span><code>arcgis.geoprocessing</code> module</a></span></li><li><span><a href=\"#arcgis.realtime-module\" data-toc-modified-id=\"arcgis.realtime-module-1.2.12\"><span class=\"toc-item-num\">1.2.12&nbsp;&nbsp;</span><code>arcgis.realtime</code> module</a></span></li><li><span><a href=\"#arcgis.mapping-module\" data-toc-modified-id=\"arcgis.mapping-module-1.2.13\"><span class=\"toc-item-num\">1.2.13&nbsp;&nbsp;</span><code>arcgis.mapping</code> module</a></span></li><li><span><a href=\"#arcgis.widgets-module\" data-toc-modified-id=\"arcgis.widgets-module-1.2.14\"><span class=\"toc-item-num\">1.2.14&nbsp;&nbsp;</span><code>arcgis.widgets</code> module</a></span></li><li><span><a href=\"#arcgis.apps-module\" data-toc-modified-id=\"arcgis.apps-module-1.2.15\"><span class=\"toc-item-num\">1.2.15&nbsp;&nbsp;</span><code>arcgis.apps</code> module</a></span><ul class=\"toc-item\"><li><span><a href=\"#How-this-website-is-organized\" data-toc-modified-id=\"How-this-website-is-organized-1.2.15.1\"><span class=\"toc-item-num\">1.2.15.1&nbsp;&nbsp;</span>How this website is organized</a></span></li></ul></li></ul></li></ul></li></ul></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ArcGIS API for Python is a powerful, modern and easy to use Pythonic library to perform GIS visualization and analysis, spatial data management and GIS system administration tasks that can run both interactively, and using scripts.\n",
+    "\n",
+    "## A Pythonic GIS API\n",
+    "The ArcGIS API for Python provides a pythonic representation of a GIS. A pythonic API is one which corresponds to Python best practices in its design and uses standard Python constructs and data structures with clean, readable idioms. The API makes it easy and natural for a Python programmer to use ArcGIS, and conversely, an ArcGIS user to script and automate their GIS.\n",
+    "\n",
+    "The ArcGIS API for Python is implemented using the online and on-premises web GIS platform provided by ArcGIS Online and ArcGIS Enterprise respectively. The API has Python modules, classes, functions, and types for managing and working with elements of the ArcGIS platform information model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Architecture of the API\n",
+    "The API is distributed as the `arcgis` package via conda and pip. Within the `arcgis` package, which represents the generic GIS model, functionality is organized into a number of different modules that makes it simple to use and understand. Each module has a handful of types and functions that are focused towards one aspect of the GIS.\n",
+    "\n",
+    "This diagram below depicts the modules present in the API.\n",
+    "\n",
+    "<img src=\"../../static/img/guide_api_overview_modules.png\" align=\"center\" width=\"500\">\n",
+    "\n",
+    "The `gis` module is the most important and provides the entry point into the GIS. It lets you manage users, groups and content in the GIS. GIS admins spend a lot of time on this module.\n",
+    "\n",
+    "The modules in green are used to access the various spatial capabilities or geographic datasets in the GIS. These modules include a family of geoprocessing functions, types and other helper objects for working with spatial data of a particular type.\n",
+    "\n",
+    "The modules in blue provide additional functionality for your workflows. They include the `geocoding` module which is for finding places, the `geometry` module for representing the geometries of feature data and functions for working with them, the `geoprocessing` module that makes it easy to import third party geoprocessing tools and work with them and the `geoenrichment` module that helps you enrich your datasets with thematic information.\n",
+    "\n",
+    "The modules in orange allow you to visualize and disseminate your GIS data and analysis. The `widgets` module includes the MapView Jupyter notebook widget for visualizing maps and layers, the `mapping` module has types and functions for working with web maps and web layers and the `apps` module helps you create and manage web applications built with ArcGIS.\n",
+    "\n",
+    "### `arcgis.gis` module\n",
+    "The `arcgis.gis` module provides an information model for GIS hosted within ArcGIS Online or Portal for ArcGIS. This module provides functionality to manage (create, read, update and delete) GIS users, groups and content. This module is the most important and provides the entry point into the GIS. \n",
+    "\n",
+    "### `arcgis.env` module\n",
+    "The `arcgis.env` module provides a shared environment used by the different modules. It stores globals such as the currently active GIS as well as environment settings that are common among all geoprocessing tools, such as the output spatial reference.\n",
+    "\n",
+    "### `arcgis.features` module\n",
+    "Entities located in space with a geometrical representation (such as points, lines or polygons) and a set of properties can be represented as features. The `arcgis.features` module is used for working with feature data, feature layers and collections of feature layers in the GIS. It also contains the spatial analysis functions which operate against feature data. \n",
+    "\n",
+    "### `arcgis.raster` module\n",
+    "Raster data is made up of a grid of cells, where each cell or pixel can have a value. Raster data is useful for storing data that varies continuously, as in a satellite image, a surface of chemical concentrations, or an elevation surface. The `arcgis.raster` module contains classes and raster analysis functions for working with raster data and imagery layers. \n",
+    "\n",
+    "### `arcgis.network` module\n",
+    "The `arcgis.network` module contains classes and functions for network analysis. Network layers and analysis can be used for operations such as finding the closest facility, the best route for a vehicle, the best routes for a fleet of vehicles, locating facilities using location allocation, calculating an OD cost matrix, and generating service areas. \n",
+    "\n",
+    "### `arcgis.schematics` module\n",
+    "Schematics are simplified representations of networks, intended to explain their structure and make the way they operate understandable. The `arcgis.schematics` module contains the types and functions for working with schematic layers and datasets. \n",
+    "\n",
+    "### `arcgis.geoanalytics` module\n",
+    "The `arcgis.geoanalytics` module provides types and functions for distributed analysis of large feature and tabular datasets. These GeoAnalytics tools work with big data registered in the GIS’s datastores as well as with feature layers. \n",
+    "\n",
+    "### `arcgis.geocoding` module\n",
+    "The `arcgis.geocoding` provides classes and functions for geocoding, batch geocoding and reverse geocoding. Geocoders can find point locations of addresses, business names, and so on. The output points can be visualized on a map, inserted as stops for a route, or loaded as input for spatial analysis.\n",
+    "\n",
+    "### `arcgis.geometry` module\n",
+    "The `arcgis.geometry` module defines useful geometry types for working with geographic information and GIS functionality. It provides functions which use geometric types as input and output as well as functions for easily converting geometries between different representations.\n",
+    "\n",
+    "### `arcgis.geoenrichment` module\n",
+    "The `arcgis.geoenrichment` module provides the ability to get facts about a location or area. Using GeoEnrichment, you can get information about the people and places in a specific area or within a certain distance or drive time from a location. You can use this data to enhance the accuracy of your predictive models or better explain the inferences you gain from them.\n",
+    "\n",
+    "### `arcgis.geoprocessing` module\n",
+    "Users can create and share geoprocessing tools in the GIS. The `arcgis.geoprocessing` module provides helper types with dynamically created methods to invoke these tools, and provides simple types that can be used as parameters for these tools along with native Python types.\n",
+    "\n",
+    "### `arcgis.realtime` module\n",
+    "The `arcgis.realtime` module provides types and functions for receiving real-time data feeds and sensor data streamed from the GIS to perform continuous processing and analysis. It includes support for stream layers that allow Python scripts to subscribe to the streamed feature data or broadcast updates or alerts.\n",
+    "\n",
+    "### `arcgis.mapping` module\n",
+    "The `arcgis.mapping` module provides components for visualizing GIS data and analysis. This module includes WebMap and WebScene components that enable 2D and 3D mapping and visualization in the GIS. This module also includes mapping layers like MapImageLayer and VectorTileLayer\n",
+    "\n",
+    "### `arcgis.widgets` module\n",
+    "The `arcgis.widgets` module provides components for visualizing GIS data and analysis. This module includes the MapView Jupyter notebook widget for visualizing maps and layers\n",
+    "\n",
+    "### `arcgis.apps` module\n",
+    "The `arcgis.apps` module allows you to manage some of the web based applications available in ArcGIS."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### How this website is organized\n",
+    "The **[guide](../)** pages explain each individual concept of the API and the best practices. The **[sample notebooks](../python/samples/)** explain how to use the API to write Python scripts, incorporating capabilities such as mapping, query, analysis, geocoding, routing, portal administration, and more to solve real world problems. If you are looking for recipes, you may find them as sample notebooks. \n",
+    "\n",
+    "The **[api reference](/python/api-reference)** provides a reference for each class, its properties and methods in the `arcgis` package. The **[ArcGIS API for Python Community](https://community.esri.com/t5/arcgis-api-for-python/ct-p/arcgis-api-for-python)** is an [Esri Community](https://community.esri.com/) where you can share your thoughts about the API, request for features, conduct polls, report bugs, ask questions and engage with the Python community in general."
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": true,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
@mohi9282 @CMPeng
  * not sure why the files changed section in this PR seems to change the whole notebook. I only edited the last cell, entitled _How this website is organized_
  * in response to feedback email from `ResourceCtr-feedback@esri.com`:
    *  change the word `geonet` to `Esri Community` and add a link to the Esri Community homepage
    * add links to the `guides`, `samples`, `api-ref`, and specific `ArcGIS API for Python Community` home page

