### PR TITLE
fix misspelling in hyperlink to differences method

### DIFF
--- a/guide/02-api-overview/release_notes_201.ipynb
+++ b/guide/02-api-overview/release_notes_201.ipynb
@@ -117,7 +117,7 @@
     "#### [`arcgis.features.managers`](/python/api-reference/arcgis.features.managers/#)\n",
     "* [`Version`](/python/api-reference/arcgis.features.managers/#version)\n",
     "  * Adds parameter table to [`reconcile()`](/python/api-reference/arcgis.features.managers/#arcgis.features._version.Version.reconcile) documentation\n",
-    "  * Adds parameter documentation to [`differences()`](/python/api-reference/arcgis.features.managers/#arcgis.features._version.Version.differnces):\n",
+    "  * Adds parameter documentation to [`differences()`](/python/api-reference/arcgis.features.managers/#arcgis.features._version.Version.differences):\n",
     "    * `from_moment`\n",
     "    * `layers`\n",
     "    * `future` - asynchronous processing\n",
@@ -575,7 +575,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.11"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
@mohi9282 
* found typo in one of the links in the release notes