### PR TITLE
update relative link to install guide and alter sentence for min deps

### DIFF
--- a/guide/01-getting-started/system-requirements.ipynb
+++ b/guide/01-getting-started/system-requirements.ipynb
@@ -1,1 +1,135 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# System requirements"]}, {"cell_type": "markdown", "metadata": {"toc": true}, "source": ["<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n", "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#System-requirements\" data-toc-modified-id=\"System-requirements-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>System requirements</a></span><ul class=\"toc-item\"><li><span><a href=\"#Operating-System\" data-toc-modified-id=\"Operating-System-1.1\"><span class=\"toc-item-num\">1.1&nbsp;&nbsp;</span>Operating System</a></span></li><li><span><a href=\"#Python-Version\" data-toc-modified-id=\"Python-Version-1.2\"><span class=\"toc-item-num\">1.2&nbsp;&nbsp;</span>Python Version</a></span></li><li><span><a href=\"#Dependencies\" data-toc-modified-id=\"Dependencies-1.3\"><span class=\"toc-item-num\">1.3&nbsp;&nbsp;</span>Dependencies</a></span><ul class=\"toc-item\"><li><span><a href=\"#Optional-Dependencies\" data-toc-modified-id=\"Optional-Dependencies-1.3.1\"><span class=\"toc-item-num\">1.3.1&nbsp;&nbsp;</span>Optional Dependencies</a></span></li></ul></li></ul></li></ul></div>"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Operating System \n", "The ArcGIS API for Python is compatible with 32-bit and 64-bit versions of Windows, macOS, and Linux.\n", "\n", "## Python Version\n", "Python 3.5 or later is required to use the ArcGIS API for Python.\n", "\n", "## Dependencies\n", "The full power of the ArcGIS API for Python is best experienced when all its dependencies are installed. However, specific tasks such as GIS administration and content management can be accomplished with just the [`six`](https://pypi.python.org/pypi/six) package installed. See [Install without Dependencies](../install-and-set-up/#Install-without-Dependencies) to install the `arcgis` package in this manner.\n", "\n", "It is recommended to install the `arcgis` package the default way of either `conda install -c esri arcgis` or `pipenv install arcgis`. When installed in this manner, all the below dependencies are automatically installed. Note that most of these packages have dependencies of their own.\n", "\n", "* [six](https://pypi.python.org/pypi/six)\n", "* [pandas>=1.3.5](https://pandas.pydata.org/) \n", "* [numpy>=1.16.2](http://www.numpy.org/) \n", "* [pyshp>=2](https://pypi.python.org/pypi/pyshp/) \n", "* [matplotlib](https://matplotlib.org/)\n", "* [notebook](https://ipython.org/notebook.html)\n", "* [ipywidgets >=7](https://ipywidgets.readthedocs.io/en/stable/)\n", "* [widgetsnbextension >=3](https://pypi.python.org/pypi/widgetsnbextension)\n", "* [keyring>=23.3.*](https://pypi.python.org/pypi/keyring/10.6.0)\n", "* [winkerberos](https://pypi.python.org/pypi/winkerberos/0.7.0) (Windows only)\n", "* [urllib3](https://pypi.python.org/pypi/urllib3)\n", "* [cachetools](https://pypi.org/project/cachetools/)\n", "* [lxml](https://pypi.org/project/lxml/)\n", "* [cryptography](https://pypi.org/project/cryptography/)\n", "* [jupyter-client<=6.1.12](https://pypi.org/project/jupyter-client/)\n", "* [jupyterlab](https://pypi.org/project/jupyterlab/)\n", "* [lerc](https://pypi.org/project/lerc/)\n", "* [ujson>=3](https://pypi.org/project/ujson/)\n", "* [python-certifi-win32](https://pypi.org/project/python-certifi-win32/)\n", "* [pywin32>=223](https://pypi.org/project/pywin32/) (Windows only)\n", "* [geomet](https://pypi.org/project/geomet/)\n", "* [requests>=1.27.1](https://pypi.org/project/requests/)\n", "* [requests-oauthlib](https://pypi.org/project/requests-oauthlib/)\n", "* [requests_toolbelt](https://pypi.org/project/requests_toolbelt/)\n", "* [requests_ntlm](https://pypi.org/project/requests_ntlm/)\n", "* [requests-gssapi](https://pypi.org/project/requests-gssapi/)\n", "* [requests-negotiate-sspi](https://pypi.org/project/requests-negotiate-sspi/) (Windows only)\n", "* [requests-kerberos](https://pypi.org/project/requests-kerberos/) (Windows only)\n", "\n", "> Note: if `arcpy` is found in the current python environment, it may be used in various locations. Otherwise, `pyshp` will be used. See [Spatially Enabled DataFrame](https://developers.arcgis.com/python/api-reference/arcgis.features.toc.html?highlight=geoaccessor#arcgis.features.GeoAccessor) for more information.\n", "\n", "### Optional Dependencies\n", "\n", "There are some other python packages that may be required to use certain functionality in the API, but are __not__ automatically installed. To use that functionality, you must manually call `conda install {package_name}` or `pipenv install {package_name}` for such optional packages."]}], "metadata": {"kernelspec": {"display_name": "Python 3 (ipykernel)", "language": "python", "name": "python3"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.7.11"}, "toc": {"base_numbering": 1, "nav_menu": {}, "number_sections": true, "sideBar": true, "skip_h1_title": false, "title_cell": "Table of Contents", "title_sidebar": "Contents", "toc_cell": true, "toc_position": {}, "toc_section_display": true, "toc_window_display": true}, "varInspector": {"cols": {"lenName": 16, "lenType": 16, "lenVar": 40}, "kernels_config": {"python": {"delete_cmd_postfix": "", "delete_cmd_prefix": "del ", "library": "var_list.py", "varRefreshCmd": "print(var_dic_list())"}, "r": {"delete_cmd_postfix": ") ", "delete_cmd_prefix": "rm(", "library": "var_list.r", "varRefreshCmd": "cat(var_dic_list()) "}}, "types_to_exclude": ["module", "function", "builtin_function_or_method", "instance", "_Feature"], "window_display": false}}, "nbformat": 4, "nbformat_minor": 1}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# System requirements"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "toc": true
+   },
+   "source": [
+    "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
+    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#System-requirements\" data-toc-modified-id=\"System-requirements-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>System requirements</a></span><ul class=\"toc-item\"><li><span><a href=\"#Operating-System\" data-toc-modified-id=\"Operating-System-1.1\"><span class=\"toc-item-num\">1.1&nbsp;&nbsp;</span>Operating System</a></span></li><li><span><a href=\"#Python-Version\" data-toc-modified-id=\"Python-Version-1.2\"><span class=\"toc-item-num\">1.2&nbsp;&nbsp;</span>Python Version</a></span></li><li><span><a href=\"#Dependencies\" data-toc-modified-id=\"Dependencies-1.3\"><span class=\"toc-item-num\">1.3&nbsp;&nbsp;</span>Dependencies</a></span><ul class=\"toc-item\"><li><span><a href=\"#Optional-Dependencies\" data-toc-modified-id=\"Optional-Dependencies-1.3.1\"><span class=\"toc-item-num\">1.3.1&nbsp;&nbsp;</span>Optional Dependencies</a></span></li></ul></li></ul></li></ul></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Operating System \n",
+    "The ArcGIS API for Python is compatible with 32-bit and 64-bit versions of Windows, macOS, and Linux.\n",
+    "\n",
+    "## Python Version\n",
+    "Python 3.5 or later is required to use the ArcGIS API for Python.\n",
+    "\n",
+    "## Dependencies\n",
+    "The full power of the ArcGIS API for Python is best experienced when all its dependencies are installed. However, specific tasks such as GIS administration and content management can be accomplished with a subset of dependencies installed. See [Install with minimum Dependencies](../install-and-set-up#install-with-minimum-dependencies) to install the `arcgis` package in this manner.\n",
+    "\n",
+    "It is recommended to install the `arcgis` package the default way of either `conda install -c esri arcgis` or `pipenv install arcgis`. When installed in this manner, all the below dependencies are automatically installed. Note that most of these packages have dependencies of their own.\n",
+    "\n",
+    "* [six](https://pypi.python.org/pypi/six)\n",
+    "* [pandas>=1.3.5](https://pandas.pydata.org/) \n",
+    "* [numpy>=1.16.2](http://www.numpy.org/) \n",
+    "* [pyshp>=2](https://pypi.python.org/pypi/pyshp/) \n",
+    "* [matplotlib](https://matplotlib.org/)\n",
+    "* [notebook](https://ipython.org/notebook.html)\n",
+    "* [ipywidgets >=7](https://ipywidgets.readthedocs.io/en/stable/)\n",
+    "* [widgetsnbextension >=3](https://pypi.python.org/pypi/widgetsnbextension)\n",
+    "* [keyring>=23.3.*](https://pypi.python.org/pypi/keyring/10.6.0)\n",
+    "* [winkerberos](https://pypi.python.org/pypi/winkerberos/0.7.0) (Windows only)\n",
+    "* [urllib3](https://pypi.python.org/pypi/urllib3)\n",
+    "* [cachetools](https://pypi.org/project/cachetools/)\n",
+    "* [lxml](https://pypi.org/project/lxml/)\n",
+    "* [cryptography](https://pypi.org/project/cryptography/)\n",
+    "* [jupyter-client<=6.1.12](https://pypi.org/project/jupyter-client/)\n",
+    "* [jupyterlab](https://pypi.org/project/jupyterlab/)\n",
+    "* [lerc](https://pypi.org/project/lerc/)\n",
+    "* [ujson>=3](https://pypi.org/project/ujson/)\n",
+    "* [python-certifi-win32](https://pypi.org/project/python-certifi-win32/)\n",
+    "* [pywin32>=223](https://pypi.org/project/pywin32/) (Windows only)\n",
+    "* [geomet](https://pypi.org/project/geomet/)\n",
+    "* [requests>=1.27.1](https://pypi.org/project/requests/)\n",
+    "* [requests-oauthlib](https://pypi.org/project/requests-oauthlib/)\n",
+    "* [requests_toolbelt](https://pypi.org/project/requests_toolbelt/)\n",
+    "* [requests_ntlm](https://pypi.org/project/requests_ntlm/)\n",
+    "* [requests-gssapi](https://pypi.org/project/requests-gssapi/)\n",
+    "* [requests-negotiate-sspi](https://pypi.org/project/requests-negotiate-sspi/) (Windows only)\n",
+    "* [requests-kerberos](https://pypi.org/project/requests-kerberos/) (Windows only)\n",
+    "\n",
+    "> Note: if `arcpy` is found in the current python environment, it may be used in various locations. Otherwise, `pyshp` will be used. See [Spatially Enabled DataFrame](https://developers.arcgis.com/python/api-reference/arcgis.features.toc.html?highlight=geoaccessor#arcgis.features.GeoAccessor) for more information.\n",
+    "\n",
+    "### Optional Dependencies\n",
+    "\n",
+    "There are some other python packages that may be required to use certain functionality in the API, but are __not__ automatically installed. To use that functionality, you must manually call `conda install {package_name}` or `pipenv install {package_name}` for such optional packages."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.11"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": true,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
* resolves #1355 
* updated text in the sentence as well as the relative link for the `install with minimum dependencies` paragraph in the system requirements guide
* specific changes are in line #31 below, not sure why the whole nb is updated. See below for a screenshot:
  <img width="904" alt="image" src="https://user-images.githubusercontent.com/1399179/197859687-1464846c-3bbc-43bc-9da5-1394bf1f7b89.png">
* link goes to: `guide/install-and-set-up/#install-with-minimum-dependencies`
