### PR TITLE
Fix rendering of the `Performing big data analysis` guide for body and right-hand navigation

### DIFF
--- a/guide/07-working-with-bigdata/03-performing_big_data_analysis.ipynb
+++ b/guide/07-working-with-bigdata/03-performing_big_data_analysis.ipynb
@@ -160,7 +160,7 @@
    "id": "7803cb1a",
    "metadata": {},
    "source": [
-    "<b>Set spatial reference"
+    "### Set spatial reference"
    ]
   },
   {

--- a/guide/07-working-with-bigdata/03-performing_big_data_analysis.ipynb
+++ b/guide/07-working-with-bigdata/03-performing_big_data_analysis.ipynb
@@ -23,7 +23,7 @@
    "id": "87173a6f",
    "metadata": {},
    "source": [
-    "<h2><b>Tools Overview"
+    "## Tools Overview"
    ]
   },
   {
@@ -65,7 +65,7 @@
    "id": "926d301e",
    "metadata": {},
    "source": [
-    "#### Feature Input"
+    "### Feature Input"
    ]
   },
   {
@@ -85,7 +85,7 @@
    "id": "9755fd6d",
    "metadata": {},
    "source": [
-    "#### Feature Output"
+    "### Feature Output"
    ]
   },
   {
@@ -188,7 +188,7 @@
    "id": "38e06489",
    "metadata": {},
    "source": [
-    "<b>Verbosity of messages"
+    "### Verbosity of messages"
    ]
   },
   {
@@ -214,7 +214,7 @@
    "id": "a66f6ce5",
    "metadata": {},
    "source": [
-    "<b>Context Parameter"
+    "### Context Parameter"
    ]
   },
   {
@@ -341,7 +341,7 @@
    "id": "12b7ff6a",
    "metadata": {},
    "source": [
-    "<b>Ensure your GIS supports GeoAnalytics"
+    "### Ensure your GIS supports GeoAnalytics"
    ]
   },
   {
@@ -378,7 +378,7 @@
    "id": "2e5f25d0",
    "metadata": {},
    "source": [
-    "<b>Search big data file share item "
+    "### Search big data file share item "
    ]
   },
   {
@@ -529,7 +529,7 @@
    "id": "51c258a3",
    "metadata": {},
    "source": [
-    "<b> Sync execution </b>"
+    "###  Sync execution"
    ]
   },
   {
@@ -589,7 +589,7 @@
    "id": "592d309e",
    "metadata": {},
    "source": [
-    "<b> Async execution </b>"
+    "### Async execution"
    ]
   },
   {
@@ -691,7 +691,7 @@
    "id": "59b211ee",
    "metadata": {},
    "source": [
-    "<b>Apply spatial filter"
+    "### Apply spatial filter"
    ]
   },
   {
@@ -797,7 +797,7 @@
    "id": "b62135e5",
    "metadata": {},
    "source": [
-    "<b>Apply filter by field value"
+    "### Apply filter by field value"
    ]
   },
   {
@@ -965,7 +965,7 @@
    "id": "3f263c05",
    "metadata": {},
    "source": [
-    "<b>Apply time filter"
+    "### Apply time filter"
    ]
   },
   {
@@ -998,7 +998,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
* Changed source notebook markdown cell headings from html to markdown
  * For example, the markdown cell for the `Tools Overview` was initially `<b>Tools Overview</b>` and changed it to `## Tools Overview`
  * Many markdown cells in the notebook used the `<b>` html tag which caused rendering issues with the Gatsby Developer Website system

|**Before**|**After**|
|---|---|
![image](https://user-images.githubusercontent.com/1399179/213306755-382d38a9-8f63-4677-9270-f865dec706cb.png)|![image](https://user-images.githubusercontent.com/1399179/213306824-53d70832-6d9b-4d15-8eae-30108beceada.png)
![image](https://user-images.githubusercontent.com/1399179/213306912-4ea03097-2089-4b3c-8b15-8de6cecf38e7.png)|![image](https://user-images.githubusercontent.com/1399179/213306996-c19e0517-166b-45e8-a41c-881fa0fc778c.png)

---
Making the changes from `html` tags to `markdown` tags fixed the issue when building the website locally.

-----

