### PR TITLE
enterprise sites guide

### DIFF
--- a/guide/13-managing-arcgis-applications/enterprise-sites-guide.ipynb
+++ b/guide/13-managing-arcgis-applications/enterprise-sites-guide.ipynb
@@ -7,14 +7,14 @@
    "source": [
     "# Introduction to Enterprise Sites features\n",
     "\n",
-    "ArcGIS Enterprise Sites allows you to create a tailored web page experience for your users to help you share your portal's authoritative GIS data to other departments more easily, even if they are not used to working in your GIS. Instead of learning to navigate the portal and access groups, members can go directly to the custom web page you create to navigate the content relevant to them. Click [here](https://enterprise.arcgis.com/en/sites/) to learn more about Enterprise Sites.\n",
+    "ArcGIS Enterprise Sites allows you to create a tailored web page experience for your users by allowing you to share your portal's authoritative GIS data to other departments more easily, even if they are not used to working in your GIS. Instead of learning to navigate the portal and access groups, members can go directly to the custom web page you create to navigate the content relevant to them. Click [here](https://enterprise.arcgis.com/en/sites/) to learn more about Enterprise Sites.\n",
     "\n",
-    "Note: The pattern to add, search, get, update, delete `Sites` and `Pages` is identical to that of __Initiatives__ (insert link to premium nb) as demonstrated here. \n",
+    "Note: The pattern to add, search, get, update and delete `Sites` and `Pages` is identical to that of __Initiatives__ (insert link to premium nb) as demonstrated here. \n",
     "\n",
-    "In this notebook we will take a look at examples to\n",
-    "* Create site with custom domain and pages\n",
-    "* Edit site theme\n",
-    "* Edit page layout"
+    "In this notebook, we will demonstrate how to\n",
+    "* Create a site with a custom domain and pages\n",
+    "* Edit a site's theme\n",
+    "* Edit a site's page layout"
    ]
   },
   {
@@ -32,11 +32,11 @@
    "id": "696a104d",
    "metadata": {},
    "source": [
-    "We will sign into an ArcGIS Enterprise organization to demonstrate these workflows. We can work with Enterprise Sites using the `sites` property of the `GIS` object. \n",
+    "First, we will sign into an ArcGIS Enterprise organization to demonstrate these workflows. We can work with Enterprise Sites using the `sites` property of the `GIS` object. \n",
     "\n",
     "Note: This workflow is for demonstration purposes only. To replicate this, you may have to sign-in to an ArcGIS Enterprise organization you have access to.\n",
     "\n",
-    "Here are examples for working with Initiatives and Events using __ArcGIS Premium__ (insert live URL) and site and page creation and cloning using __ArcGIS Basic__ (insert live URL) to see other ways of working with your Hub using the ArcGIS API for Python. "
+    "Here are examples for working with Initiatives and Events using __ArcGIS Premium__ (insert live URL) and site and page creation and cloning using __ArcGIS Basic__ (insert live URL) that demonstrate other ways of working with your Hub using the ArcGIS API for Python. "
    ]
   },
   {
@@ -188,7 +188,7 @@
    "id": "842b184b",
    "metadata": {},
    "source": [
-    "We fetch the value for the `background` color for this site theme, to change it."
+    "Next, we fetch the value for the `background` color for this site theme to change it."
    ]
   },
   {
@@ -274,8 +274,8 @@
     "\n",
     "The Site Editor provides a user with several capabilities in the form of __cards__ to simplify their site building and editing workflows. However, applying a common change to multiple sites and pages in your organization can become a tedious process.\n",
     "Using the site layout editing functionality supported in the Python API, you can successfully apply a common change across all the necessary sites and pages. \n",
-    "In order to programmatically edit a site, we need to take a deeper dive into the data model of a Site/Page item. The site layout has __Sections__ which contain __Rows__ within, and the row contain __Cards__ within. \n",
-    "Sections have configurable attributes such as background color and font-color and are used to theme a site or page. Rows are the building blocks of your site are implicitly created when you add a card to a section below another card. Whenever you want to add a card, such as a text card or image card, you must have a row card positioned where you want to add the content. Multiple cards can fit in a row card.\n",
+    "In order to programmatically edit a site, we need to take a deeper dive into the data model of a Site/Page item. The site layout has __Sections__ that contain __Rows__, and the rows further contain __Cards__. \n",
+    "Sections have configurable attributes, like background color and font-color, and are used to theme a site or page. Rows are the building blocks of your site and are implicitly created when you add a card to a section below another card. Whenever you want to add a card, such as a text card or image card, you must have a row card positioned where you want to add that content. Multiple cards can fit in a row card.\n",
     "\n",
     "![site_layout](https://user-images.githubusercontent.com/13968196/75702534-a8c25280-5c83-11ea-844a-1b513bdef50b.png)"
    ]
@@ -285,7 +285,7 @@
    "id": "ac17fa13",
    "metadata": {},
    "source": [
-    "We will see an example each of editing the layout of this site and its page. \n",
+    "Next, we will see an example of how to edit each aspect of the layout of this site and its page. \n",
     "\n",
     "The process is similar to editing the theme of the site. We fetch the layout of the site/page, make the required changes and commit them using the `update_layout()` method. "
    ]
@@ -313,7 +313,7 @@
    "id": "4a33646b",
    "metadata": {},
    "source": [
-    "You can access the nested sections, rows and cards of the layout as follows:"
+    "You can access the nested sections, rows and cards of the layout as shown below."
    ]
   },
   {
@@ -342,9 +342,9 @@
    "id": "01d0d218",
    "metadata": {},
    "source": [
-    "To add a new card you update the cards list - for the row within the section - with the dictionary for the new card.\n",
+    "To add a new card, you must update the cards list for the row within the section with the dictionary for the new card.\n",
     "\n",
-    "We start by first accessing the row of interest we would like to add the new card to."
+    "First, we will access the row we want to add the new card to."
    ]
   },
   {
@@ -373,7 +373,7 @@
    "id": "0bdb72ce",
    "metadata": {},
    "source": [
-    "The 1st row of 2nd section has 1 text card. We will now add another text card."
+    "The first row of second section has 1 text card. We will now add another text card."
    ]
   },
   {
@@ -408,7 +408,7 @@
    "id": "e4a57e25",
    "metadata": {},
    "source": [
-    "Let's publish these changes and verify them on the site."
+    "Now, we publish these changes and verify them on the site."
    ]
   },
   {
@@ -449,7 +449,7 @@
    "source": [
     "### Deleting a card from the page\n",
     "\n",
-    "We will now delete the red text card from the page that reads \"Where we're going\". We first fetch the layout of the page, delete the card from the layout and publish the changes.\n",
+    "We will now delete the red text card from the page that reads \"Where we're going\". To do this, we fetch the layout of the page, delete the card from the layout, and publish the changes.\n",
     "\n",
     "![image](https://user-images.githubusercontent.com/13968196/207743156-a671fc6b-f2ef-4484-909e-353436c88fe8.png)"
    ]
@@ -490,7 +490,7 @@
    "id": "863d2295",
    "metadata": {},
    "source": [
-    "We delete this card from the row."
+    "Next, we delete the card from the row."
    ]
   },
   {

--- a/guide/13-managing-arcgis-applications/enterprise-sites-guide.ipynb
+++ b/guide/13-managing-arcgis-applications/enterprise-sites-guide.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "ArcGIS Enterprise Sites allows you to create a tailored web page experience for your users by allowing you to share your portal's authoritative GIS data to other departments more easily, even if they are not used to working in your GIS. Instead of learning to navigate the portal and access groups, members can go directly to the custom web page you create to navigate the content relevant to them. Click [here](https://enterprise.arcgis.com/en/sites/) to learn more about Enterprise Sites.\n",
     "\n",
-    "Note: The pattern to add, search, get, update and delete `Sites` and `Pages` is identical to that of __Initiatives__ (insert link to premium nb) as demonstrated here. \n",
+    "Note: The pattern to add, search, get, update and delete `Sites` and `Pages` is identical to that of [Initiatives](../guide/hub-for-guide-premium) as demonstrated here. \n",
     "\n",
     "In this notebook, we will demonstrate how to\n",
     "* Create a site with a custom domain and pages\n",
@@ -36,7 +36,7 @@
     "\n",
     "Note: This workflow is for demonstration purposes only. To replicate this, you may have to sign-in to an ArcGIS Enterprise organization you have access to.\n",
     "\n",
-    "Here are examples for working with Initiatives and Events using __ArcGIS Premium__ (insert live URL) and site and page creation and cloning using __ArcGIS Basic__ (insert live URL) that demonstrate other ways of working with your Hub using the ArcGIS API for Python. "
+    "Here are examples for working with Initiatives and Events using [ArcGIS Premium](../guide/hub-for-guide-premium) and site and page creation and cloning using [ArcGIS Basic](../guide/hub-for-guide-basic) that demonstrate other ways of working with your Hub using the ArcGIS API for Python. "
    ]
   },
   {
@@ -54,12 +54,12 @@
     }
    ],
    "source": [
-    "gis_portal = GIS(\"https://rpubs22001.ags.esri.com/portal/home/\", \"creator1\")"
+    "gis_portal = GIS(profile='your_enterprise_profile')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "5d3bb436",
    "metadata": {},
    "outputs": [
@@ -68,16 +68,16 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://rpubs22001.ags.esri.com/portal/home//home/item.html?id=99c495bf38684dada961ac3de50a9e19' target='_blank'>\n",
+       "                       <a href='https://rpubs22001.ags.esri.com/portal/home//home/item.html?id=a6d496adc7fc4be39ee1990c30380b23' target='_blank'>\n",
        "                        <img src='https://rpubs22001.ags.esri.com/portal/home//portalimages/desktopapp.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://rpubs22001.ags.esri.com/portal/home//home/item.html?id=99c495bf38684dada961ac3de50a9e19' target='_blank'><b>Portal Python Site</b>\n",
+       "                        <a href='https://rpubs22001.ags.esri.com/portal/home//home/item.html?id=a6d496adc7fc4be39ee1990c30380b23' target='_blank'><b>Portal Python Site</b>\n",
        "                        </a>\n",
-       "                        <br/><img src='https://rpubs22001.ags.esri.com/portal/home//home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">Site Application by creator1\n",
-       "                        <br/>Last Modified: December 14, 2022\n",
+       "                        <br/><img src='https://rpubs22001.ags.esri.com/portal/home//home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\" width=16 height=16>Site Application by creator1\n",
+       "                        <br/>Last Modified: July 07, 2023\n",
        "                        <br/>0 comments, 0 views\n",
        "                    </div>\n",
        "                </div>\n",
@@ -87,14 +87,22 @@
        "<Item title:\"Portal Python Site\" type:Site Application owner:creator1>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "portal_site = gis_portal.sites.add('Portal Python Site', subdomain='site-in-python')\n",
+    "portal_site = gis_portal.sites.add('Portal Python Site', subdomain='site-in-python-new')\n",
     "portal_site.item"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f493aceb",
+   "metadata": {},
+   "source": [
+    "Enterprise Sites also come with a Site item and the Content Team group for that site, where you can add the items for your site's Content Library. Users with Administrative privileges that create a site will also have a Core Team group created as part of the site, to allow collaboration among members of that team. You can also create Enterprise Sites with a custom domain that is different from the title, as shown above."
    ]
   },
   {
@@ -107,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "88c384d2",
    "metadata": {},
    "outputs": [
@@ -116,16 +124,16 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://rpubs22001.ags.esri.com/portal/home//home/item.html?id=d09143066cc04d14b4d29d9b4344ebfc' target='_blank'>\n",
+       "                       <a href='https://rpubs22001.ags.esri.com/portal/home//home/item.html?id=efc8a92f48c6487da49cb1770178e6ae' target='_blank'>\n",
        "                        <img src='https://rpubs22001.ags.esri.com/portal/home//portalimages/desktopapp.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://rpubs22001.ags.esri.com/portal/home//home/item.html?id=d09143066cc04d14b4d29d9b4344ebfc' target='_blank'><b>New page</b>\n",
+       "                        <a href='https://rpubs22001.ags.esri.com/portal/home//home/item.html?id=efc8a92f48c6487da49cb1770178e6ae' target='_blank'><b>New page</b>\n",
        "                        </a>\n",
-       "                        <br/><img src='https://rpubs22001.ags.esri.com/portal/home//home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">Site Page by creator1\n",
-       "                        <br/>Last Modified: December 14, 2022\n",
+       "                        <br/><img src='https://rpubs22001.ags.esri.com/portal/home//home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\" width=16 height=16>Site Page by creator1\n",
+       "                        <br/>Last Modified: July 07, 2023\n",
        "                        <br/>0 comments, 0 views\n",
        "                    </div>\n",
        "                </div>\n",
@@ -135,7 +143,7 @@
        "<Item title:\"New page\" type:Site Page owner:creator1>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -163,17 +171,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "33c1e112",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'header': {'background': '#fff', 'text': '#4c4c4c'}, 'body': {'background': '#fff', 'text': '#4c4c4c', 'link': '#0079c1'}, 'button': {'background': '#0079c1', 'text': '#fff'}, 'logo': {'small': ''}, 'fonts': {'base': {'url': '', 'family': 'Avenir Next'}, 'heading': {'url': '', 'family': 'Avenir Next'}}}"
+       "{'header': {'background': '#fff', 'text': '#000000'}, 'body': {'background': '#fff', 'text': '#4c4c4c', 'link': '#0079c1'}, 'button': {'background': '#0079c1', 'text': '#fff'}, 'logo': {'small': ''}, 'fonts': {'base': {'url': '', 'family': 'Avenir Next'}, 'heading': {'url': '', 'family': 'Avenir Next'}}, 'globalNav': {'background': '#fff', 'text': '#000000'}}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -193,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "6fd93ff8",
    "metadata": {},
    "outputs": [
@@ -203,7 +211,7 @@
        "'#fff'"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -226,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "c3cf31ac",
    "metadata": {},
    "outputs": [],
@@ -236,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "200b2186",
    "metadata": {},
    "outputs": [
@@ -246,7 +254,7 @@
        "True"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -300,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "958142e9",
    "metadata": {},
    "outputs": [],
@@ -318,17 +326,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "cbf5e535",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'component': {'name': 'jumbotron-card', 'settings': {'header': 'Data Sharing', 'subheader': 'Search, Visualize, Download, Create', 'minHeight': '150', 'showLocation': False, 'imageUrl': '', 'showSearch': False}}, 'width': 12}"
+       "{'component': {'name': 'spacer-card', 'settings': {'height': '50'}}, 'width': 12}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -349,17 +357,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "f993f45b",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'cards': [{'component': {'name': 'markdown-card', 'settings': {'markdown': \"<p class='lead text-justify'>This is the platform for exploring and downloading GIS data, discovering and building apps, and engaging others to solve important issues. You can analyze and combine datasets using maps, as well as develop new web and mobile applications. Let's achieve our goals together</p>\"}}, 'width': 12, 'showEditor': False}]}"
+       "{'cards': [{'component': {'name': 'markdown-card', 'settings': {'schemaVersion': 1, 'markdown': '<p class=\"lead text-justify\">This is the platform for exploring and downloading GIS data, discovering and building apps, and engaging others to solve important issues. You can analyze and combine datasets using maps, as well as develop new web and mobile applications. Let\\'s achieve our goals together</p>'}}, 'width': 12, 'showEditor': False}]}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -378,21 +386,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "03cbdf46",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[{'component': {'name': 'markdown-card', 'settings': {'markdown': \"<p class='lead text-justify'>This is the platform for exploring and downloading GIS data, discovering and building apps, and engaging others to solve important issues. You can analyze and combine datasets using maps, as well as develop new web and mobile applications. Let's achieve our goals together</p>\"}}, 'width': 12, 'showEditor': False},\n",
+       "[{'component': {'name': 'markdown-card', 'settings': {'schemaVersion': 1, 'markdown': '<p class=\"lead text-justify\">This is the platform for exploring and downloading GIS data, discovering and building apps, and engaging others to solve important issues. You can analyze and combine datasets using maps, as well as develop new web and mobile applications. Let\\'s achieve our goals together</p>'}}, 'width': 12, 'showEditor': False},\n",
        " {'component': {'name': 'markdown-card',\n",
        "   'settings': {'markdown': 'Build tailored websites and webpages to showcase ArcGIS Enterprise content to your users.'}},\n",
        "  'width': 6,\n",
        "  'showEditor': False}]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -413,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "3dfd7207",
    "metadata": {},
    "outputs": [
@@ -423,7 +431,7 @@
        "True"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -456,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "93c32836",
    "metadata": {},
    "outputs": [],
@@ -466,7 +474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "cff113c2",
    "metadata": {},
    "outputs": [
@@ -476,7 +484,7 @@
        "{'component': {'name': 'markdown-card', 'settings': {'markdown': \"<h2 id='where-we-re-going'>Where We&#39;re Going</h2> <p>Here are the next steps and how we need your help to improve this data:</p> \", 'schemaVersion': 1}}, 'width': 12, 'showEditor': False}"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -495,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "9dd885d4",
    "metadata": {},
    "outputs": [
@@ -505,7 +513,7 @@
        "{'cards': [{'component': {'name': 'markdown-card', 'settings': {'markdown': \"<h2 id='where-we-re-going'>Where We&#39;re Going</h2> <p>Here are the next steps and how we need your help to improve this data:</p> \", 'schemaVersion': 1}}, 'width': 12, 'showEditor': False}]}"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -516,7 +524,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "c0c5e5b6",
    "metadata": {},
    "outputs": [
@@ -526,7 +534,7 @@
        "True"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -570,7 +578,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.11"
+   "version": "3.7.16"
   }
  },
  "nbformat": 4,

--- a/guide/13-managing-arcgis-applications/enterprise-sites-guide.ipynb
+++ b/guide/13-managing-arcgis-applications/enterprise-sites-guide.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "ArcGIS Enterprise Sites allows you to create a tailored web page experience for your users by allowing you to share your portal's authoritative GIS data to other departments more easily, even if they are not used to working in your GIS. Instead of learning to navigate the portal and access groups, members can go directly to the custom web page you create to navigate the content relevant to them. Click [here](https://enterprise.arcgis.com/en/sites/) to learn more about Enterprise Sites.\n",
     "\n",
-    "Note: The pattern to add, search, get, update and delete `Sites` and `Pages` is identical to that of [Initiatives](../guide/hub-for-guide-premium) as demonstrated here. \n",
+    ">_Note:_ The pattern to add, search, get, update and delete `Sites` and `Pages` is identical to that of [Initiatives](../hub-for-guide-premium). \n",
     "\n",
     "In this notebook, we will demonstrate how to\n",
     "* Create a site with a custom domain and pages\n",
@@ -36,7 +36,7 @@
     "\n",
     "Note: This workflow is for demonstration purposes only. To replicate this, you may have to sign-in to an ArcGIS Enterprise organization you have access to.\n",
     "\n",
-    "Here are examples for working with Initiatives and Events using [ArcGIS Premium](../guide/hub-for-guide-premium) and site and page creation and cloning using [ArcGIS Basic](../guide/hub-for-guide-basic) that demonstrate other ways of working with your Hub using the ArcGIS API for Python. "
+    "The following are examples for working with Initiatives and Events using [ArcGIS Premium](../hub-for-guide-premium) and site and page creation and cloning using [ArcGIS Basic](../hub-for-guide-basic) that demonstrate other ways of working with your Hub using the ArcGIS API for Python. "
    ]
   },
   {
@@ -102,7 +102,7 @@
    "id": "f493aceb",
    "metadata": {},
    "source": [
-    "Enterprise Sites also come with a Site item and the Content Team group for that site, where you can add the items for your site's Content Library. Users with Administrative privileges that create a site will also have a Core Team group created as part of the site, to allow collaboration among members of that team. You can also create Enterprise Sites with a custom domain that is different from the title, as shown above."
+    "Enterprise Sites also come with a Site item and the Content Team group for that site, where you can add the items for your site's Content Library. Additional information about this can be found in ArcGIS Hub's [Content Basics](https://doc.arcgis.com/en/hub/content/content-basics.htm) documentation. Users with Administrative privileges that create a site will also have a Core Team group created as part of the site, to allow collaboration among members of that team. You can also create Enterprise Sites with a custom domain that is different from the title, as shown above."
    ]
   },
   {
@@ -578,7 +578,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.16"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/guide/13-managing-arcgis-applications/enterprise-sites-guide.ipynb
+++ b/guide/13-managing-arcgis-applications/enterprise-sites-guide.ipynb
@@ -1,0 +1,578 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ce0d50bb",
+   "metadata": {},
+   "source": [
+    "# Introduction to Enterprise Sites features\n",
+    "\n",
+    "ArcGIS Enterprise Sites allows you to create a tailored web page experience for your users to help you share your portal's authoritative GIS data to other departments more easily, even if they are not used to working in your GIS. Instead of learning to navigate the portal and access groups, members can go directly to the custom web page you create to navigate the content relevant to them. Click [here](https://enterprise.arcgis.com/en/sites/) to learn more about Enterprise Sites.\n",
+    "\n",
+    "Note: The pattern to add, search, get, update, delete `Sites` and `Pages` is identical to that of __Initiatives__ (insert link to premium nb) as demonstrated here. \n",
+    "\n",
+    "In this notebook we will take a look at examples to\n",
+    "* Create site with custom domain and pages\n",
+    "* Edit site theme\n",
+    "* Edit page layout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "02f133d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from arcgis.gis import GIS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "696a104d",
+   "metadata": {},
+   "source": [
+    "We will sign into an ArcGIS Enterprise organization to demonstrate these workflows. We can work with Enterprise Sites using the `sites` property of the `GIS` object. \n",
+    "\n",
+    "Note: This workflow is for demonstration purposes only. To replicate this, you may have to sign-in to an ArcGIS Enterprise organization you have access to.\n",
+    "\n",
+    "Here are examples for working with Initiatives and Events using __ArcGIS Premium__ (insert live URL) and site and page creation and cloning using __ArcGIS Basic__ (insert live URL) to see other ways of working with your Hub using the ArcGIS API for Python. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "653f56e1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Enter password: ········\n"
+     ]
+    }
+   ],
+   "source": [
+    "gis_portal = GIS(\"https://rpubs22001.ags.esri.com/portal/home/\", \"creator1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5d3bb436",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://rpubs22001.ags.esri.com/portal/home//home/item.html?id=99c495bf38684dada961ac3de50a9e19' target='_blank'>\n",
+       "                        <img src='https://rpubs22001.ags.esri.com/portal/home//portalimages/desktopapp.png' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://rpubs22001.ags.esri.com/portal/home//home/item.html?id=99c495bf38684dada961ac3de50a9e19' target='_blank'><b>Portal Python Site</b>\n",
+       "                        </a>\n",
+       "                        <br/><img src='https://rpubs22001.ags.esri.com/portal/home//home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">Site Application by creator1\n",
+       "                        <br/>Last Modified: December 14, 2022\n",
+       "                        <br/>0 comments, 0 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"Portal Python Site\" type:Site Application owner:creator1>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "portal_site = gis_portal.sites.add('Portal Python Site', subdomain='site-in-python')\n",
+    "portal_site.item"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb3ae83e",
+   "metadata": {},
+   "source": [
+    "Let's add a page to the site."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "88c384d2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                       <a href='https://rpubs22001.ags.esri.com/portal/home//home/item.html?id=d09143066cc04d14b4d29d9b4344ebfc' target='_blank'>\n",
+       "                        <img src='https://rpubs22001.ags.esri.com/portal/home//portalimages/desktopapp.png' class=\"itemThumbnail\">\n",
+       "                       </a>\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <a href='https://rpubs22001.ags.esri.com/portal/home//home/item.html?id=d09143066cc04d14b4d29d9b4344ebfc' target='_blank'><b>New page</b>\n",
+       "                        </a>\n",
+       "                        <br/><img src='https://rpubs22001.ags.esri.com/portal/home//home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">Site Page by creator1\n",
+       "                        <br/>Last Modified: December 14, 2022\n",
+       "                        <br/>0 comments, 0 views\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<Item title:\"New page\" type:Site Page owner:creator1>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "portal_page = portal_site.pages.add('New page')\n",
+    "portal_page.item"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09eda9df",
+   "metadata": {},
+   "source": [
+    "### Editing the theme of a site\n",
+    "\n",
+    "The __Theme__ settings help you define the colors for the header, global navigation bar, buttons, text, and background colors. The colors and fonts that you select are applied to the entire site layout and to any pages attached to the site.\n",
+    "\n",
+    "Here is the default theme for the site we just created. We will see how a theme of a site can be edited. \n",
+    "\n",
+    "![image](https://user-images.githubusercontent.com/13968196/207694302-a6ee8fd7-6c86-46e0-b725-5452642d714f.png)\n",
+    "\n",
+    "We start by fetching the theme for this site."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "33c1e112",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'header': {'background': '#fff', 'text': '#4c4c4c'}, 'body': {'background': '#fff', 'text': '#4c4c4c', 'link': '#0079c1'}, 'button': {'background': '#0079c1', 'text': '#fff'}, 'logo': {'small': ''}, 'fonts': {'base': {'url': '', 'family': 'Avenir Next'}, 'heading': {'url': '', 'family': 'Avenir Next'}}}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "theme = portal_site.theme\n",
+    "theme"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "842b184b",
+   "metadata": {},
+   "source": [
+    "We fetch the value for the `background` color for this site theme, to change it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6fd93ff8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'#fff'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "theme.body.background"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "263acc06",
+   "metadata": {},
+   "source": [
+    "### Updating the theme for this site\n",
+    "\n",
+    "Updating this theme color is a two-step process. You first assign newer values to the theme variables, and then use the `update_theme()` method to commit these changes to the site object.\n",
+    "\n",
+    "This same process of assigning new values to existing variables (sections, rows, cards) can be followed to update the specific layout elements of the site or page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c3cf31ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "theme.body.background = '#b20000'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "200b2186",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "portal_site.update_theme(theme)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d99b678e",
+   "metadata": {},
+   "source": [
+    "The theme background color has successfully changed on our site.\n",
+    "\n",
+    "![image](https://user-images.githubusercontent.com/13968196/207700016-7b204b6b-2c93-4e2b-ab75-50ec356e6515.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b95f120b",
+   "metadata": {},
+   "source": [
+    "### Background on the layout of a site and page\n",
+    "\n",
+    "The Site Editor provides a user with several capabilities in the form of __cards__ to simplify their site building and editing workflows. However, applying a common change to multiple sites and pages in your organization can become a tedious process.\n",
+    "Using the site layout editing functionality supported in the Python API, you can successfully apply a common change across all the necessary sites and pages. \n",
+    "In order to programmatically edit a site, we need to take a deeper dive into the data model of a Site/Page item. The site layout has __Sections__ which contain __Rows__ within, and the row contain __Cards__ within. \n",
+    "Sections have configurable attributes such as background color and font-color and are used to theme a site or page. Rows are the building blocks of your site are implicitly created when you add a card to a section below another card. Whenever you want to add a card, such as a text card or image card, you must have a row card positioned where you want to add the content. Multiple cards can fit in a row card.\n",
+    "\n",
+    "![site_layout](https://user-images.githubusercontent.com/13968196/75702534-a8c25280-5c83-11ea-844a-1b513bdef50b.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac17fa13",
+   "metadata": {},
+   "source": [
+    "We will see an example each of editing the layout of this site and its page. \n",
+    "\n",
+    "The process is similar to editing the theme of the site. We fetch the layout of the site/page, make the required changes and commit them using the `update_layout()` method. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc942a1d",
+   "metadata": {},
+   "source": [
+    "### Adding a new card to the site"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "958142e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layout1 = portal_site.layout"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a33646b",
+   "metadata": {},
+   "source": [
+    "You can access the nested sections, rows and cards of the layout as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cbf5e535",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'component': {'name': 'jumbotron-card', 'settings': {'header': 'Data Sharing', 'subheader': 'Search, Visualize, Download, Create', 'minHeight': '150', 'showLocation': False, 'imageUrl': '', 'showSearch': False}}, 'width': 12}"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "layout1.sections[0].ROWS[0].cards[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01d0d218",
+   "metadata": {},
+   "source": [
+    "To add a new card you update the cards list - for the row within the section - with the dictionary for the new card.\n",
+    "\n",
+    "We start by first accessing the row of interest we would like to add the new card to."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f993f45b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'cards': [{'component': {'name': 'markdown-card', 'settings': {'markdown': \"<p class='lead text-justify'>This is the platform for exploring and downloading GIS data, discovering and building apps, and engaging others to solve important issues. You can analyze and combine datasets using maps, as well as develop new web and mobile applications. Let's achieve our goals together</p>\"}}, 'width': 12, 'showEditor': False}]}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "layout1.sections[1].rows[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bdb72ce",
+   "metadata": {},
+   "source": [
+    "The 1st row of 2nd section has 1 text card. We will now add another text card."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "03cbdf46",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'component': {'name': 'markdown-card', 'settings': {'markdown': \"<p class='lead text-justify'>This is the platform for exploring and downloading GIS data, discovering and building apps, and engaging others to solve important issues. You can analyze and combine datasets using maps, as well as develop new web and mobile applications. Let's achieve our goals together</p>\"}}, 'width': 12, 'showEditor': False},\n",
+       " {'component': {'name': 'markdown-card',\n",
+       "   'settings': {'markdown': 'Build tailored websites and webpages to showcase ArcGIS Enterprise content to your users.'}},\n",
+       "  'width': 6,\n",
+       "  'showEditor': False}]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_card = {'component': {'name': \"markdown-card\",'settings': {'markdown': \"Build tailored websites and webpages to showcase ArcGIS Enterprise content to your users.\"}},'width': 6,'showEditor': False}\n",
+    "layout1.sections[1].rows[0].cards.append(new_card)\n",
+    "layout1.sections[1].rows[0].cards"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4a57e25",
+   "metadata": {},
+   "source": [
+    "Let's publish these changes and verify them on the site."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "3dfd7207",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "portal_site.update_layout(layout1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cca3211e",
+   "metadata": {},
+   "source": [
+    "![image](https://user-images.githubusercontent.com/13968196/207742634-d54632e8-3312-4976-986a-5bbbf018ff18.png)\n",
+    "\n",
+    "The new text card is successfully added to the site."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "045370cd",
+   "metadata": {},
+   "source": [
+    "### Deleting a card from the page\n",
+    "\n",
+    "We will now delete the red text card from the page that reads \"Where we're going\". We first fetch the layout of the page, delete the card from the layout and publish the changes.\n",
+    "\n",
+    "![image](https://user-images.githubusercontent.com/13968196/207743156-a671fc6b-f2ef-4484-909e-353436c88fe8.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "93c32836",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layout2 = portal_page.layout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "cff113c2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'component': {'name': 'markdown-card', 'settings': {'markdown': \"<h2 id='where-we-re-going'>Where We&#39;re Going</h2> <p>Here are the next steps and how we need your help to improve this data:</p> \", 'schemaVersion': 1}}, 'width': 12, 'showEditor': False}"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "layout2.sections[2].rows[0].cards[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "863d2295",
+   "metadata": {},
+   "source": [
+    "We delete this card from the row."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "9dd885d4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'cards': [{'component': {'name': 'markdown-card', 'settings': {'markdown': \"<h2 id='where-we-re-going'>Where We&#39;re Going</h2> <p>Here are the next steps and how we need your help to improve this data:</p> \", 'schemaVersion': 1}}, 'width': 12, 'showEditor': False}]}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "layout2.sections[2].rows.pop(-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "c0c5e5b6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "portal_page.update_layout(layout2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0d50d8b",
+   "metadata": {},
+   "source": [
+    "Verifying the changes, we see that the row has been retained while the text card has been deleted.\n",
+    "\n",
+    "![image](https://user-images.githubusercontent.com/13968196/207743858-d1b1603c-6ddb-4c56-bafa-0e1768c8165b.png)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46b596e1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
\<insert pull request description here\>
Guide 4 of 4. Enterprise sites demo with focus on site creation with custom domain, site layout and theme editing, page creation and layout editing.
-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ mohi9282 so he can add it to the list for the next deploy 
