### PR TITLE
suggested fix for Traffic Light Detection In Oriented Imagery Using Triangulation

### DIFF
--- a/samples/04_gis_analysts_data_scientists/traffic-light-detection-on-oriented-imagery-triangulation.ipynb
+++ b/samples/04_gis_analysts_data_scientists/traffic-light-detection-on-oriented-imagery-triangulation.ipynb
@@ -38,13 +38,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8d325f6a",
    "metadata": {},
    "source": [
-    "We have generally applied object detection on images taken looking straight down at the ground, like traditional satellite imagery, predictions from which can be visualized on a map and incorporated into your GIS. Other imagery, however, is more difficult to visualize and incorporate into your GIS. Such non-nadir oriented imagery includes oblique, bubble, 360-degree, street-side, and inspection imagery, among others. Through this sample, we will demonstrate the utility of an object detection model for detecting objects in an oriented imagery using `ArcGIS API for Python`.\n",
+    "Generally, object detection is applied on images taken looking straight down at the ground, like in traditional satellite imagery, predictions from which can be visualized on a map and incorporated into your GIS. Other imagery, however, is more difficult to visualize and incorporate into your GIS. Such non-nadir oriented imagery includes oblique, bubble, 360-degree, street-side, and inspection imagery, among others. Through this sample, we will demonstrate the utility of an object detection model for detecting objects in oriented imagery using `ArcGIS API for Python`.\n",
     "\n",
-    "The `arcgis.learn` module supports number of object detection models such as `SingleShotDetector`, `RetinaNet`, `FasterRCNN`, `YoloV3` and even more. In the notebook, we will be using `YoloV3` model for detecting traffic lights in the oriented imagery. The biggest advantage of `YOLOv3` in `arcgis.learn` is that it comes preloaded with weights pretrained on the [COCO dataset](https://cocodataset.org/#home). This makes it ready-to-use for the 80 common objects (car, truck, person, etc.) that are part of the COCO dataset. Using this model, we will try to detect traffic light in the oriented imagery."
+    "The `arcgis.learn` module supports a number of object detection models, such as `SingleShotDetector`, `RetinaNet`, `FasterRCNN`, `YoloV3`, and more. In this notebook, we will be using the YoloV3 model for detecting traffic lights in oriented imagery. The biggest advantage of `YOLOv3` in `arcgis.learn`, is that it comes preloaded with weights pretrained on the [COCO dataset](https://cocodataset.org/#home). This makes it ready-to-use for the 80 common objects (car, truck, person, etc.) that are part of the COCO dataset. Using this model, we will detect traffic lights in oriented imagery."
    ]
   },
   {
@@ -94,13 +95,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5755953f",
    "metadata": {
     "hidden": true
    },
    "source": [
-    "We will need oriented imagery and oriented imagery meta data file so that we can use that for inferencing and plotting the points. We have sample images uploaded on the ArcGIS Online org. We will download those items below and use those for our workflow."
+    "For this notebook, we will use sample oriented imagery and oriented imagery meta data files, available on ArcGIS Online, for inferencing and plotting points."
    ]
   },
   {
@@ -171,24 +173,7 @@
    "outputs": [
     {
      "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 6;\n",
-       "                var nbb_unformatted_code = \"# filepath = oriented_imagery_data.download(save_path = os.getcwd(), file_name=oriented_imagery_data.name)\\nfilepath = \\\"D:\\\\TrafficSignalDataset\\\\sample\\\\sample\\\\oriented_imagery_sample_notebook.zip\\\"\";\n",
-       "                var nbb_formatted_code = \"# filepath = oriented_imagery_data.download(save_path = os.getcwd(), file_name=oriented_imagery_data.name)\\nfilepath = \\\"D:\\\\TrafficSignalDataset\\\\sample\\\\sample\\\\oriented_imagery_sample_notebook.zip\\\"\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
+      "application/javascript": "\n            setTimeout(function() {\n                var nbb_cell_id = 6;\n                var nbb_unformatted_code = \"# filepath = oriented_imagery_data.download(save_path = os.getcwd(), file_name=oriented_imagery_data.name)\\nfilepath = \\\"D:\\\\TrafficSignalDataset\\\\sample\\\\sample\\\\oriented_imagery_sample_notebook.zip\\\"\";\n                var nbb_formatted_code = \"# filepath = oriented_imagery_data.download(save_path = os.getcwd(), file_name=oriented_imagery_data.name)\\nfilepath = \\\"D:\\\\TrafficSignalDataset\\\\sample\\\\sample\\\\oriented_imagery_sample_notebook.zip\\\"\";\n                var nbb_cells = Jupyter.notebook.get_cells();\n                for (var i = 0; i < nbb_cells.length; ++i) {\n                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n                             nbb_cells[i].set_text(nbb_formatted_code);\n                        }\n                        break;\n                    }\n                }\n            }, 500);\n            ",
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -215,15 +200,16 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9d5d76e4",
    "metadata": {
     "hidden": true
    },
    "source": [
-    "After the extraction of the zip file, we will set the path of the items which are there in the zip file which we will use in this workflow.\n",
+    "After extracting the zip file, we will set the path of the items in the zip file.\n",
     "- `data_path`: Folder containing all the oriented imagery.\n",
-    "- `image_meta_data` : File containing meta data for all the oriented images in the data_path.\n"
+    "- `image_meta_data` : File containing meta data for all the oriented images in the `data_path`.\n"
    ]
   },
   {
@@ -236,24 +222,7 @@
    "outputs": [
     {
      "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 7;\n",
-       "                var nbb_unformatted_code = \"data_path = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"street_view_data\\\")\\nimage_meta_data = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"oriented_imagery_meta_data.csv\\\")\\ndepth_image_path = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"saved_depth_image\\\")\";\n",
-       "                var nbb_formatted_code = \"data_path = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"street_view_data\\\")\\nimage_meta_data = Path(\\n    os.path.join(os.path.splitext(filepath)[0]), \\\"oriented_imagery_meta_data.csv\\\"\\n)\\ndepth_image_path = Path(\\n    os.path.join(os.path.splitext(filepath)[0]), \\\"saved_depth_image\\\"\\n)\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
+      "application/javascript": "\n            setTimeout(function() {\n                var nbb_cell_id = 7;\n                var nbb_unformatted_code = \"data_path = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"street_view_data\\\")\\nimage_meta_data = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"oriented_imagery_meta_data.csv\\\")\\ndepth_image_path = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"saved_depth_image\\\")\";\n                var nbb_formatted_code = \"data_path = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"street_view_data\\\")\\nimage_meta_data = Path(\\n    os.path.join(os.path.splitext(filepath)[0]), \\\"oriented_imagery_meta_data.csv\\\"\\n)\\ndepth_image_path = Path(\\n    os.path.join(os.path.splitext(filepath)[0]), \\\"saved_depth_image\\\"\\n)\";\n                var nbb_cells = Jupyter.notebook.get_cells();\n                for (var i = 0; i < nbb_cells.length; ++i) {\n                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n                             nbb_cells[i].set_text(nbb_formatted_code);\n                        }\n                        break;\n                    }\n                }\n            }, 500);\n            ",
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -277,24 +246,7 @@
    "outputs": [
     {
      "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 8;\n",
-       "                var nbb_unformatted_code = \"image_path_list = [os.path.join(data_path,image) for image in os.listdir(data_path)]\";\n",
-       "                var nbb_formatted_code = \"image_path_list = [os.path.join(data_path, image) for image in os.listdir(data_path)]\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
+      "application/javascript": "\n            setTimeout(function() {\n                var nbb_cell_id = 8;\n                var nbb_unformatted_code = \"image_path_list = [os.path.join(data_path,image) for image in os.listdir(data_path)]\";\n                var nbb_formatted_code = \"image_path_list = [os.path.join(data_path, image) for image in os.listdir(data_path)]\";\n                var nbb_cells = Jupyter.notebook.get_cells();\n                for (var i = 0; i < nbb_cells.length; ++i) {\n                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n                             nbb_cells[i].set_text(nbb_formatted_code);\n                        }\n                        break;\n                    }\n                }\n            }, 500);\n            ",
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -318,13 +270,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e16c9153",
    "metadata": {
     "hidden": true
    },
    "source": [
-    "Since we will be using the pretrained `YOLOv3` model so we will pass `pretrained_backbone` as `True`. In this way while initializing the `YOLOv3` model the pre trained weights of the `YOLOv3` model with COCO dataset will be downloaded. We will later be using these weights to detect traffic lights."
+    "Since we are using the pretrained `YOLOv3` model, we will pass the `pretrained_backbone` attribute as `True`. This will download the pre trained weights of the `YOLOv3` model with COCO dataset while the `YOLOv3` model is initializing. We will use these weights later to detect traffic lights."
    ]
   },
   {
@@ -337,24 +290,7 @@
    "outputs": [
     {
      "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 9;\n",
-       "                var nbb_unformatted_code = \"yolo = YOLOv3(pretrained_backbone=True)\";\n",
-       "                var nbb_formatted_code = \"yolo = YOLOv3(pretrained_backbone=True)\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
+      "application/javascript": "\n            setTimeout(function() {\n                var nbb_cell_id = 9;\n                var nbb_unformatted_code = \"yolo = YOLOv3(pretrained_backbone=True)\";\n                var nbb_formatted_code = \"yolo = YOLOv3(pretrained_backbone=True)\";\n                var nbb_cells = Jupyter.notebook.get_cells();\n                for (var i = 0; i < nbb_cells.length; ++i) {\n                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n                             nbb_cells[i].set_text(nbb_formatted_code);\n                        }\n                        break;\n                    }\n                }\n            }, 500);\n            ",
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -376,15 +312,16 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0169f406",
    "metadata": {},
    "source": [
-    "Once we have the model loaded and ready for inferencing, we will be create a function named `traffic_light_finder` that will take oriented image as input and will return 2 things. \n",
-    "- Json containing traffic lights coordinates\n",
+    "Once the model is loaded and ready for inferencing, we will create a function named `traffic_light_finder` that will take oriented imagery as input and will return the following:\n",
+    "- `Json` containing traffic lights coordinates\n",
     "- Traffic lights annotated image\n",
     "\n",
-    "We will save all the traffic lights annotated image into a folder named <b>traffic_light_marked</b> and save all the annotations in a combined json file on the disk."
+    "We will save all the traffic lights annotated image into a folder named <b>traffic_light_marked</b> and save all the annotations in a combined `json` file on the disk."
    ]
   },
   {
@@ -395,24 +332,7 @@
    "outputs": [
     {
      "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 10;\n",
-       "                var nbb_unformatted_code = \"def traffic_light_finder(oriented_image_path):\\n    flag = 0\\n    coordlist = []\\n    temp_list = {}\\n    out = yolo.predict(oriented_image_path, threshold=0.5)\\n    test_img = cv2.imread(oriented_image_path)\\n    if len(out[0]) == 0:\\n        temp_list[\\\"object\\\"] = False\\n    else:\\n        for index, (value, label, confidence) in enumerate(zip(out[0], out[1], out[2])):\\n            if label == \\\"traffic light\\\":\\n                flag = 1\\n                coordlist.append(\\n                    [int(value[0]), int(value[1]), int(value[2]), int(value[3])]\\n                )\\n                test_img = cv2.rectangle(\\n                    test_img,\\n                    (int(value[0]), int(value[1]), int(value[2]), int(value[3])),\\n                    (0, 0, 255),\\n                    10,\\n                )\\n                textvalue = label + \\\"_\\\" + str(confidence)\\n                cv2.putText(\\n                    test_img,\\n                    textvalue,\\n                    (int(value[0]), int(value[1]) - 10),\\n                    cv2.FONT_HERSHEY_SIMPLEX,\\n                    1.5,\\n                    (0, 0, 255),\\n                    2,\\n                )\\n        if flag == 1:\\n            temp_list[\\\"object\\\"] = True\\n            temp_list[\\\"coords\\\"] = coordlist\\n            temp_list[\\\"assetname\\\"] = \\\"traffic light\\\"\\n    return temp_list, test_img\";\n",
-       "                var nbb_formatted_code = \"def traffic_light_finder(oriented_image_path):\\n    flag = 0\\n    coordlist = []\\n    temp_list = {}\\n    out = yolo.predict(oriented_image_path, threshold=0.5)\\n    test_img = cv2.imread(oriented_image_path)\\n    if len(out[0]) == 0:\\n        temp_list[\\\"object\\\"] = False\\n    else:\\n        for index, (value, label, confidence) in enumerate(zip(out[0], out[1], out[2])):\\n            if label == \\\"traffic light\\\":\\n                flag = 1\\n                coordlist.append(\\n                    [int(value[0]), int(value[1]), int(value[2]), int(value[3])]\\n                )\\n                test_img = cv2.rectangle(\\n                    test_img,\\n                    (int(value[0]), int(value[1]), int(value[2]), int(value[3])),\\n                    (0, 0, 255),\\n                    10,\\n                )\\n                textvalue = label + \\\"_\\\" + str(confidence)\\n                cv2.putText(\\n                    test_img,\\n                    textvalue,\\n                    (int(value[0]), int(value[1]) - 10),\\n                    cv2.FONT_HERSHEY_SIMPLEX,\\n                    1.5,\\n                    (0, 0, 255),\\n                    2,\\n                )\\n        if flag == 1:\\n            temp_list[\\\"object\\\"] = True\\n            temp_list[\\\"coords\\\"] = coordlist\\n            temp_list[\\\"assetname\\\"] = \\\"traffic light\\\"\\n    return temp_list, test_img\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
+      "application/javascript": "\n            setTimeout(function() {\n                var nbb_cell_id = 10;\n                var nbb_unformatted_code = \"def traffic_light_finder(oriented_image_path):\\n    flag = 0\\n    coordlist = []\\n    temp_list = {}\\n    out = yolo.predict(oriented_image_path, threshold=0.5)\\n    test_img = cv2.imread(oriented_image_path)\\n    if len(out[0]) == 0:\\n        temp_list[\\\"object\\\"] = False\\n    else:\\n        for index, (value, label, confidence) in enumerate(zip(out[0], out[1], out[2])):\\n            if label == \\\"traffic light\\\":\\n                flag = 1\\n                coordlist.append(\\n                    [int(value[0]), int(value[1]), int(value[2]), int(value[3])]\\n                )\\n                test_img = cv2.rectangle(\\n                    test_img,\\n                    (int(value[0]), int(value[1]), int(value[2]), int(value[3])),\\n                    (0, 0, 255),\\n                    10,\\n                )\\n                textvalue = label + \\\"_\\\" + str(confidence)\\n                cv2.putText(\\n                    test_img,\\n                    textvalue,\\n                    (int(value[0]), int(value[1]) - 10),\\n                    cv2.FONT_HERSHEY_SIMPLEX,\\n                    1.5,\\n                    (0, 0, 255),\\n                    2,\\n                )\\n        if flag == 1:\\n            temp_list[\\\"object\\\"] = True\\n            temp_list[\\\"coords\\\"] = coordlist\\n            temp_list[\\\"assetname\\\"] = \\\"traffic light\\\"\\n    return temp_list, test_img\";\n                var nbb_formatted_code = \"def traffic_light_finder(oriented_image_path):\\n    flag = 0\\n    coordlist = []\\n    temp_list = {}\\n    out = yolo.predict(oriented_image_path, threshold=0.5)\\n    test_img = cv2.imread(oriented_image_path)\\n    if len(out[0]) == 0:\\n        temp_list[\\\"object\\\"] = False\\n    else:\\n        for index, (value, label, confidence) in enumerate(zip(out[0], out[1], out[2])):\\n            if label == \\\"traffic light\\\":\\n                flag = 1\\n                coordlist.append(\\n                    [int(value[0]), int(value[1]), int(value[2]), int(value[3])]\\n                )\\n                test_img = cv2.rectangle(\\n                    test_img,\\n                    (int(value[0]), int(value[1]), int(value[2]), int(value[3])),\\n                    (0, 0, 255),\\n                    10,\\n                )\\n                textvalue = label + \\\"_\\\" + str(confidence)\\n                cv2.putText(\\n                    test_img,\\n                    textvalue,\\n                    (int(value[0]), int(value[1]) - 10),\\n                    cv2.FONT_HERSHEY_SIMPLEX,\\n                    1.5,\\n                    (0, 0, 255),\\n                    2,\\n                )\\n        if flag == 1:\\n            temp_list[\\\"object\\\"] = True\\n            temp_list[\\\"coords\\\"] = coordlist\\n            temp_list[\\\"assetname\\\"] = \\\"traffic light\\\"\\n    return temp_list, test_img\";\n                var nbb_cells = Jupyter.notebook.get_cells();\n                for (var i = 0; i < nbb_cells.length; ++i) {\n                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n                             nbb_cells[i].set_text(nbb_formatted_code);\n                        }\n                        break;\n                    }\n                }\n            }, 500);\n            ",
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -463,11 +383,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "10cef39b",
    "metadata": {},
    "source": [
-    "Here we will create a folder named <b>traffic_light_marked</b> which will contain all the images with traffic lights detected on them. We can use these images to check the output of the model. Later we can use them for our use case."
+    "Here we will create a folder named <b>traffic_light_marked</b> that will contain the images with detected traffic lights. We can use these images to check the output of the model, and later for our use case."
    ]
   },
   {
@@ -509,11 +430,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a8592b00",
    "metadata": {},
    "source": [
-    "Here we are also saving the coordinates of the traffic lights in a json file. We can use these coordinates to create a web map or in any of the other use cases."
+    "Here, we are also saving the coordinates of the traffic lights in a `json` file. We can use these coordinates to create a web map or for other use cases."
    ]
   },
   {
@@ -524,24 +446,7 @@
    "outputs": [
     {
      "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 14;\n",
-       "                var nbb_unformatted_code = \"with open('traffic_light_data_sample.json', 'w') as f:\\n    json.dump(data_list, f)\";\n",
-       "                var nbb_formatted_code = \"with open(\\\"traffic_light_data_sample.json\\\", \\\"w\\\") as f:\\n    json.dump(data_list, f)\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
+      "application/javascript": "\n            setTimeout(function() {\n                var nbb_cell_id = 14;\n                var nbb_unformatted_code = \"with open('traffic_light_data_sample.json', 'w') as f:\\n    json.dump(data_list, f)\";\n                var nbb_formatted_code = \"with open(\\\"traffic_light_data_sample.json\\\", \\\"w\\\") as f:\\n    json.dump(data_list, f)\";\n                var nbb_cells = Jupyter.notebook.get_cells();\n                for (var i = 0; i < nbb_cells.length; ++i) {\n                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n                             nbb_cells[i].set_text(nbb_formatted_code);\n                        }\n                        break;\n                    }\n                }\n            }, 500);\n            ",
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -582,17 +487,18 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "27a3ed31",
    "metadata": {
     "hidden": true
    },
    "source": [
-    "We now have run the `YOLOv3` pretrained model on all the oriented images and got the coordinates of detected traffic lights in them.\n",
+    "We have successfully ran the `YOLOv3` pretrained model on the oriented imagery and generated the coordinates of the detected traffic lights.\n",
     "\n",
-    "We also have an oriented image meta data file in csv format (downloaded above) which contains the meta data of the oriented imagery like the coordinate at which the image was taken, <b>AvgHtAG</b>, <b>CamHeading</b>, <b>CamOri</b>, <b>HFOV</b>, <b>VFOV</b> etc. You can understand more about these data points from this [document](https://www.esri.com/content/dam/esrisites/en-us/about/events/media/UC-2019/technical-workshops/tw-5765-872.pdf).\n",
+    "We also created an oriented image meta data CSV file (downloaded above) that contains the meta data of the oriented imagery, such as the coordinates of the image, <b>AvgHtAG</b>, <b>CamHeading</b>, <b>CamOri</b>, <b>HFOV</b>, <b>VFOV</b> etc. You can learn more about these data points from this [document](https://www.esri.com/content/dam/esrisites/en-us/about/events/media/UC-2019/technical-workshops/tw-5765-872.pdf).\n",
     "\n",
-    "Using these data, now we will now try to find the exact location of the traffic lights on the map."
+    "Using this data, we will now try to find the exact location of the traffic lights on the map."
    ]
   },
   {
@@ -1002,13 +908,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "98ea478d",
    "metadata": {
     "hidden": true
    },
    "source": [
-    "We will load a map and draw the final selected coordinates on it. These coordinates are the places where there are traffic lights."
+    "Next, we will load a map and draw the final selected traffic light coordinates on it."
    ]
   },
   {
@@ -1156,13 +1063,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d694ee63",
    "metadata": {
     "hidden": true
    },
    "source": [
-    "In this notebook, we have performed object detection on imagery taken at any angle naming oriented imagery. We use `YoloV3` model with pretrained weights for detecting traffic lights and located these on the gis map using `ArcGIS API for Python` and exported the output as a feature class."
+    "In this notebook, we performed object detection on oriented imagery. We used the `YoloV3` model with pretrained weights for detecting traffic lights, located these on the gis map using `ArcGIS API for Python`, and exported the output as a feature class."
    ]
   },
   {


### PR DESCRIPTION
\<insert pull request description here\>

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ mohi9282 so he can add it to the list for the next deploy 
