### PR TITLE
Updated sample notebooks: coastline extraction and LULC classification using sparse training data

### DIFF
--- a/samples/04_gis_analysts_data_scientists/coastline_extraction-usa-landsat8_multispectral_imagery.ipynb
+++ b/samples/04_gis_analysts_data_scientists/coastline_extraction-usa-landsat8_multispectral_imagery.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Coastline extraction using Landsat-8 multispectral imagery and band ratio technique"
+    "## Coastline extraction using Landsat-8 multispectral imagery and band ratio technique"
    ]
   },
   {
@@ -12,6 +12,7 @@
    "metadata": {},
    "source": [
     "## Table of Contents\n",
+    "* [Prerequisites](#20)\n",
     "* [Introduction](#1)\n",
     "* [Necessary imports](#2)\n",
     "* [Connect to your GIS](#3)\n",
@@ -31,6 +32,15 @@
     "* [Results](#17)\n",
     "* [Conclusion](#18)\n",
     "* [Data resources](#19)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites<a class=\"anchor\" id=\"20\"></a>\n",
+    "\n",
+    "- This sample demonstrates how the coastlines can be extracted using [ArcGIS Image Server](https://www.esri.com/en-us/arcgis/products/arcgis-image-server). Alternatively, this can be done using [ArcGIS Image for ArcGIS Online](https://www.esri.com/en-us/arcgis/products/arcgis-image/options/arcgis-online)."
    ]
   },
   {
@@ -1133,7 +1143,8 @@
    "source": [
     "## Get the polygon with largest area as it will represent the coastline\n",
     "df = water_poly.layers[0].query().sdf\n",
-    "dfm5 = df[df['SHAPE__Area']==df['SHAPE__Area'].max()]\n",
+    "df['MYAREA'] = df.SHAPE.geom.area\n",
+    "dfm5 = df[df['Shape__Area']==df['Shape__Area'].max()]\n",
     "coast_poly = gis2.content.import_data(dfm5, title='coast_poly'+str(datetime.now().microsecond))"
    ]
   },
@@ -1400,7 +1411,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1414,7 +1425,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.11"
+   "version": "3.9.11"
   }
  },
  "nbformat": 4,

--- a/samples/04_gis_analysts_data_scientists/coastline_extraction-usa-landsat8_multispectral_imagery.ipynb
+++ b/samples/04_gis_analysts_data_scientists/coastline_extraction-usa-landsat8_multispectral_imagery.ipynb
@@ -1144,7 +1144,7 @@
     "## Get the polygon with largest area as it will represent the coastline\n",
     "df = water_poly.layers[0].query().sdf\n",
     "df['MYAREA'] = df.SHAPE.geom.area\n",
-    "dfm5 = df[df['Shape__Area']==df['Shape__Area'].max()]\n",
+    "dfm5 = df[df['MYAREA']==df['MYAREA'].max()]\n",
     "coast_poly = gis2.content.import_data(dfm5, title='coast_poly'+str(datetime.now().microsecond))"
    ]
   },


### PR DESCRIPTION
\<insert pull request description here\>

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ mohi9282 so he can add it to the list for the next deploy 
