### PR TITLE
NEW ArcGIS notebook to manage and allocate credits

### DIFF
--- a/samples/03_org_administrators/manage_and_allocate_credits.ipynb
+++ b/samples/03_org_administrators/manage_and_allocate_credits.ipynb
@@ -1,0 +1,415 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "toc": true
+   },
+   "source": [
+    "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
+    "<div class=\"toc\"><ul class=\"toc-item\"><li><ul class=\"toc-item\"><li><span><a href=\"#Managing-credits-through-credit-budgeting\" data-toc-modified-id=\"Managing-credits-through-credit-budgeting-0.1\"><span class=\"toc-item-num\">0.1&nbsp;&nbsp;</span>Managing credits through credit budgeting</a></span></li><li><span><a href=\"#Allocating-credits-to-a-user\" data-toc-modified-id=\"Allocating-credits-to-a-user-0.2\"><span class=\"toc-item-num\">0.2&nbsp;&nbsp;</span>Allocating credits to a user</a></span></li><li><span><a href=\"#Checking-credits-assigned-and-available-to-a-user\" data-toc-modified-id=\"Checking-credits-assigned-and-available-to-a-user-0.3\"><span class=\"toc-item-num\">0.3&nbsp;&nbsp;</span>Checking credits assigned and available to a user</a></span></li><li><span><a href=\"#Disable-credit-budgeting\" data-toc-modified-id=\"Disable-credit-budgeting-0.4\"><span class=\"toc-item-num\">0.4&nbsp;&nbsp;</span>Disable credit budgeting</a></span></li></ul></li><li><span><a href=\"#Additional-Resources\" data-toc-modified-id=\"Additional-Resources-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Additional Resources</a></span></li></ul></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Administration: Manage and Allocate Credits\n",
+    "\n",
+    "* 👟 Ready To Run!\n",
+    "* 🗄️ Administration\n",
+    "* 💰 Credit Management\n",
+    "\n",
+    "__Requirements__\n",
+    "* 🔒 Administrator Privileges\n",
+    "\n",
+    "Service credits are the currency used across ArcGIS and are consumed for specific transactions and types of storage such as storing features, performing analytics, and using premium content. Any ArcGIS software that interacts with ArcGIS Online can use credits. Managing credit expenditures is an important component of administering our organization.\n",
+    "\n",
+    "To get started managing our credits, let's connect to our organization:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from arcgis.gis import GIS\n",
+    "gis = GIS(\"home\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There is a [CreditManager](https://developers.arcgis.com/python/api-reference/arcgis.gis.admin.html#creditmanager) instance exposed on our `gis` via `gis.admin.credits`. We can use this to view, allocate credits to our users, set a default limit etc. Run the below cell to view the total amount of credits in our organization:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "80404.89"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gis.admin.credits.credits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Managing credits through credit budgeting\n",
+    "The credit budgeting feature of ArcGIS Online allows administrators to view, limit and allocate credits to its users. Learn more about [credit budgeting here](http://doc.arcgis.com/en/arcgis-online/administer/configure-credits.htm).\n",
+    "\n",
+    "We can use the `enable()` method to turn on credit budgeting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gis.admin.credits.enable()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use the `is_enabled` property to verify if credit budgeting is turned on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gis.admin.credits.is_enabled"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once we turn on credit budgeting, we can set a default limit for the number of credits for each user. In addition to this, we can set custom limits to users as well. Default limit applies when we create a new user and do not set a custom limit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8000"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gis.admin.credits.default_limit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> __Note__: If credit budgetting is not enabled/not configured for the organization, the above value will show up as `-1`, and `some_user.assignedCredits` will also show up as `-1`. This means that there is no limit, any user can use up to the number of credits in the org."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Allocating credits to a user\n",
+    "We can use the `allocate()` and `deallocate()` methods to allocate custom number of credits or remove credits from any user in an organization. Let's apply this logic to ourselves. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"9item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
+       "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
+       "                        <img src='https://geosaurus.maps.arcgis.com//home/js/arcgisonline/css/images/no-user-thumb.jpg' class=\"itemThumbnail\">\n",
+       "                    </div>\n",
+       "\n",
+       "                    <div class=\"item_right\" style=\"float: none; width: auto; overflow: hidden;\">\n",
+       "                        <br/><br/><b>Bio</b>: \n",
+       "                        <br/><b>First Name</b>: Demo\n",
+       "                        <br/><b>Last Name</b>: Account\n",
+       "                        <br/><b>Username</b>:                        <br/><b>Joined</b>:\n",
+       "\n",
+       "                    </div>\n",
+       "                </div>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<User username:arcgis_python>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "me = gis.users.me\n",
+    "me"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the below cell to allocate 1/10th of our organization's credits to us:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "credits_alloc = gis.admin.credits.credits / 10\n",
+    "gis.admin.credits.allocate(username=me.username,\n",
+    "                           credits=credits_alloc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Checking credits assigned and available to a user"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When we turn on credit budgeting, the `User` object gets additional properties to indicate the `assignedCredits` and remaining `avialableCredits`. Run the below cells to view our assigned credits and available credits:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8039.734"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "me.assignedCredits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8039.734"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "me.availableCredits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As users in our organization continue to use credits, the `availableCredits` property can be used to check how much is available for that account. If a user does not have a limit set, then the total available credits in the org become their available credits. The account shown below as not custom limit, hence, it inherits the org's total limit. Run the below cell to check the amount of credits for an arbitrary user:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8039.734"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "some_user = gis.users.search(\"some_user\")[0]\n",
+    "some_user.assignedCredits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8039.734"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "some_user.availableCredits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Disable credit budgeting\n",
+    "We can disable credit budgetting by calling the `disable()` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gis.admin.credits.disable()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Additional Resources\n",
+    "\n",
+    "To learn more about credit management in ArcGIS Online, see these resources:\n",
+    "\n",
+    "- http://doc.arcgis.com/en/arcgis-online/reference/credits.htm\n",
+    "\n",
+    "- https://www.esri.com/en-us/arcgis/products/arcgis-online/pricing/credits\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "esriNotebookRuntime": {
+   "notebookRuntimeName": "ArcGIS Notebook Python 3 Standard",
+   "notebookRuntimeVersion": "7.0"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.11"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": true,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
This is an ArcGIS Notebook available under Esri sample Notebooks in AGOL. Refer to this epic in [ArcGIS:geosaurus#9824](https://github.com/ArcGIS/geosaurus/issues/9824) to learn more.

For this notebook:
1. I tested to see if it works.
2. I tested links to see if they work and fixed one broken link regarding API reference link to `CreditManager` class.
-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [x] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [x] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ mohi9282 so he can add it to the list for the next deploy 
