### PR TITLE
adding hub intro guide again on new branch

### DIFF
--- a/guide/13-managing-arcgis-applications/hub-submodule-intro.ipynb
+++ b/guide/13-managing-arcgis-applications/hub-submodule-intro.ipynb
@@ -1,0 +1,73 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6cec2944",
+   "metadata": {},
+   "source": [
+    "## The `hub` submodule\n",
+    "\n",
+    "The `hub` submodule within `arcgis.apps` acts as the pythonic interface to [ArcGIS Hub](https://www.esri.com/en-us/arcgis/products/arcgis-hub/overview). It enables automation of several Hub workflows and simplifies the use of the Hub information model by allowing access to Hub objects such as `Initiative`, `Event`, `Site` and `Page`. For tutorials and additional resources on using ArcGIS Hub, see [here](https://www.esri.com/en-us/arcgis/products/arcgis-hub/resources).\n",
+    "\n",
+    "ArcGIS Hub is available with ArcGIS Online in Hub Basic and Hub Premium, depending on your licensing of Hub. Every user of ArcGIS Online has access to Hub Basic, unless upgraded to Hub Premium at the Organization level. Users of ArcGIS Enterprise have access to [ArcGIS Enterprise Sites](https://enterprise.arcgis.com/en/sites/latest/get-started/about-this-application.htm) which enables users to automate several workflows involving Sites and Pages, similar to Hub Basic. Once you sign-in to your `GIS`, you can access the Hub capabilities in ArcGIS Online through `gis.hub`, which is the entry point to Hub. As an Enterprise Sites user, the entry point is `gis.sites` to access your Sites and Pages in ArcGIS Enterprise. Let's explore this through the architecture diagrams below.\n",
+    "\n",
+    "\n",
+    "\n",
+    "## Architecture Diagram\n",
+    "\n",
+    "\n",
+    "![image](https://user-images.githubusercontent.com/13968196/213733145-2f5747e9-4555-4440-a2f2-3b3a13608ec8.png)\n",
+    "\n",
+    "\n",
+    "\n",
+    "The capabilities supported in the API both match and exceed those available in Hub's UI. It equips users with tools necessary for working with the Sites in their Hub or Enterprise organization. With it, you can create, search for, edit the layout of, and clone sites and pages within the same organization and to different organizations. \n",
+    "\n",
+    "You can learn more about the functionality supported through the classes in the hub submodule through the links below:\n",
+    "* [Hub](/python/api-reference/arcgis.apps.hub.html#hub): Represents a Hub organization\n",
+    "* [Initiative](/python/api-reference/arcgis.apps.hub.html#initiative): Represents a Hub Premium Initiative\n",
+    "* [Site](/python/api-reference/arcgis.apps.hub.html#site): Represents a Hub or Enterprise Site\n",
+    "* [Page](/python/api-reference/arcgis.apps.hub.html#page): Represents a Page of a Hub or Enterprise Site\n",
+    "* [Event](/python/api-reference/arcgis.apps.hub.html#event): Represents a Hub Premium Event\n",
+    "* Resource Manager classes for managing these objects above:\n",
+    "    * [InitiativeManager](/python/api-reference/arcgis.apps.hub.html#initiativemanager): To manage initiatives\n",
+    "    * [SiteManager](/python/api-reference/arcgis.apps.hub.html#sitemanager): To manage sites\n",
+    "    * [PageManager](/python/api-reference/arcgis.apps.hub.html#pagemanager): To manage pages\n",
+    "    * [EventManager](/python/api-reference/arcgis.apps.hub.html#eventmanager): To manage events\n",
+    "    \n",
+    "We have three more guides that cover a range of functionality, also split based on Hub type.\n",
+    "* [Hub Premium](../hub-for-guide-premium): Working with Initiatives and Events\n",
+    "* [Hub Basic](../hub-for-guide-basic): Adding site and page, cloning the site to Hub Premium + Basic + Enterprise, Linking and unlinking pages\n",
+    "* [Enterprise Sites](../enterprise-sites): Adding site with custom domain, adding page, editing site layout and theme, editing page layout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e11bafd0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/guide/13-managing-arcgis-applications/hub-submodule-intro.ipynb
+++ b/guide/13-managing-arcgis-applications/hub-submodule-intro.ipynb
@@ -2,11 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "39cc5b1e",
+   "metadata": {},
+   "source": [
+    "# The `hub` submodule"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6cec2944",
    "metadata": {},
    "source": [
-    "## The `hub` submodule\n",
-    "\n",
     "The `hub` submodule within `arcgis.apps` acts as the pythonic interface to [ArcGIS Hub](https://www.esri.com/en-us/arcgis/products/arcgis-hub/overview). It enables automation of several Hub workflows and simplifies the use of the Hub information model by allowing access to Hub objects such as `Initiative`, `Event`, `Site` and `Page`. For tutorials and additional resources on using ArcGIS Hub, see [here](https://www.esri.com/en-us/arcgis/products/arcgis-hub/resources).\n",
     "\n",
     "ArcGIS Hub is available with ArcGIS Online in Hub Basic and Hub Premium, depending on your licensing of Hub. Every user of ArcGIS Online has access to Hub Basic, unless upgraded to Hub Premium at the Organization level. Users of ArcGIS Enterprise have access to [ArcGIS Enterprise Sites](https://enterprise.arcgis.com/en/sites/latest/get-started/about-this-application.htm) which enables users to automate several workflows involving Sites and Pages, similar to Hub Basic. Once you sign-in to your `GIS`, you can access the Hub capabilities in ArcGIS Online through `gis.hub`, which is the entry point to Hub. As an Enterprise Sites user, the entry point is `gis.sites` to access your Sites and Pages in ArcGIS Enterprise. Let's explore this through the architecture diagrams below.\n",
@@ -65,7 +71,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hub intro guide on a new branch so that it doesn't update 100s of other files.

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ mohi9282 so he can add it to the list for the next deploy 
