### PR TITLE
Create DeleteFeatures_onebyone_Portal.ipynb

### DIFF
--- a/samples/05_content_publishers/DeleteFeatures_onebyone_Portal.ipynb
+++ b/samples/05_content_publishers/DeleteFeatures_onebyone_Portal.ipynb
@@ -1,0 +1,32 @@
+from arcgis.gis import GIS
+
+# Iniciar sesión en ArcGIS Online
+gis = GIS("https://www.arcgis.com", "YOURUSER", "YOURPASSWORD")
+
+# Obtener el Feature Service por su ID
+feature_service_id = "YOURFEATURESERVICEID" # Ejemplo: 1234567890abcdef1234567890abcdef
+feature_service = gis.content.get(feature_service_id)
+
+print("Feature Service: " + feature_service.title)
+
+
+# Obtener la capa dentro del Feature Service
+layer = feature_service.layers[0]  # can be ajusted
+
+
+print("Feature Service: " + layer.properties.name)
+
+
+# Consultar los elementos que deseas eliminar (por ejemplo, todos los elementos)
+query_result = layer.query()
+
+
+print("Número de elementos a eliminar: " + str(len(query_result.features)))
+
+
+feature.attributes
+
+
+# Borrar cada elemento uno por uno
+for feature in query_result.features:
+    layer.edit_features(deletes=str(feature.attributes['objectid']))

--- a/samples/05_content_publishers/DeleteFeatures_onebyone_Portal.ipynb
+++ b/samples/05_content_publishers/DeleteFeatures_onebyone_Portal.ipynb
@@ -1,32 +1,182 @@
-from arcgis.gis import GIS
-
-# Iniciar sesión en ArcGIS Online
-gis = GIS("https://www.arcgis.com", "YOURUSER", "YOURPASSWORD")
-
-# Obtener el Feature Service por su ID
-feature_service_id = "YOURFEATURESERVICEID" # Ejemplo: 1234567890abcdef1234567890abcdef
-feature_service = gis.content.get(feature_service_id)
-
-print("Feature Service: " + feature_service.title)
-
-
-# Obtener la capa dentro del Feature Service
-layer = feature_service.layers[0]  # can be ajusted
-
-
-print("Feature Service: " + layer.properties.name)
-
-
-# Consultar los elementos que deseas eliminar (por ejemplo, todos los elementos)
-query_result = layer.query()
-
-
-print("Número de elementos a eliminar: " + str(len(query_result.features)))
-
-
-feature.attributes
-
-
-# Borrar cada elemento uno por uno
-for feature in query_result.features:
-    layer.edit_features(deletes=str(feature.attributes['objectid']))
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from arcgis.gis import GIS\n",
+    "\n",
+    "# Iniciar sesión en ArcGIS Online\n",
+    "gis = GIS(\"https://www.arcgis.com\", \"YOURUSER\", \"YOURPASSWORD\")\n",
+    "\n",
+    "# Obtener el Feature Service por su ID\n",
+    "feature_service_id = \"YOURFEATURESERVICEID\"  # Ejemplo: 1234567890abcdef1234567890abcdef\n",
+    "feature_service = gis.content.get(feature_service_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Feature Service: Servicios Técnicos\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Feature Service: \" + feature_service.title)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Obtener la capa dentro del Feature Service, request the layer by index\n",
+    "layer = feature_service.layers[0]  # Puedes ajustar el índice según tu cas de uso"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Feature Service: Servicios_Tecnicos\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Feature Service: \" + layer.properties.name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Consultar los elementos que deseas eliminar (por ejemplo, todos los elementos) , consult the features you want to delete (e.g. all features)\n",
+    "query_result = layer.query()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Número de elementos a eliminar: 64025\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Número de elementos a eliminar: \" + str(len(query_result.features))) # Imprimir el número de elementos a eliminar , print the number of features to delete"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'objectid': 1,\n",
+       " 'globalid': '3929a7d7-8183-412a-94ec-df0bbb86d249',\n",
+       " 'zona': '1',\n",
+       " 'finca': 'Los Ángeles',\n",
+       " 'MuestreosST': 'Plagas fruta',\n",
+       " 'id_muestreador': 76,\n",
+       " 'lote': 21422,\n",
+       " 'seccion': 100,\n",
+       " 'grupo': 22,\n",
+       " 'cosecha': 2,\n",
+       " 'edad_plagas1': None,\n",
+       " 'block1': None,\n",
+       " 'camas_plagasblock': None,\n",
+       " 'camas_plagas1medio': None,\n",
+       " 'camas_plagas1medioATK': None,\n",
+       " 'camas_plagasblockATK': None,\n",
+       " 'edad_fruta1': '117',\n",
+       " 'block2': 'medio',\n",
+       " 'camas_fruta1': '1',\n",
+       " 'edad_larva1': None,\n",
+       " 'block3': None,\n",
+       " 'camas_larva1': None,\n",
+       " 'edad_pdt1': None,\n",
+       " 'evaluacion': None,\n",
+       " 'edad_prepa1': None,\n",
+       " 'blockprepa': None,\n",
+       " 'CreationDate': 1685038623651,\n",
+       " 'Creator': 'Admin_Pindeco',\n",
+       " 'EditDate': 1685120477962,\n",
+       " 'Editor': 'Admin_Pindeco'}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "feature.attributes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    " # Borrar cada elemento uno por uno , DeleteFeatures_onebyone\n",
+    "for feature in query_result.features:\n",
+    "    layer.edit_features(deletes=str(feature.attributes[\"objectid\"]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# borrar todos los elementos de una sola vez - Delete all features at once\n",
+    "layer.edit_features(deletes=str([feature.attributes['objectid'] for feature in query_result.features]))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
one notebook to delete elements in AGOL one by one.

\<insert pull request description here\>

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [X ] All `import`s are in the first cell? 
    - [X ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [x ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ x] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [x] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [x ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ mohi9282 so he can add it to the list for the next deploy 
