### PR TITLE
sample notebook for saving backups and loading them into new graphs

### DIFF
--- a/samples/05_content_publishers/create_and_load_knowledge_graph_backups.ipynb
+++ b/samples/05_content_publishers/create_and_load_knowledge_graph_backups.ipynb
@@ -80,11 +80,11 @@
    "outputs": [],
    "source": [
     "# imports\n",
-    "from arcgis.gis import GIS\n",
-    "from arcgis.graph import KnowledgeGraph\n",
+    "import os, json, datetime\n",
+    "from uuid import UUID\n",
     "\n",
-    "import sys, os, json, datetime\n",
-    "from uuid import UUID"
+    "from arcgis.gis import GIS\n",
+    "from arcgis.graph import KnowledgeGraph"
    ]
   },
   {

--- a/samples/05_content_publishers/create_and_load_knowledge_graph_backups.ipynb
+++ b/samples/05_content_publishers/create_and_load_knowledge_graph_backups.ipynb
@@ -139,10 +139,11 @@
    "outputs": [],
    "source": [
     "gis_backup = GIS(\"home\")  # connect to portal\n",
+    "# connect to knowledge graph service\n",
     "knowledgegraph_backup = KnowledgeGraph(\n",
     "    \"https://myportal.com/server/rest/services/Hosted/myknowledgegraph/KnowledgeGraphServer\",\n",
     "    gis=gis_backup,\n",
-    ")  # connect to knowledge graph service\n",
+    ")\n",
     "try:\n",
     "    knowledgegraph_backup.datamodel\n",
     "except:\n",
@@ -155,7 +156,7 @@
    "metadata": {},
    "source": [
     "## Write data model entity types to backup json file\n",
-    "Iterate through the data model of the knowledge graph to write all entity type objects to a json backup file"
+    "Iterate through the data model of the knowledge graph to write all entity type objects to a backup json file"
    ]
   },
   {
@@ -165,8 +166,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "entity_types = []\n",
     "# create list of formatted entity types\n",
+    "entity_types = []\n",
     "for types in knowledgegraph_backup.datamodel[\"entity_types\"]:\n",
     "    curr_entity_type = {\n",
     "        \"name\": knowledgegraph_backup.datamodel[\"entity_types\"][types][\"name\"],\n",
@@ -174,7 +175,16 @@
     "            \"properties\"\n",
     "        ],\n",
     "    }\n",
-    "    entity_types.append(curr_entity_type)\n",
+    "    entity_types.append(curr_entity_type)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d73069ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# write entity types to json file\n",
     "with open(os.path.join(output_folder, dm_ent), \"w\") as f:\n",
     "    json.dump(entity_types, f)"
@@ -186,7 +196,7 @@
    "metadata": {},
    "source": [
     "## Write data model relationship types to backup json file\n",
-    "Iterate through the data model of the knowledge graph to write all relationship type objects to a json backup file"
+    "Iterate through the data model of the knowledge graph to write all relationship type objects to a backup json file"
    ]
   },
   {
@@ -196,8 +206,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "relationship_types = []\n",
     "# create list of formatted relationship types\n",
+    "relationship_types = []\n",
     "for types in knowledgegraph_backup.datamodel[\"relationship_types\"]:\n",
     "    curr_relationship_type = {\n",
     "        \"name\": knowledgegraph_backup.datamodel[\"relationship_types\"][types][\"name\"],\n",
@@ -205,7 +215,16 @@
     "            \"properties\"\n",
     "        ],\n",
     "    }\n",
-    "    relationship_types.append(curr_relationship_type)\n",
+    "    relationship_types.append(curr_relationship_type)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cee22fea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# write relationship types to json file\n",
     "with open(os.path.join(output_folder, dm_rel), \"w\") as f:\n",
     "    json.dump(relationship_types, f)"
@@ -227,9 +246,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# query for all entities in graph\n",
     "original_entities = knowledgegraph_backup.query_streaming(\n",
     "    \"MATCH (n) RETURN distinct n\"\n",
-    ")  # query for all entities in graph\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc90a817",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create list of formatted entities to add to the graph\n",
     "all_entities_fromquery = []\n",
     "for entity in list(original_entities):\n",
     "    curr_entity = entity[0]\n",
@@ -238,10 +268,20 @@
     "    for prop in curr_entity[\"_properties\"]:\n",
     "        if type(curr_entity[\"_properties\"][prop]) == UUID:\n",
     "            curr_entity[\"_properties\"][prop] = str(curr_entity[\"_properties\"][prop])\n",
+    "    # delete objectid, the server will handle creating new ones when we load the backup\n",
     "    del curr_entity[\"_properties\"][\n",
     "        \"objectid\"\n",
-    "    ]  # delete objectid, the server will handle creating new ones when we load the backup\n",
-    "    all_entities_fromquery.append(curr_entity)\n",
+    "    ]\n",
+    "    all_entities_fromquery.append(curr_entity)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2760a47b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# write entities list to json file\n",
     "with open(os.path.join(output_folder, all_ent), \"w\") as f:\n",
     "    json.dump(all_entities_fromquery, f)"
@@ -263,9 +303,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# query for all relationships in graph\n",
     "original_relationships = knowledgegraph_backup.query_streaming(\n",
     "    \"MATCH ()-[rel]->() RETURN distinct rel\"\n",
-    ")  # query for all relationships in graph\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4835acc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create list of formatted entities to add to the graph\n",
     "all_relationships_fromquery = []\n",
     "for relationship in list(original_relationships):\n",
     "    curr_relationship = relationship[0]\n",
@@ -280,10 +331,20 @@
     "            curr_relationship[\"_properties\"][prop] = str(\n",
     "                curr_relationship[\"_properties\"][prop]\n",
     "            )\n",
+    "    # delete objectid, the server will handle creating new ones when we load the backup\n",
     "    del curr_relationship[\"_properties\"][\n",
     "        \"objectid\"\n",
-    "    ]  # delete objectid, the server will handle creating new ones when we load the backup\n",
-    "    all_relationships_fromquery.append(curr_relationship)\n",
+    "    ]\n",
+    "    all_relationships_fromquery.append(curr_relationship)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffb27ca4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# write relationships list to json file\n",
     "with open(os.path.join(output_folder, all_rel), \"w\") as f:\n",
     "    json.dump(all_relationships_fromquery, f)"
@@ -305,9 +366,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# query for all provenance records in the graph\n",
     "provenance_entities = knowledgegraph_backup.query_streaming(\n",
     "    \"MATCH (n:Provenance) RETURN distinct n\", include_provenance=True\n",
-    ")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "402ca4ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create list of formatted provenance records to the graph\n",
     "all_provenance_fromquery = []\n",
     "for entity in list(provenance_entities):\n",
     "    curr_provenance = entity[0]\n",
@@ -318,10 +390,20 @@
     "            curr_provenance[\"_properties\"][prop] = str(\n",
     "                curr_provenance[\"_properties\"][prop]\n",
     "            )\n",
+    "    # delete objectid, the server will handle creating new ones when we load the backup\n",
     "    del curr_provenance[\"_properties\"][\n",
     "        \"objectid\"\n",
-    "    ]  # delete objectid, the server will handle creating new ones when we load the backup\n",
-    "    all_provenance_fromquery.append(curr_provenance)\n",
+    "    ]\n",
+    "    all_provenance_fromquery.append(curr_provenance)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e00efce3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# write provenance list to json file\n",
     "with open(os.path.join(output_folder, prov_file), \"w\") as f:\n",
     "    json.dump(all_provenance_fromquery, f)"
@@ -351,9 +433,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# connect to portal via GIS\n",
     "gis_load = GIS(\n",
     "    \"https://myportal.com/portal\", \"username\", \"password\"\n",
-    ")  # connect to portal via GIS\n",
+    ")\n",
     "# create a knowledge graph without provenance enabled\n",
     "result = gis_load.content.create_service(\n",
     "    name=\"myknowledgegraph\",\n",
@@ -381,6 +464,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# load data model json files into graph data model\n",
     "with open(os.path.join(output_folder, dm_ent), \"r\") as file:\n",
     "    dm_ents = json.load(file)\n",
     "with open(os.path.join(output_folder, dm_rel), \"r\") as file:\n",
@@ -411,7 +495,16 @@
     "for entity_type in dm_ents:\n",
     "    for prop in entity_type[\"properties\"]:\n",
     "        if entity_type[\"properties\"][prop][\"role\"] == \"esriGraphNamedObjectDocument\":\n",
-    "            doc_type_name = entity_type[\"name\"]\n",
+    "            doc_type_name = entity_type[\"name\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c3eaba3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# get document relationship type name\n",
     "doc_rel_type_name = \"HasDocument\"\n",
     "for relationship_type in dm_rels:\n",
@@ -449,7 +542,16 @@
     "    prop_list.append(origin_document_properties[prop])\n",
     "knowledgegraph_load.graph_property_adds(\n",
     "    type_name=\"Document\", graph_properties=prop_list\n",
-    ")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4aead427",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# load any additional document relationship type properties\n",
     "for relationship_type in dm_rels:\n",
     "    if relationship_type[\"name\"] == doc_rel_type_name:\n",
@@ -479,11 +581,20 @@
    "outputs": [],
    "source": [
     "date_properties = []\n",
-    "# add date property names for entitie types\n",
+    "# add date property names for entity types\n",
     "for types in dm_ents:\n",
     "    for prop in types[\"properties\"]:\n",
     "        if types[\"properties\"][prop][\"fieldType\"] == \"esriFieldTypeDate\":\n",
-    "            date_properties.append(prop)\n",
+    "            date_properties.append(prop)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d13d12b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# add date property names for relationship types\n",
     "for types in dm_rels:\n",
     "    for prop in types[\"properties\"]:\n",
@@ -641,7 +752,16 @@
     "            prop_list.append(prop)\n",
     "    knowledgegraph_load.update_search_index(\n",
     "        adds={entity_type: {\"property_names\": prop_list}}\n",
-    "    )\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29234c25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# add search indexes for all relationship text properties\n",
     "for entity_type in load_dm[\"relationship_types\"]:\n",
     "    prop_list = []\n",
@@ -674,7 +794,16 @@
    "source": [
     "# load provenance records json file\n",
     "with open(os.path.join(output_folder, prov_file), \"r\") as file:\n",
-    "    prov_entities = json.load(file)\n",
+    "    prov_entities = json.load(file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "973c889f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# add all provenance records\n",
     "for curr_prov in prov_entities:\n",
     "    # format UUID properties\n",

--- a/samples/05_content_publishers/create_and_load_knowledge_graph_backups.ipynb
+++ b/samples/05_content_publishers/create_and_load_knowledge_graph_backups.ipynb
@@ -1,0 +1,714 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a0c79d53",
+   "metadata": {},
+   "source": [
+    "# Create and load knowledge graph backups"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "709ec115",
+   "metadata": {},
+   "source": [
+    "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
+    "<div class=\"toc\"><ul class=\"toc-item\">\n",
+    "    <li><span><a href=\"#Setup\" data-toc-modified-id=\"Setup-1\">Setup</a></span></li>\n",
+    "        <ul class=\"toc-item\">\n",
+    "            <li><span><a href=\"#Import-necessary-libraries\" data-toc-modified-id=\"Import-necessary-libraries-1.1\">Import necessary libraries</a></span></li>\n",
+    "            <li><span><a href=\"#Define-folder-and-file-names\" data-toc-modified-id=\"Define-folder-and-file-names-1.2\">Define flder and file names</a></span></li>\n",
+    "        </ul>\n",
+    "    <li><span><a href=\"#Create-backup-files\" data-toc-modified-id=\"Create-backup-files-2\">Create backup files</a></span></li>\n",
+    "        <ul class=\"toc-item\">\n",
+    "            <li><span><a href=\"#Connect-to-portal-and-knowledge-graph\" data-toc-modified-id=\"Connect-to-portal-and-knowledge-graph-2.1\">Connect to portal and knowledge graph</a></span></li>\n",
+    "            <li><span><a href=\"#Write-data-model-entity-types-to-backup-json-file\" data-toc-modified-id=\"Write-data-model-entity-types-to-backup-json-file-2.2\">Write data model entity types to backup json file</a></span></li>\n",
+    "            <li><span><a href=\"#Write-data-model-relationship-types-to-backup-json-file\" data-toc-modified-id=\"Write-data-model-relationship-types-to-backup-json-file-2.3\">Write data model relationship types to backup json file</a></span></li>\n",
+    "            <li><span><a href=\"#Write-entities-to-backup-json-file\" data-toc-modified-id=\"Write-entities-to-backup-json-file-2.4\">Write entities to backup json file</a></span></li>\n",
+    "            <li><span><a href=\"#Write-relationships-to-backup-json-file\" data-toc-modified-id=\"Write-relationships-to-backup-json-file-2.5\">Write relationships to backup json file</a></span></li>\n",
+    "            <li><span><a href=\"#OPTIONAL:-Write-provenance-records-to-backup-json-file\" data-toc-modified-id=\"OPTIONAL:-Write-provenance-records-to-backup-json-file-2.6\">OPTIONAL: Write provenance records to backup json file</a></span></li>\n",
+    "        </ul>\n",
+    "    <li><span><a href=\"#Load-backup-files\" data-toc-modified-id=\"Load-backup-files-3\">Load backup files</a></span></li>\n",
+    "        <ul class=\"toc-item\">\n",
+    "            <li><span><a href=\"#Connect-to-portal-and-create-knowledge-graph\" data-toc-modified-id=\"Connect-to-portal-and-create-knowledge-graph-3.1\">Connect to portal and create knowledge graph</a></span></li>\n",
+    "            <li><span><a href=\"#Populate-data-model-from-saved-json-files\" data-toc-modified-id=\"Populate-data-model-from-saved-json-files-3.2\">Populate data model from saved json files</a></span></li>\n",
+    "            <li><span><a href=\"#Get-original-document-names-to-correctly-load-data\" data-toc-modified-id=\"Get-original-document-names-to-correctly-load-data-3.3\">Get original document names to correctly load data</a></span></li>\n",
+    "            <li><span><a href=\"#Add-additional-document-entity-and-relationship-type-properties\" data-toc-modified-id=\"Add-additional-document-entity-and-relationship-type-properties-3.4\">Add additional document entity and relationship type properties</a></span></li>\n",
+    "            <li><span><a href=\"#Get-list-of-date-properties-from-the-data-model-json-files\" data-toc-modified-id=\"Get-list-of-date-properties-from-the-data-model-json-files-3.5\">Get list of date properties from the data model json files</a></span></li>\n",
+    "            <li><span><a href=\"#Add-all-entities-to-the-knowledge-graph\" data-toc-modified-id=\"Add-all-entities-to-the-knowledge-graph-3.6\">Add all entities to the knowledge graph</a></span></li>\n",
+    "            <li><span><a href=\"#Add-all-relationships-to-the-knowledge-graph\" data-toc-modified-id=\"Add-all-relationships-to-the-knowledge-graph-3.7\">Add all relationships to the knowledge graph</a></span></li>\n",
+    "            <li><span><a href=\"#Add-search-indexes-to-all-text-properties\" data-toc-modified-id=\"Add-search-indexes-to-all-text-properties-3.8\">Add search indexes to all text properties</a></span></li>\n",
+    "            <li><span><a href=\"#OPTIONAL:-Add-provenance-records-to-the-knowledge-graph\" data-toc-modified-id=\"OPTIONAL:-Add-provenance-records-to-the-knowledge-graph-3.9\">OPTIONAL: Add provenance records to the knowledge graph</a></span></li>\n",
+    "        </ul>\n",
+    "</ul></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c9288de",
+   "metadata": {},
+   "source": [
+    "## Never lose your graphs again with backups!\n",
+    "Create a backup of an ArcGIS Knowledge graph you have created to store your data model and data. The backup will be in the format of json files that can read to recreate your graph or be shared for others to be able to create the same graph on a different server.\n",
+    "## Load a new graph easily from your backup files!\n",
+    "Use the backup files with the load backup files portion of this notebook to create a graph with the same data model and data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b373d48b",
+   "metadata": {},
+   "source": [
+    "# Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d20f5e6c",
+   "metadata": {},
+   "source": [
+    "## Import necessary libraries\n",
+    "Start by importing the libraries we need for connecting to portal, accessing knowledge graph, and manipulating data as needed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd42438c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# imports\n",
+    "from arcgis.gis import GIS\n",
+    "from arcgis.graph import KnowledgeGraph\n",
+    "\n",
+    "import sys, os, json, datetime\n",
+    "from uuid import UUID"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b14f1c6e",
+   "metadata": {},
+   "source": [
+    "## Define folder and file names\n",
+    "Define all names for files so we can stay consistent for backing up and loading files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9dea238",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# output folder name\n",
+    "output_folder = \"C:\\backups\\myknowledgegraph_backup\"\n",
+    "\n",
+    "# output backup json file names\n",
+    "dm_ent = \"datamodel_entities.json\"\n",
+    "dm_rel = \"datamodel_relationships.json\"\n",
+    "all_ent = \"all_entities.json\"\n",
+    "all_rel = \"all_relationships.json\"\n",
+    "prov_file = \"provenance_entities.json\"  # this will only be used if you want to backup provenance records"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8efc688e",
+   "metadata": {},
+   "source": [
+    "# Create backup files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b58d0f34",
+   "metadata": {},
+   "source": [
+    "## Connect to portal and knowledge graph\n",
+    "Connect to the portal and knowledge graph on that portal, also ensure knowledge graph service exists (url is correct)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5c95926",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gis_backup = GIS(\"home\")  # connect to portal\n",
+    "knowledgegraph_backup = KnowledgeGraph(\n",
+    "    \"https://myportal.com/server/rest/services/Hosted/myknowledgegraph/KnowledgeGraphServer\",\n",
+    "    gis=gis_backup,\n",
+    ")  # connect to knowledge graph service\n",
+    "try:\n",
+    "    knowledgegraph_backup.datamodel\n",
+    "except:\n",
+    "    raise Exception(\"Knowledge graph to backup does not exist\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ced3a37e",
+   "metadata": {},
+   "source": [
+    "## Write data model entity types to backup json file\n",
+    "Iterate through the data model of the knowledge graph to write all entity type objects to a json backup file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a52591c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "entity_types = []\n",
+    "# create list of formatted entity types\n",
+    "for types in knowledgegraph_backup.datamodel[\"entity_types\"]:\n",
+    "    curr_entity_type = {\n",
+    "        \"name\": knowledgegraph_backup.datamodel[\"entity_types\"][types][\"name\"],\n",
+    "        \"properties\": knowledgegraph_backup.datamodel[\"entity_types\"][types][\n",
+    "            \"properties\"\n",
+    "        ],\n",
+    "    }\n",
+    "    entity_types.append(curr_entity_type)\n",
+    "# write entity types to json file\n",
+    "with open(os.path.join(output_folder, dm_ent), \"w\") as f:\n",
+    "    json.dump(entity_types, f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dff06f42",
+   "metadata": {},
+   "source": [
+    "## Write data model relationship types to backup json file\n",
+    "Iterate through the data model of the knowledge graph to write all relationship type objects to a json backup file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83c275c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relationship_types = []\n",
+    "# create list of formatted relationship types\n",
+    "for types in knowledgegraph_backup.datamodel[\"relationship_types\"]:\n",
+    "    curr_relationship_type = {\n",
+    "        \"name\": knowledgegraph_backup.datamodel[\"relationship_types\"][types][\"name\"],\n",
+    "        \"properties\": knowledgegraph_backup.datamodel[\"relationship_types\"][types][\n",
+    "            \"properties\"\n",
+    "        ],\n",
+    "    }\n",
+    "    relationship_types.append(curr_relationship_type)\n",
+    "# write relationship types to json file\n",
+    "with open(os.path.join(output_folder, dm_rel), \"w\") as f:\n",
+    "    json.dump(relationship_types, f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd6f9f53",
+   "metadata": {},
+   "source": [
+    "## Write entities to backup json file\n",
+    "Get all entities from the knowledge graph using a streaming query, clean them up for better writing when loading, and save the resulting entities to a json backup file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d1bbe7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "original_entities = knowledgegraph_backup.query_streaming(\n",
+    "    \"MATCH (n) RETURN distinct n\"\n",
+    ")  # query for all entities in graph\n",
+    "all_entities_fromquery = []\n",
+    "for entity in list(original_entities):\n",
+    "    curr_entity = entity[0]\n",
+    "    # convert UUID values to a string since json can't store UUIDs\n",
+    "    curr_entity[\"_id\"] = str(curr_entity[\"_id\"])\n",
+    "    for prop in curr_entity[\"_properties\"]:\n",
+    "        if type(curr_entity[\"_properties\"][prop]) == UUID:\n",
+    "            curr_entity[\"_properties\"][prop] = str(curr_entity[\"_properties\"][prop])\n",
+    "    del curr_entity[\"_properties\"][\n",
+    "        \"objectid\"\n",
+    "    ]  # delete objectid, the server will handle creating new ones when we load the backup\n",
+    "    all_entities_fromquery.append(curr_entity)\n",
+    "# write entities list to json file\n",
+    "with open(os.path.join(output_folder, all_ent), \"w\") as f:\n",
+    "    json.dump(all_entities_fromquery, f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53d50a65",
+   "metadata": {},
+   "source": [
+    "## Write relationships to backup json file\n",
+    "Get all relationships from the knowledge graph using a streaming query, clean them up for better writing when loading, and save the resulting relationships to a json backup file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bf7c90b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "original_relationships = knowledgegraph_backup.query_streaming(\n",
+    "    \"MATCH ()-[rel]->() RETURN distinct rel\"\n",
+    ")  # query for all relationships in graph\n",
+    "all_relationships_fromquery = []\n",
+    "for relationship in list(original_relationships):\n",
+    "    curr_relationship = relationship[0]\n",
+    "    # convert UUID values to a string since json can't store UUIDs\n",
+    "    curr_relationship[\"_id\"] = str(curr_relationship[\"_id\"])\n",
+    "    curr_relationship[\"_originEntityId\"] = str(curr_relationship[\"_originEntityId\"])\n",
+    "    curr_relationship[\"_destinationEntityId\"] = str(\n",
+    "        curr_relationship[\"_destinationEntityId\"]\n",
+    "    )\n",
+    "    for prop in curr_relationship[\"_properties\"]:\n",
+    "        if type(curr_relationship[\"_properties\"][prop]) == UUID:\n",
+    "            curr_relationship[\"_properties\"][prop] = str(\n",
+    "                curr_relationship[\"_properties\"][prop]\n",
+    "            )\n",
+    "    del curr_relationship[\"_properties\"][\n",
+    "        \"objectid\"\n",
+    "    ]  # delete objectid, the server will handle creating new ones when we load the backup\n",
+    "    all_relationships_fromquery.append(curr_relationship)\n",
+    "# write relationships list to json file\n",
+    "with open(os.path.join(output_folder, all_rel), \"w\") as f:\n",
+    "    json.dump(all_relationships_fromquery, f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be75a27f",
+   "metadata": {},
+   "source": [
+    "## OPTIONAL: Write provenance records to backup json file\n",
+    "If you have provenance records that you want to maintain in the backups, this will get all provenance records and save them to a json backup file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e8576d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "provenance_entities = knowledgegraph_backup.query_streaming(\n",
+    "    \"MATCH (n:Provenance) RETURN distinct n\", include_provenance=True\n",
+    ")\n",
+    "all_provenance_fromquery = []\n",
+    "for entity in list(provenance_entities):\n",
+    "    curr_provenance = entity[0]\n",
+    "    # convert UUID values to a string since json can't store UUIDs\n",
+    "    curr_provenance[\"_id\"] = str(curr_provenance[\"_id\"])\n",
+    "    for prop in curr_provenance[\"_properties\"]:\n",
+    "        if type(curr_provenance[\"_properties\"][prop]) == UUID:\n",
+    "            curr_provenance[\"_properties\"][prop] = str(\n",
+    "                curr_provenance[\"_properties\"][prop]\n",
+    "            )\n",
+    "    del curr_provenance[\"_properties\"][\n",
+    "        \"objectid\"\n",
+    "    ]  # delete objectid, the server will handle creating new ones when we load the backup\n",
+    "    all_provenance_fromquery.append(curr_provenance)\n",
+    "# write provenance list to json file\n",
+    "with open(os.path.join(output_folder, prov_file), \"w\") as f:\n",
+    "    json.dump(all_provenance_fromquery, f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c21c8066",
+   "metadata": {},
+   "source": [
+    "# Load backup files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db4a59d8",
+   "metadata": {},
+   "source": [
+    "## Connect to portal and create knowledge graph\n",
+    "Connect to the portal and create a new knowledge graph service to load data model and data into"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd042d14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gis_load = GIS(\n",
+    "    \"https://myportal.com/portal\", \"username\", \"password\"\n",
+    ")  # connect to portal via GIS\n",
+    "# create a knowledge graph without provenance enabled\n",
+    "result = gis_load.content.create_service(\n",
+    "    name=\"myknowledgegraph\",\n",
+    "    capabilities=\"Query,Editing,Create,Update,Delete\",\n",
+    "    service_type=\"KnowledgeGraph\",\n",
+    ")\n",
+    "# OPTIONAL: switch line above with line below to create knowledge graph WITH provenance enabled\n",
+    "# result = gis_load.content.create_service(name=\"\", service_type=\"KnowledgeGraph\",create_params={\"name\": \"myknowledgegraph\", \"capabilities\": \"Query\", \"jsonProperties\": {\"supportsProvenance\": True}})\n",
+    "knowledgegraph_load = KnowledgeGraph(result.url, gis=gis_load)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70b11b8a",
+   "metadata": {},
+   "source": [
+    "## Populate data model from saved json files\n",
+    "Populate entity and relationship types from saved json files. This is using the variables defined in the 'Setup' section above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad6f6d63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(os.path.join(output_folder, dm_ent), \"r\") as file:\n",
+    "    dm_ents = json.load(file)\n",
+    "with open(os.path.join(output_folder, dm_rel), \"r\") as file:\n",
+    "    dm_rels = json.load(file)\n",
+    "knowledgegraph_load.named_object_type_adds(\n",
+    "    entity_types=dm_ents, relationship_types=dm_rels\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85163b0a",
+   "metadata": {},
+   "source": [
+    "## Get original documents names to correctly load data\n",
+    "This section will get the names of the document entity and relationship types from the original graph data, using the above commands the document types get their default names of 'Document' and 'HasDocument'. Just in case they have been named differently in the original knowledge graph, this steps allows us to match them up in later loading steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1dd1cce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get document entity type name\n",
+    "doc_type_name = \"Document\"\n",
+    "for entity_type in dm_ents:\n",
+    "    for prop in entity_type[\"properties\"]:\n",
+    "        if entity_type[\"properties\"][prop][\"role\"] == \"esriGraphNamedObjectDocument\":\n",
+    "            doc_type_name = entity_type[\"name\"]\n",
+    "# get document relationship type name\n",
+    "doc_rel_type_name = \"HasDocument\"\n",
+    "for relationship_type in dm_rels:\n",
+    "    for prop in relationship_type[\"properties\"]:\n",
+    "        if (\n",
+    "            relationship_type[\"properties\"][prop][\"role\"]\n",
+    "            == \"esriGraphNamedObjectDocument\"\n",
+    "        ):\n",
+    "            doc_rel_type_name = relationship_type[\"name\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd1eecc7",
+   "metadata": {},
+   "source": [
+    "## Add additional document entity and relationship type properties\n",
+    "In the case additional properties exist in the original graph on document entity or relationship types, since the type was created at the time of knowledge graph creation we need to additional properties using graph_property_adds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c14b97c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load any additional document entity type properties\n",
+    "origin_document_properties = None\n",
+    "for entity_type in dm_ents:\n",
+    "    if entity_type[\"name\"] == doc_type_name:\n",
+    "        origin_document_properties = entity_type[\"properties\"]\n",
+    "prop_list = []\n",
+    "for prop in origin_document_properties:\n",
+    "    prop_list.append(origin_document_properties[prop])\n",
+    "knowledgegraph_load.graph_property_adds(\n",
+    "    type_name=\"Document\", graph_properties=prop_list\n",
+    ")\n",
+    "# load any additional document relationship type properties\n",
+    "for relationship_type in dm_rels:\n",
+    "    if relationship_type[\"name\"] == doc_rel_type_name:\n",
+    "        origin_document_rel_properties = relationship_type[\"properties\"]\n",
+    "prop_list = []\n",
+    "for prop in origin_document_rel_properties:\n",
+    "    prop_list.append(origin_document_rel_properties[prop])\n",
+    "knowledgegraph_load.graph_property_adds(\n",
+    "    type_name=\"HasDocument\", graph_properties=prop_list\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31027810",
+   "metadata": {},
+   "source": [
+    "## Get list of date properties from the data model json files\n",
+    "From the data model type json files, find and make a list of date files so we can correctly create datetime objects when loading the data into the knowledge graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cecd788",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "date_properties = []\n",
+    "# add date property names for entitie types\n",
+    "for types in dm_ents:\n",
+    "    for prop in types[\"properties\"]:\n",
+    "        if types[\"properties\"][prop][\"fieldType\"] == \"esriFieldTypeDate\":\n",
+    "            date_properties.append(prop)\n",
+    "# add date property names for relationship types\n",
+    "for types in dm_rels:\n",
+    "    for prop in types[\"properties\"]:\n",
+    "        if types[\"properties\"][prop][\"fieldType\"] == \"esriFieldTypeDate\":\n",
+    "            date_properties.append(prop)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33eca61c",
+   "metadata": {},
+   "source": [
+    "## Add all entities to the knowledge graph\n",
+    "Add all entities from json file to the knowledge graph, formatting UUIDs, dates, and documents before loading the values. This loads the data in batches of 20,000 entities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d959142e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load entities json file\n",
+    "with open(os.path.join(output_folder, all_ent), \"r\") as file:\n",
+    "    original_entities = json.load(file)\n",
+    "batch = []\n",
+    "for curr_entity in original_entities:\n",
+    "    # if a batch reaches 20k records, apply that batch of edits to the knowledge graph\n",
+    "    if len(batch) > 20000:\n",
+    "        result = knowledgegraph_load.apply_edits(adds=batch)\n",
+    "        batch = []\n",
+    "        # print error if one occurs during edit operation\n",
+    "        try:\n",
+    "            print(result[\"error\"])\n",
+    "        except:\n",
+    "            print(\"No error adding entities\")\n",
+    "    # in case original document type name is different, change name to Document\n",
+    "    if curr_entity[\"_typeName\"] == doc_type_name:\n",
+    "        curr_entity[\"_typeName\"] = \"Document\"\n",
+    "    # format UUID and date properties\n",
+    "    for prop in curr_entity[\"_properties\"]:\n",
+    "        if prop in date_properties:\n",
+    "            try:\n",
+    "                curr_entity[\"_properties\"][prop] = datetime.fromtimestamp(\n",
+    "                    int(curr_entity[\"_properties\"][prop] / 1000)\n",
+    "                )\n",
+    "            except:\n",
+    "                curr_entity[\"_properties\"][prop] = None\n",
+    "        try:\n",
+    "            curr_entity[\"_properties\"][prop] = UUID(curr_entity[\"_properties\"][prop])\n",
+    "        except:\n",
+    "            continue\n",
+    "    # format id UUID\n",
+    "    curr_entity[\"_id\"] = UUID(curr_entity[\"_id\"])\n",
+    "    batch.append(curr_entity)\n",
+    "# apply final batch of edits to the knowledge graph\n",
+    "result = knowledgegraph_load.apply_edits(adds=batch)\n",
+    "# print error if one occurs during edit operation\n",
+    "try:\n",
+    "    print(result[\"error\"])\n",
+    "except:\n",
+    "    print(\"No error adding entities\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "034ed628",
+   "metadata": {},
+   "source": [
+    "## Add all relationships to the knowledge graph\n",
+    "Add all relationships from json file to the knowledge graph, formatting UUIDs, dates, and documents before loading the values. This loads the data in batches of 20,000 relationships."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "573343e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load relationships json file\n",
+    "with open(os.path.join(output_folder, all_rel), \"r\") as file:\n",
+    "    original_rels = json.load(file)\n",
+    "batch = []\n",
+    "for curr_relationship in original_rels:\n",
+    "    # if a batch reaches 20k records, apply that batch of edits to the knowledge graph\n",
+    "    if len(batch) > 20000:\n",
+    "        result = knowledgegraph_load.apply_edits(adds=batch)\n",
+    "        batch = []\n",
+    "        # print error if one occurs during edit operation\n",
+    "        try:\n",
+    "            print(result[\"error\"])\n",
+    "        except:\n",
+    "            print(\"No error adding relationships\")\n",
+    "    # in case original document type name is different, change name to HasDocument\n",
+    "    if curr_relationship[\"_typeName\"] == doc_rel_type_name:\n",
+    "        curr_relationship[\"_typeName\"] = \"HasDocument\"\n",
+    "    # format UUID and date properties\n",
+    "    for prop in curr_relationship[\"_properties\"]:\n",
+    "        if prop in date_properties:\n",
+    "            try:\n",
+    "                curr_relationship[\"_properties\"][prop] = datetime.fromtimestamp(\n",
+    "                    int(curr_relationship[\"_properties\"][prop] / 1000)\n",
+    "                )\n",
+    "            except:\n",
+    "                curr_relationship[\"_properties\"][prop] = None\n",
+    "        try:\n",
+    "            curr_relationship[\"_properties\"][prop] = UUID(\n",
+    "                curr_relationship[\"_properties\"][prop]\n",
+    "            )\n",
+    "        except:\n",
+    "            continue\n",
+    "    # format other relationship specific UUIDs\n",
+    "    curr_relationship[\"_id\"] = UUID(curr_relationship[\"_id\"])\n",
+    "    curr_relationship[\"_originEntityId\"] = UUID(curr_relationship[\"_originEntityId\"])\n",
+    "    curr_relationship[\"_destinationEntityId\"] = UUID(\n",
+    "        curr_relationship[\"_destinationEntityId\"]\n",
+    "    )\n",
+    "    batch.append(curr_relationship)\n",
+    "# apply final batch of edits to the knowledge graph\n",
+    "result = knowledgegraph_load.apply_edits(adds=batch)\n",
+    "# print error if one occurs during edit operation\n",
+    "try:\n",
+    "    print(result[\"error\"])\n",
+    "except:\n",
+    "    print(\"No error adding relationships\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d67f4ed",
+   "metadata": {},
+   "source": [
+    "## Add search indexes to all text properties\n",
+    "Adding search indexes to all text properties will allow for the values in those properties to be searched for when using search in any client."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e542d1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "load_dm = knowledgegraph_load.datamodel\n",
+    "# add search indexes for all entity text properties\n",
+    "for entity_type in load_dm[\"entity_types\"]:\n",
+    "    prop_list = []\n",
+    "    for prop in load_dm[\"entity_types\"][entity_type][\"properties\"]:\n",
+    "        if (\n",
+    "            load_dm[\"entity_types\"][entity_type][\"properties\"][prop][\"fieldType\"]\n",
+    "            == \"esriFieldTypeString\"\n",
+    "        ):\n",
+    "            prop_list.append(prop)\n",
+    "    knowledgegraph_load.update_search_index(\n",
+    "        adds={entity_type: {\"property_names\": prop_list}}\n",
+    "    )\n",
+    "# add search indexes for all relationship text properties\n",
+    "for entity_type in load_dm[\"relationship_types\"]:\n",
+    "    prop_list = []\n",
+    "    for prop in load_dm[\"relationship_types\"][entity_type][\"properties\"]:\n",
+    "        if (\n",
+    "            load_dm[\"relationship_types\"][entity_type][\"properties\"][prop][\"fieldType\"]\n",
+    "            == \"esriFieldTypeString\"\n",
+    "        ):\n",
+    "            prop_list.append(prop)\n",
+    "    knowledgegraph_load.update_search_index(\n",
+    "        adds={entity_type: {\"property_names\": prop_list}}\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0694de09",
+   "metadata": {},
+   "source": [
+    "## OPTIONAL: Add provenance records to the knowledge graph\n",
+    "This will only apply if you created a backup of provenance records and have enabled provenance on your knowledge graph service."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13b25b06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load provenance records json file\n",
+    "with open(os.path.join(output_folder, prov_file), \"r\") as file:\n",
+    "    prov_entities = json.load(file)\n",
+    "# add all provenance records\n",
+    "for curr_prov in prov_entities:\n",
+    "    # format UUID properties\n",
+    "    for prop in curr_prov[\"_properties\"]:\n",
+    "        try:\n",
+    "            curr_prov[\"_properties\"][prop] = UUID(curr_prov[\"_properties\"][prop])\n",
+    "        except:\n",
+    "            continue\n",
+    "    # format id as UUID\n",
+    "    curr_prov[\"_id\"] = UUID(curr_prov[\"_id\"])\n",
+    "    # add provenance record\n",
+    "    knowledgegraph_load.apply_edits(adds=[curr_prov])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
New sample notebook for the process of saving backups of the data model and data in a knowledge graph and loading a new graph from those files, this is a request we've gotten from a good amount of users and also shows a real scenario around using all the various tools for manipulating knowledge graphs

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [x] All `import`s are in the first cell? 
    - [x] First block of imports are standard libraries
    - [x] Second block are 3rd party libraries
    - [x] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [x] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [x] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [x] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [x] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [x] Code simplified & split out across multiple cells, useful comments?
- [x] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [x] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [x] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [x] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @ mohi9282 so he can add it to the list for the next deploy 
