### PR TITLE
add create_service instructions for knowledge graph guide

### DIFF
--- a/guide/17-working-with-knowledge-graphs/part1_introduction_to_knowledge_graphs.ipynb
+++ b/guide/17-working-with-knowledge-graphs/part1_introduction_to_knowledge_graphs.ipynb
@@ -91,6 +91,72 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create\n",
+    "Using the ArcGIS API for Python, you can create a new Knowledge Graph using [create_service()](https://developers.arcgis.com/python/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager.create_service)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gis = GIS(\"home\")\n",
+    "result = gis.content.create_service(\n",
+    "    name=\"myKnowledgeGraph\",\n",
+    "    capabilities=\"Query,Editing,Create,Update,Delete\",\n",
+    "    service_type=\"KnowledgeGraph\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Services can also be created using create parameters to choose more service options."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = gis.content.create_service(\n",
+    "    name=\"\", \n",
+    "    service_type=\"KnowledgeGraph\",\n",
+    "    create_params={\n",
+    "        \"name\": \"myKnowledgeGraph\",\n",
+    "        \"capabilities\": \"Query\", \n",
+    "        \"jsonProperties\": {\n",
+    "            \"supportsProvenance\": False,\n",
+    "            \"arcgisManagedData\": False,\n",
+    "            \"dataSourceItemID\": \"f63a6725058c4c05a63480521acffe01\"\n",
+    "        }\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, the result from create_service can be used to initialize the KnowledgeGraph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "knowledge_graph = KnowledgeGraph(url=result.url, gis=gis)"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/guide/17-working-with-knowledge-graphs/part1_introduction_to_knowledge_graphs.ipynb
+++ b/guide/17-working-with-knowledge-graphs/part1_introduction_to_knowledge_graphs.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -9,7 +8,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -23,14 +21,14 @@
     "            </ul>\n",
     "        </li>\n",
     "        <li><span><a href=\"#Connect\" data-toc-modified-id=\"Connect-2\">Connect</a></span></li>\n",
-    "        <li><span><a href=\"#Data-Model\" data-toc-modified-id=\"Data-Model-3\">Data Model</a></span></li>\n",
-    "        <li><span><a href=\"#Path-Forward\" data-toc-modified-id=\"Path-Forward-4\">Path Forward</a></span></li>\n",
+    "        <li><span><a href=\"#Create\" data-toc-modified-id=\"Create-3\">Create</a></span></li>\n",
+    "        <li><span><a href=\"#Data-Model\" data-toc-modified-id=\"Data-Model-4\">Data Model</a></span></li>\n",
+    "        <li><span><a href=\"#Path-Forward\" data-toc-modified-id=\"Path-Forward-5\">Path Forward</a></span></li>\n",
     "    </ul>\n",
     "</div>"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -42,7 +40,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -59,7 +56,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -83,7 +79,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -126,17 +121,17 @@
    "outputs": [],
    "source": [
     "result = gis.content.create_service(\n",
-    "    name=\"\", \n",
+    "    name=\"\",\n",
     "    service_type=\"KnowledgeGraph\",\n",
     "    create_params={\n",
     "        \"name\": \"myKnowledgeGraph\",\n",
-    "        \"capabilities\": \"Query\", \n",
+    "        \"capabilities\": \"Query\",\n",
     "        \"jsonProperties\": {\n",
     "            \"supportsProvenance\": False,\n",
     "            \"arcgisManagedData\": False,\n",
-    "            \"dataSourceItemID\": \"f63a6725058c4c05a63480521acffe01\"\n",
-    "        }\n",
-    "    }\n",
+    "            \"dataSourceItemID\": \"f63a6725058c4c05a63480521acffe01\",\n",
+    "        },\n",
+    "    },\n",
     ")"
    ]
   },
@@ -157,7 +152,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -176,7 +170,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -314,7 +307,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -326,15 +318,22 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.9.13"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "d622b5871f1605057390dea3c8b45e995d0d19bef8604acd7f5b2e1066a85139"


### PR DESCRIPTION
Update guide to include create_service instructions for knowledge graph services.

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [x] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [x] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [x] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [x] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [x] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [x] Code simplified & split out across multiple cells, useful comments?
- [x] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [x] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [x] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [x] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.