### PR TITLE
update Lambda docker image to v2.2.0

### DIFF
--- a/.github/workflows/DockerBuild.LambdaBaseImage.yaml
+++ b/.github/workflows/DockerBuild.LambdaBaseImage.yaml
@@ -31,7 +31,7 @@ jobs:
           images: |
             ghcr.io/esri/arcgis-python-api-lambda
           tags: |
-            type=raw,value=2.1.0,enable={{is_default_branch}}
+            type=raw,value=2.2.0,enable={{is_default_branch}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=schedule,pattern={{date 'YY.MM'}},enable={{is_default_branch}}
             type=sha,format=long

--- a/docker/LambdaBaseImage.Dockerfile
+++ b/docker/LambdaBaseImage.Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.source=https://github.com/esri/arcgis-python-api
 # install dependencies, then clean yum cache
 RUN yum -y install gcc krb5-devel krb5-server krb5-libs && yum clean all && rm -rf /var/cache/yum
 # install arcgis
-ARG ARCGIS_PYTHON_VERSION=2.1.0.3
+ARG ARCGIS_PYTHON_VERSION=2.2.0
 RUN  pip3 install arcgis==${ARCGIS_PYTHON_VERSION} --target "${LAMBDA_TASK_ROOT}"
 # set entrypoint to app.py handler method
 # (note that app.py is missing from this base image)


### PR DESCRIPTION
This can be merged any time and I'll manually run the build after the release has been pushed to pypi