### PR TITLE
update spelling typo in url for kg intro guide

### DIFF
--- a/guide/02-api-overview/release_notes_220.ipynb
+++ b/guide/02-api-overview/release_notes_220.ipynb
@@ -29,7 +29,7 @@
     "      * [Introduction to ArcGIS Hub Premium](../guide/hub-premium-guide/)\n",
     "      * [Introduction to ArcGIS Enterprise Sites](../guide/enterprise-sites-guide/)\n",
     "    * [Working with Knowledge Graphs](../)\n",
-    "      * [Part 1 - Introduction to Knowledge Graphs](../guide/part1-introduction-to-knowlege-graphs/)\n",
+    "      * [Part 1 - Introduction to Knowledge Graphs](../guide/part1-introduction-to-knowledge-graphs/)\n",
     "      * [Part 2 - Search and Query Knowledge Graphs](../guide/part2-search-query-knowledge-graph/)\n",
     "      * [Part 3 - Edit Knowledge Graphs](../guide/part3-edit-knowledge-graph/)\n",
     "    * [Working with Experience Builder](../)\n",


### PR DESCRIPTION
* url misspelled for _intro to knowledge graph_ guide