### PR TITLE
Updates to text for hyperlinks and corrections to urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You have multiple ways of executing these notebooks as listed below:
  - Execute locally on your computer by installing anaconda and the API. See _Install and set up_ help [Package managers](https://developers.arcgis.com/python/guide/anaconda/)
  - Execute with ArcGIS Pro. See the _Install and set up_ [ArcGIS Pro](https://developers.arcgis.com/python/guide/arcgis-pro/) topic. For additional details, see [Notebooks in ArcGIS Pro](https://pro.arcgis.com/en/pro-app/latest/arcpy/get-started/pro-notebooks.htm).
  - Execute with ArcGIS Notebooks, hosted on ArcGIS Online. Checkout [this group](https://www.arcgis.com/home/group.html?id=2464da88f55e45d89aedcae843167f51#overview) with sample notebooks.
- - Execute in a Dockerised environment. See help _Install and set up_ help [Installation as Docker image](https://developers.arcgis.com/python/guide/install-and-set-up/#installation-as-a-docker-image)
+ - Execute in a Dockerised environment. See _Install and set up_ help [Installation as Docker image](https://developers.arcgis.com/python/guide/install-and-set-up/#installation-as-a-docker-image)
  - Execute with Binder. See help [here](https://mybinder.org/)
 
 ## Issues

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This SDK repository contains the following items:
 
 You have multiple ways of executing these notebooks as listed below:
 
- - Execute locally on your computer by installing anaconda and the API. See help [here](https://developers.arcgis.com/python/guide/install-and-set-up/#Installation-using-Anaconda-for-Python-Distribution)
- - Execute with ArcGIS Pro. See help [here](https://developers.arcgis.com/python/guide/install-and-set-up/#Installation-for-ArcGIS-Pro-2.5.x-and-later)
+ - Execute locally on your computer by installing anaconda and the API. See help [here](https://developers.arcgis.com/python/guide/anaconda/)
+ - Execute with ArcGIS Pro. See the _Install and set up_ [ArcGIS Pro](https://developers.arcgis.com/python/guide/arcgis-pro/) topic. For additional details, see [Notebooks in ArcGIS Pro](https://pro.arcgis.com/en/pro-app/latest/arcpy/get-started/pro-notebooks.htm).
  - Execute with ArcGIS Notebooks, hosted on ArcGIS Online. Checkout [this group](https://www.arcgis.com/home/group.html?id=2464da88f55e45d89aedcae843167f51#overview) with sample notebooks.
- - Execute in a Dockerised environment. See help [here](https://developers.arcgis.com/python/guide/install-and-set-up/#Installation-as-a-Docker-image)
+ - Execute in a Dockerised environment. See help [here](https://developers.arcgis.com/python/guide/install-and-set-up/#installation-as-a-docker-image)
  - Execute with Binder. See help [here](https://mybinder.org/)
 
 ## Issues

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This SDK repository contains the following items:
 
 You have multiple ways of executing these notebooks as listed below:
 
- - Execute locally on your computer by installing anaconda and the API. See help [here](https://developers.arcgis.com/python/guide/anaconda/)
+ - Execute locally on your computer by installing anaconda and the API. See _Install and set up_ help [Package managers](https://developers.arcgis.com/python/guide/anaconda/)
  - Execute with ArcGIS Pro. See the _Install and set up_ [ArcGIS Pro](https://developers.arcgis.com/python/guide/arcgis-pro/) topic. For additional details, see [Notebooks in ArcGIS Pro](https://pro.arcgis.com/en/pro-app/latest/arcpy/get-started/pro-notebooks.htm).
  - Execute with ArcGIS Notebooks, hosted on ArcGIS Online. Checkout [this group](https://www.arcgis.com/home/group.html?id=2464da88f55e45d89aedcae843167f51#overview) with sample notebooks.
- - Execute in a Dockerised environment. See help [here](https://developers.arcgis.com/python/guide/install-and-set-up/#installation-as-a-docker-image)
+ - Execute in a Dockerised environment. See help _Install and set up_ help [Installation as Docker image](https://developers.arcgis.com/python/guide/install-and-set-up/#installation-as-a-docker-image)
  - Execute with Binder. See help [here](https://mybinder.org/)
 
 ## Issues

--- a/apidoc/README.md
+++ b/apidoc/README.md
@@ -1,3 +1,3 @@
 # API Reference Documentation
 
-* Live API Reference Documentation for the latest release can be found [here](https://developers.arcgis.com/python/api-reference/).  Downloads are available for current and previous versions [here](https://developers.arcgis.com/downloads/#python).
+* Live API Reference Documentation for the latest release can be found [here](https://developers.arcgis.com/python/api-reference/).  Downloads are available for current and previous versions at the [ArcGIS API for Python Downloads page](https://developers.arcgis.com/downloads/#python).

--- a/apidoc/README.md
+++ b/apidoc/README.md
@@ -1,3 +1,3 @@
 # API Reference Documentation
 
-* Live API Reference Documentation for the latest release can be found [here](https://developers.arcgis.com/python/api-reference/).  Downloads are available for current and previous versions at the [ArcGIS API for Python Downloads page](https://developers.arcgis.com/downloads/#python).
+* Live API Reference Documentation for the latest release can be found at the [ArcGIS for Developers API for Python home page](https://developers.arcgis.com/python/api-reference/).  Downloads are available for current and previous versions at the [ArcGIS API for Python Downloads page](https://developers.arcgis.com/downloads/#python).


### PR DESCRIPTION
@jtroe 
I think this is great!!! From what I see no problems getting rid of the contents of that _apidoc_ directory.  The upper case letters in links was breaking them, so I updated that text.  And I changed the word _here_ to some more explicit phrases.

you ok with that?

Before merging let's check in with Andrew to make sure there's no issues with removing this.