### PR TITLE
add support for building notebook docker for previous versions

### DIFF
--- a/.github/workflows/DockerBuild.NotebookImage.yaml
+++ b/.github/workflows/DockerBuild.NotebookImage.yaml
@@ -52,7 +52,6 @@ jobs:
             type=raw,value=${{ inputs.version }},enable=${{ inputs.is_default_supported_python && github.ref_name == github.event.repository.default_branch }}
             type=raw,value=latest,enable=${{ inputs.is_latest_release && inputs.is_default_supported_python && github.ref_name == github.event.repository.default_branch }}
             type=schedule,pattern={{date 'YY.MM'}},enable=${{ inputs.is_latest_release && inputs.is_default_supported_python && github.ref_name == github.event.repository.default_branch }}
-            type=sha,format=long
 
       - id: docker_build
         name: Build image and push to GitHub Container Registry

--- a/.github/workflows/DockerBuild.NotebookImage.yaml
+++ b/.github/workflows/DockerBuild.NotebookImage.yaml
@@ -3,6 +3,23 @@ name: DockerBuild.NotebookImage
 on:
   # allow it to be run on-demand
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version of ArcGIS API for Python to install in the image"
+        type: string
+        default: "2.2.0"
+      python_version:
+        description: "Python version to base image on"
+        type: string
+        default: "3.9"
+      is_latest_release:
+        description: "Version of ArcGIS API for Python is Latest current release"
+        type: boolean
+        default: false
+      is_default_supported_python:
+        description: "Python version is default supported version (i.e. python used by Pro and Enterprise)"
+        type: boolean
+        default: false
 
 jobs:
   build-and-push:
@@ -31,9 +48,10 @@ jobs:
           images: |
             ghcr.io/esri/arcgis-python-api-notebook
           tags: |
-            type=raw,value=2.3.0,enable={{is_default_branch}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=schedule,pattern={{date 'YY.MM'}},enable={{is_default_branch}}
+            type=raw,value=${{ inputs.version }}-python${{ inputs.python_version }}
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.is_default_supported_python && github.ref_name == github.event.repository.default_branch }}
+            type=raw,value=latest,enable=${{ inputs.is_latest_release && inputs.is_default_supported_python && github.ref_name == github.event.repository.default_branch }}
+            type=schedule,pattern={{date 'YY.MM'}},enable=${{ inputs.is_latest_release && inputs.is_default_supported_python && github.ref_name == github.event.repository.default_branch }}
             type=sha,format=long
 
       - id: docker_build
@@ -43,6 +61,9 @@ jobs:
           # relative path to the place where source code with Dockerfile is located
           context: ./docker
           file: ./docker/NotebookImage.Dockerfile
+          build-args: |
+            python_version=${{ inputs.python_version }}
+            arcgis_version=${{ inputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           provenance: false
           platforms: linux/amd64


### PR DESCRIPTION
update build workflow to accept parameters for api version and python version, as well as toggles for whether the specified versions are authoritative