### PR TITLE
changed item id for two samples

### DIFF
--- a/samples/04_gis_analysts_data_scientists/traffic-light-detection-on-oriented-imagery-triangulation.ipynb
+++ b/samples/04_gis_analysts_data_scientists/traffic-light-detection-on-oriented-imagery-triangulation.ipynb
@@ -38,7 +38,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "8d325f6a",
    "metadata": {},
@@ -87,20 +86,15 @@
   {
    "cell_type": "markdown",
    "id": "3822a3cc",
-   "metadata": {
-    "heading_collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Download & setup data"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "5755953f",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "For this notebook, we will use sample oriented imagery and oriented imagery meta data files, available on ArcGIS Online, for inferencing and plotting points."
    ]
@@ -109,36 +103,30 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "075264e6",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "gis = GIS(\n",
-    "    \"home\"\n",
-    ")"
+    "gis = GIS(\"home\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
    "id": "e3a5f2f6",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://www.arcgis.com/home/item.html?id=96c6401f5eb94a899c85ab044ddcb8fb' target='_blank'>\n",
-       "                        <img src='https://www.arcgis.com/sharing/rest//content/items/96c6401f5eb94a899c85ab044ddcb8fb/info/thumbnail/ago_downloaded.png' class=\"itemThumbnail\">\n",
+       "                       <a href='https://www.arcgis.com/home/item.html?id=d606e6827c8746e383de96d8718be9a8' target='_blank'>\n",
+       "                        <img src='https://www.arcgis.com/sharing/rest//content/items/d606e6827c8746e383de96d8718be9a8/info/thumbnail/ago_downloaded.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://www.arcgis.com/home/item.html?id=96c6401f5eb94a899c85ab044ddcb8fb' target='_blank'><b>Oriented Imagery Sample Data</b>\n",
+       "                        <a href='https://www.arcgis.com/home/item.html?id=d606e6827c8746e383de96d8718be9a8' target='_blank'><b>Oriented Imagery Sample Data</b>\n",
        "                        </a>\n",
        "                        <br/>oriented imagery sample notebook data<img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">Image Collection by api_data_owner\n",
        "                        <br/>Last Modified: January 03, 2023\n",
@@ -157,9 +145,8 @@
     }
    ],
    "source": [
-    "# 96c6401f5eb94a899c85ab044ddcb8fb item id is for sample imagery\n",
     "# Sample data can be directly downloded by clickng on the link below\n",
-    "oriented_imagery_data = gis.content.get(\"96c6401f5eb94a899c85ab044ddcb8fb\") \n",
+    "oriented_imagery_data = gis.content.get(\"d606e6827c8746e383de96d8718be9a8\") \n",
     "oriented_imagery_data"
    ]
   },
@@ -167,13 +154,28 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "58c3b834",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/javascript": "\n            setTimeout(function() {\n                var nbb_cell_id = 6;\n                var nbb_unformatted_code = \"# filepath = oriented_imagery_data.download(save_path = os.getcwd(), file_name=oriented_imagery_data.name)\\nfilepath = \\\"D:\\\\TrafficSignalDataset\\\\sample\\\\sample\\\\oriented_imagery_sample_notebook.zip\\\"\";\n                var nbb_formatted_code = \"# filepath = oriented_imagery_data.download(save_path = os.getcwd(), file_name=oriented_imagery_data.name)\\nfilepath = \\\"D:\\\\TrafficSignalDataset\\\\sample\\\\sample\\\\oriented_imagery_sample_notebook.zip\\\"\";\n                var nbb_cells = Jupyter.notebook.get_cells();\n                for (var i = 0; i < nbb_cells.length; ++i) {\n                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n                             nbb_cells[i].set_text(nbb_formatted_code);\n                        }\n                        break;\n                    }\n                }\n            }, 500);\n            ",
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 6;\n",
+       "                var nbb_unformatted_code = \"# filepath = oriented_imagery_data.download(save_path = os.getcwd(), file_name=oriented_imagery_data.name)\\nfilepath = \\\"D:\\\\TrafficSignalDataset\\\\sample\\\\sample\\\\oriented_imagery_sample_notebook.zip\\\"\";\n",
+       "                var nbb_formatted_code = \"# filepath = oriented_imagery_data.download(save_path = os.getcwd(), file_name=oriented_imagery_data.name)\\nfilepath = \\\"D:\\\\TrafficSignalDataset\\\\sample\\\\sample\\\\oriented_imagery_sample_notebook.zip\\\"\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -190,9 +192,7 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "19d161fd",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with zipfile.ZipFile(filepath, 'r') as zip_ref:\n",
@@ -200,12 +200,9 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9d5d76e4",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "After extracting the zip file, we will set the path of the items in the zip file.\n",
     "- `data_path`: Folder containing all the oriented imagery.\n",
@@ -216,13 +213,28 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "ced8ef18",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/javascript": "\n            setTimeout(function() {\n                var nbb_cell_id = 7;\n                var nbb_unformatted_code = \"data_path = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"street_view_data\\\")\\nimage_meta_data = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"oriented_imagery_meta_data.csv\\\")\\ndepth_image_path = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"saved_depth_image\\\")\";\n                var nbb_formatted_code = \"data_path = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"street_view_data\\\")\\nimage_meta_data = Path(\\n    os.path.join(os.path.splitext(filepath)[0]), \\\"oriented_imagery_meta_data.csv\\\"\\n)\\ndepth_image_path = Path(\\n    os.path.join(os.path.splitext(filepath)[0]), \\\"saved_depth_image\\\"\\n)\";\n                var nbb_cells = Jupyter.notebook.get_cells();\n                for (var i = 0; i < nbb_cells.length; ++i) {\n                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n                             nbb_cells[i].set_text(nbb_formatted_code);\n                        }\n                        break;\n                    }\n                }\n            }, 500);\n            ",
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 7;\n",
+       "                var nbb_unformatted_code = \"data_path = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"street_view_data\\\")\\nimage_meta_data = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"oriented_imagery_meta_data.csv\\\")\\ndepth_image_path = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"saved_depth_image\\\")\";\n",
+       "                var nbb_formatted_code = \"data_path = Path(os.path.join(os.path.splitext(filepath)[0]), \\\"street_view_data\\\")\\nimage_meta_data = Path(\\n    os.path.join(os.path.splitext(filepath)[0]), \\\"oriented_imagery_meta_data.csv\\\"\\n)\\ndepth_image_path = Path(\\n    os.path.join(os.path.splitext(filepath)[0]), \\\"saved_depth_image\\\"\\n)\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -240,13 +252,28 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "72152a81",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "application/javascript": "\n            setTimeout(function() {\n                var nbb_cell_id = 8;\n                var nbb_unformatted_code = \"image_path_list = [os.path.join(data_path,image) for image in os.listdir(data_path)]\";\n                var nbb_formatted_code = \"image_path_list = [os.path.join(data_path, image) for image in os.listdir(data_path)]\";\n                var nbb_cells = Jupyter.notebook.get_cells();\n                for (var i = 0; i < nbb_cells.length; ++i) {\n                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n                             nbb_cells[i].set_text(nbb_formatted_code);\n                        }\n                        break;\n                    }\n                }\n            }, 500);\n            ",
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 8;\n",
+       "                var nbb_unformatted_code = \"image_path_list = [os.path.join(data_path,image) for image in os.listdir(data_path)]\";\n",
+       "                var nbb_formatted_code = \"image_path_list = [os.path.join(data_path, image) for image in os.listdir(data_path)]\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -270,7 +297,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "e16c9153",
    "metadata": {
@@ -290,7 +316,24 @@
    "outputs": [
     {
      "data": {
-      "application/javascript": "\n            setTimeout(function() {\n                var nbb_cell_id = 9;\n                var nbb_unformatted_code = \"yolo = YOLOv3(pretrained_backbone=True)\";\n                var nbb_formatted_code = \"yolo = YOLOv3(pretrained_backbone=True)\";\n                var nbb_cells = Jupyter.notebook.get_cells();\n                for (var i = 0; i < nbb_cells.length; ++i) {\n                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n                             nbb_cells[i].set_text(nbb_formatted_code);\n                        }\n                        break;\n                    }\n                }\n            }, 500);\n            ",
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 9;\n",
+       "                var nbb_unformatted_code = \"yolo = YOLOv3(pretrained_backbone=True)\";\n",
+       "                var nbb_formatted_code = \"yolo = YOLOv3(pretrained_backbone=True)\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -312,7 +355,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0169f406",
    "metadata": {},
@@ -332,7 +374,24 @@
    "outputs": [
     {
      "data": {
-      "application/javascript": "\n            setTimeout(function() {\n                var nbb_cell_id = 10;\n                var nbb_unformatted_code = \"def traffic_light_finder(oriented_image_path):\\n    flag = 0\\n    coordlist = []\\n    temp_list = {}\\n    out = yolo.predict(oriented_image_path, threshold=0.5)\\n    test_img = cv2.imread(oriented_image_path)\\n    if len(out[0]) == 0:\\n        temp_list[\\\"object\\\"] = False\\n    else:\\n        for index, (value, label, confidence) in enumerate(zip(out[0], out[1], out[2])):\\n            if label == \\\"traffic light\\\":\\n                flag = 1\\n                coordlist.append(\\n                    [int(value[0]), int(value[1]), int(value[2]), int(value[3])]\\n                )\\n                test_img = cv2.rectangle(\\n                    test_img,\\n                    (int(value[0]), int(value[1]), int(value[2]), int(value[3])),\\n                    (0, 0, 255),\\n                    10,\\n                )\\n                textvalue = label + \\\"_\\\" + str(confidence)\\n                cv2.putText(\\n                    test_img,\\n                    textvalue,\\n                    (int(value[0]), int(value[1]) - 10),\\n                    cv2.FONT_HERSHEY_SIMPLEX,\\n                    1.5,\\n                    (0, 0, 255),\\n                    2,\\n                )\\n        if flag == 1:\\n            temp_list[\\\"object\\\"] = True\\n            temp_list[\\\"coords\\\"] = coordlist\\n            temp_list[\\\"assetname\\\"] = \\\"traffic light\\\"\\n    return temp_list, test_img\";\n                var nbb_formatted_code = \"def traffic_light_finder(oriented_image_path):\\n    flag = 0\\n    coordlist = []\\n    temp_list = {}\\n    out = yolo.predict(oriented_image_path, threshold=0.5)\\n    test_img = cv2.imread(oriented_image_path)\\n    if len(out[0]) == 0:\\n        temp_list[\\\"object\\\"] = False\\n    else:\\n        for index, (value, label, confidence) in enumerate(zip(out[0], out[1], out[2])):\\n            if label == \\\"traffic light\\\":\\n                flag = 1\\n                coordlist.append(\\n                    [int(value[0]), int(value[1]), int(value[2]), int(value[3])]\\n                )\\n                test_img = cv2.rectangle(\\n                    test_img,\\n                    (int(value[0]), int(value[1]), int(value[2]), int(value[3])),\\n                    (0, 0, 255),\\n                    10,\\n                )\\n                textvalue = label + \\\"_\\\" + str(confidence)\\n                cv2.putText(\\n                    test_img,\\n                    textvalue,\\n                    (int(value[0]), int(value[1]) - 10),\\n                    cv2.FONT_HERSHEY_SIMPLEX,\\n                    1.5,\\n                    (0, 0, 255),\\n                    2,\\n                )\\n        if flag == 1:\\n            temp_list[\\\"object\\\"] = True\\n            temp_list[\\\"coords\\\"] = coordlist\\n            temp_list[\\\"assetname\\\"] = \\\"traffic light\\\"\\n    return temp_list, test_img\";\n                var nbb_cells = Jupyter.notebook.get_cells();\n                for (var i = 0; i < nbb_cells.length; ++i) {\n                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n                             nbb_cells[i].set_text(nbb_formatted_code);\n                        }\n                        break;\n                    }\n                }\n            }, 500);\n            ",
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 10;\n",
+       "                var nbb_unformatted_code = \"def traffic_light_finder(oriented_image_path):\\n    flag = 0\\n    coordlist = []\\n    temp_list = {}\\n    out = yolo.predict(oriented_image_path, threshold=0.5)\\n    test_img = cv2.imread(oriented_image_path)\\n    if len(out[0]) == 0:\\n        temp_list[\\\"object\\\"] = False\\n    else:\\n        for index, (value, label, confidence) in enumerate(zip(out[0], out[1], out[2])):\\n            if label == \\\"traffic light\\\":\\n                flag = 1\\n                coordlist.append(\\n                    [int(value[0]), int(value[1]), int(value[2]), int(value[3])]\\n                )\\n                test_img = cv2.rectangle(\\n                    test_img,\\n                    (int(value[0]), int(value[1]), int(value[2]), int(value[3])),\\n                    (0, 0, 255),\\n                    10,\\n                )\\n                textvalue = label + \\\"_\\\" + str(confidence)\\n                cv2.putText(\\n                    test_img,\\n                    textvalue,\\n                    (int(value[0]), int(value[1]) - 10),\\n                    cv2.FONT_HERSHEY_SIMPLEX,\\n                    1.5,\\n                    (0, 0, 255),\\n                    2,\\n                )\\n        if flag == 1:\\n            temp_list[\\\"object\\\"] = True\\n            temp_list[\\\"coords\\\"] = coordlist\\n            temp_list[\\\"assetname\\\"] = \\\"traffic light\\\"\\n    return temp_list, test_img\";\n",
+       "                var nbb_formatted_code = \"def traffic_light_finder(oriented_image_path):\\n    flag = 0\\n    coordlist = []\\n    temp_list = {}\\n    out = yolo.predict(oriented_image_path, threshold=0.5)\\n    test_img = cv2.imread(oriented_image_path)\\n    if len(out[0]) == 0:\\n        temp_list[\\\"object\\\"] = False\\n    else:\\n        for index, (value, label, confidence) in enumerate(zip(out[0], out[1], out[2])):\\n            if label == \\\"traffic light\\\":\\n                flag = 1\\n                coordlist.append(\\n                    [int(value[0]), int(value[1]), int(value[2]), int(value[3])]\\n                )\\n                test_img = cv2.rectangle(\\n                    test_img,\\n                    (int(value[0]), int(value[1]), int(value[2]), int(value[3])),\\n                    (0, 0, 255),\\n                    10,\\n                )\\n                textvalue = label + \\\"_\\\" + str(confidence)\\n                cv2.putText(\\n                    test_img,\\n                    textvalue,\\n                    (int(value[0]), int(value[1]) - 10),\\n                    cv2.FONT_HERSHEY_SIMPLEX,\\n                    1.5,\\n                    (0, 0, 255),\\n                    2,\\n                )\\n        if flag == 1:\\n            temp_list[\\\"object\\\"] = True\\n            temp_list[\\\"coords\\\"] = coordlist\\n            temp_list[\\\"assetname\\\"] = \\\"traffic light\\\"\\n    return temp_list, test_img\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -383,7 +442,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "10cef39b",
    "metadata": {},
@@ -430,7 +488,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a8592b00",
    "metadata": {},
@@ -446,7 +503,24 @@
    "outputs": [
     {
      "data": {
-      "application/javascript": "\n            setTimeout(function() {\n                var nbb_cell_id = 14;\n                var nbb_unformatted_code = \"with open('traffic_light_data_sample.json', 'w') as f:\\n    json.dump(data_list, f)\";\n                var nbb_formatted_code = \"with open(\\\"traffic_light_data_sample.json\\\", \\\"w\\\") as f:\\n    json.dump(data_list, f)\";\n                var nbb_cells = Jupyter.notebook.get_cells();\n                for (var i = 0; i < nbb_cells.length; ++i) {\n                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n                             nbb_cells[i].set_text(nbb_formatted_code);\n                        }\n                        break;\n                    }\n                }\n            }, 500);\n            ",
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 14;\n",
+       "                var nbb_unformatted_code = \"with open('traffic_light_data_sample.json', 'w') as f:\\n    json.dump(data_list, f)\";\n",
+       "                var nbb_formatted_code = \"with open(\\\"traffic_light_data_sample.json\\\", \\\"w\\\") as f:\\n    json.dump(data_list, f)\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
       "text/plain": [
        "<IPython.core.display.Javascript object>"
       ]
@@ -487,7 +561,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "27a3ed31",
    "metadata": {
@@ -908,7 +981,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "98ea478d",
    "metadata": {
@@ -1063,7 +1135,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d694ee63",
    "metadata": {
@@ -1100,7 +1171,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1114,7 +1185,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.11"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/samples/04_gis_analysts_data_scientists/traffic-light-detection-on-oriented-imagery.ipynb
+++ b/samples/04_gis_analysts_data_scientists/traffic-light-detection-on-oriented-imagery.ipynb
@@ -123,13 +123,13 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://www.arcgis.com/home/item.html?id=96c6401f5eb94a899c85ab044ddcb8fb' target='_blank'>\n",
-       "                        <img src='https://www.arcgis.com/sharing/rest//content/items/96c6401f5eb94a899c85ab044ddcb8fb/info/thumbnail/ago_downloaded.png' class=\"itemThumbnail\">\n",
+       "                       <a href='https://www.arcgis.com/home/item.html?id=d606e6827c8746e383de96d8718be9a8' target='_blank'>\n",
+       "                        <img src='https://www.arcgis.com/sharing/rest//content/items/d606e6827c8746e383de96d8718be9a8/info/thumbnail/ago_downloaded.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://www.arcgis.com/home/item.html?id=96c6401f5eb94a899c85ab044ddcb8fb' target='_blank'><b>Oriented Imagery Sample Data</b>\n",
+       "                        <a href='https://www.arcgis.com/home/item.html?id=d606e6827c8746e383de96d8718be9a8' target='_blank'><b>Oriented Imagery Sample Data</b>\n",
        "                        </a>\n",
        "                        <br/>oriented imagery sample notebook data<img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\">Image Collection by api_data_owner\n",
        "                        <br/>Last Modified: January 03, 2023\n",
@@ -148,9 +148,8 @@
     }
    ],
    "source": [
-    "# 96c6401f5eb94a899c85ab044ddcb8fb item id is for sample imagery\n",
     "# Sample data can be directly downloded by clickng on the link below\n",
-    "oriented_imagery_data = gis.content.get(\"96c6401f5eb94a899c85ab044ddcb8fb\") \n",
+    "oriented_imagery_data = gis.content.get(\"d606e6827c8746e383de96d8718be9a8\") \n",
     "oriented_imagery_data"
    ]
   },
@@ -567,7 +566,7 @@
     "\n",
     "We have packagaed the model as a dlpk file which we can use with ArcGIS Pro to calculate the relative estimated depth of the objects in the oriented imagery.\n",
     "\n",
-    "For this sample notebook, we have already provided the output of this model on all the sample images in the folder <b>saved_depth_image</b> with the sample data downloded in the [Oriented Imagery Sample Data](https://www.arcgis.com/home/item.html?id=96c6401f5eb94a899c85ab044ddcb8fb)."
+    "For this sample notebook, we have already provided the output of this model on all the sample images in the folder <b>saved_depth_image</b> with the sample data downloded in the [Oriented Imagery Sample Data](https://www.arcgis.com/home/item.html?id=d606e6827c8746e383de96d8718be9a8)."
    ]
   },
   {
@@ -1180,7 +1179,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1194,7 +1193,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.11"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
\<insert pull request description here\>

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **If this notebook showcases deep learning capabilities, please go through the following checklist:**
    - [ ] Are the inputs required for `Export Training Data Using Deep Learning` tool published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function?
    - [ ] Is training data zipped and published as Image Collection? Note: Whole folder is zipped with name same as the notebook name.
    - [ ] Are the inputs required for model inferencing published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function? Note: This includes providing test raster and trained model.
    - [ ] Are the inferenced results displayed using a webmap widget?
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @jyaistMap so he can add it to the list for the next deploy.