### PR TITLE
enable installation of patch releases in lambda image

### DIFF
--- a/.github/workflows/DockerBuild.LambdaBaseImage.yaml
+++ b/.github/workflows/DockerBuild.LambdaBaseImage.yaml
@@ -3,6 +3,23 @@ name: DockerBuild.LambdaImage
 on:
   # allow it to be run on-demand
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version of ArcGIS API for Python to install in the image"
+        type: string
+        default: "2.2.0"
+      python_version:
+        description: "Python version to base image on"
+        type: string
+        default: "3.9"
+      is_latest_release:
+        description: "Version of ArcGIS API for Python is Latest current release"
+        type: boolean
+        default: false
+      is_default_supported_python:
+        description: "Python version is default supported version (i.e. python used by Pro and Enterprise)"
+        type: boolean
+        default: false
 
 jobs:
   build-and-push:
@@ -31,10 +48,10 @@ jobs:
           images: |
             ghcr.io/esri/arcgis-python-api-lambda
           tags: |
-            type=raw,value=2.2.0,enable={{is_default_branch}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=schedule,pattern={{date 'YY.MM'}},enable={{is_default_branch}}
-            type=sha,format=long
+            type=raw,value=${{ inputs.version }}-python${{ inputs.python_version }}
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.is_default_supported_python && github.ref_name == github.event.repository.default_branch }}
+            type=raw,value=latest,enable=${{ inputs.is_latest_release && inputs.is_default_supported_python && github.ref_name == github.event.repository.default_branch }}
+            type=schedule,pattern={{date 'YY.MM'}},enable=${{ inputs.is_latest_release && inputs.is_default_supported_python && github.ref_name == github.event.repository.default_branch }}
 
       - id: docker_build
         name: Build image and push to GitHub Container Registry
@@ -43,6 +60,9 @@ jobs:
           # relative path to the place where source code with Dockerfile is located
           context: .
           file: ./docker/LambdaBaseImage.Dockerfile
+          build-args: |
+            python_version=${{ inputs.python_version }}
+            arcgis_version=${{ inputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           provenance: false
           platforms: linux/amd64

--- a/docker/LambdaBaseImage.Dockerfile
+++ b/docker/LambdaBaseImage.Dockerfile
@@ -1,6 +1,6 @@
-ARG PYTHON_VERSION=3.9
+ARG python_version=3.9
 # lambda python image, defaults to python 3.9
-FROM public.ecr.aws/lambda/python:${PYTHON_VERSION}
+FROM public.ecr.aws/lambda/python:${python_version}
 
 # set metadata
 LABEL org.opencontainers.image.authors="jroebuck@esri.com"
@@ -11,8 +11,8 @@ LABEL org.opencontainers.image.source=https://github.com/esri/arcgis-python-api
 # install dependencies, then clean yum cache
 RUN yum -y install gcc krb5-devel krb5-server krb5-libs && yum clean all && rm -rf /var/cache/yum
 # install arcgis
-ARG ARCGIS_PYTHON_VERSION=2.2.0
-RUN  pip3 install arcgis==${ARCGIS_PYTHON_VERSION} --target "${LAMBDA_TASK_ROOT}"
+ARG arcgis_version="2.2.0"
+RUN  pip3 install "arcgis==${arcgis_version}.*" --target "${LAMBDA_TASK_ROOT}"
 # set entrypoint to app.py handler method
 # (note that app.py is missing from this base image)
 CMD [ "app.handler" ]


### PR DESCRIPTION
also, enables building of multiple images for each release of the Python API, for alternate python versions

updates the pip install command to install <provided version>.* to grab the latest patch, if any.  Images will still be tagged only with the base version, e.g. 2.2.0 for patch release 2.2.0.2