### PR TITLE
Update link for the releases page on original samples overview page

### DIFF
--- a/samples/01_get_started/overview.ipynb
+++ b/samples/01_get_started/overview.ipynb
@@ -1,1 +1,48 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# Samples\n", "\n", "These samples demonstrate various features of the ArcGIS API for Python. The samples are categorized by the user profile they are most relevant to. Most samples are in the form of a [Jupyter Notebooks](http://jupyter-notebook.readthedocs.io/en/latest/notebook.html), that can be viewed online, or downloaded and run interactively. Other samples are provided as stand-alone Python scripts in the GitHub SDK repository.\n", "\n", "## Download and run the sample notebooks\n", "To run the sample notebooks locally, you need the ArcGIS API for Python installed on your computer. See the [Getting Started](https://developers.arcgis.com/python/guide/install-and-set-up/) section in the Guide to learn how to download and run the API.\n", "\n", "Once the API is installed, you can download the samples either as an [archive](https://github.com/Esri/arcgis-python-api/archive/v1.0.1.zip) or clone the [arcgis-python-api](https://github.com/Esri/arcgis-python-api) GitHub repository. \n", "\n", "Next, extract the archive if you downloaded as an archive then open your terminal application and enter the directory with the samples. Then start Jupyter notebook application. Refer to [Using the Jupyter Notebook environment](https://developers.arcgis.com/python/guide/using-the-jupyter-notebook-environment/) tutorial in the Guide for instructions on how to do this and to get yourself familiar with the notebook environment."]}], "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.5.3"}}, "nbformat": 4, "nbformat_minor": 1}
+{
+    "cells":
+    [
+        {
+            "cell_type": "markdown",
+            "metadata":
+            {},
+            "source":
+            [
+                "# Samples\n",
+                "\n",
+                "These samples demonstrate various features of the ArcGIS API for Python. The samples are categorized by the user profile they are most relevant to. Most samples are in the form of a [Jupyter Notebooks](http://jupyter-notebook.readthedocs.io/en/latest/notebook.html), that can be viewed online, or downloaded and run interactively. Other samples are provided as stand-alone Python scripts in the GitHub SDK repository.\n",
+                "\n",
+                "## Download and run the sample notebooks\n",
+                "To run the sample notebooks locally, you need the ArcGIS API for Python installed on your computer. See the [Getting Started](https://developers.arcgis.com/python/guide/install-and-set-up/) section in the Guide to learn how to download and run the API.\n",
+                "\n",
+                "Once the API is installed, you can download the samples either as an [archive](https://github.com/Esri/arcgis-python-api/releases) or clone the [arcgis-python-api](https://github.com/Esri/arcgis-python-api) GitHub repository. \n",
+                "\n",
+                "Next, extract the archive if you downloaded as an archive then open your terminal application and enter the directory with the samples. Then start Jupyter notebook application. Refer to [Using the Jupyter Notebook environment](https://developers.arcgis.com/python/guide/using-the-jupyter-notebook-environment/) tutorial in the Guide for instructions on how to do this and to get yourself familiar with the notebook environment."
+            ]
+        }
+    ],
+    "metadata":
+    {
+        "kernelspec":
+        {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info":
+        {
+            "codemirror_mode":
+            {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.5.3"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 1
+}

--- a/samples/01_get_started/overview.ipynb
+++ b/samples/01_get_started/overview.ipynb
@@ -1,48 +1,41 @@
 {
-    "cells":
-    [
-        {
-            "cell_type": "markdown",
-            "metadata":
-            {},
-            "source":
-            [
-                "# Samples\n",
-                "\n",
-                "These samples demonstrate various features of the ArcGIS API for Python. The samples are categorized by the user profile they are most relevant to. Most samples are in the form of a [Jupyter Notebooks](http://jupyter-notebook.readthedocs.io/en/latest/notebook.html), that can be viewed online, or downloaded and run interactively. Other samples are provided as stand-alone Python scripts in the GitHub SDK repository.\n",
-                "\n",
-                "## Download and run the sample notebooks\n",
-                "To run the sample notebooks locally, you need the ArcGIS API for Python installed on your computer. See the [Getting Started](https://developers.arcgis.com/python/guide/install-and-set-up/) section in the Guide to learn how to download and run the API.\n",
-                "\n",
-                "Once the API is installed, you can download the samples either as an [archive](https://github.com/Esri/arcgis-python-api/releases) or clone the [arcgis-python-api](https://github.com/Esri/arcgis-python-api) GitHub repository. \n",
-                "\n",
-                "Next, extract the archive if you downloaded as an archive then open your terminal application and enter the directory with the samples. Then start Jupyter notebook application. Refer to [Using the Jupyter Notebook environment](https://developers.arcgis.com/python/guide/using-the-jupyter-notebook-environment/) tutorial in the Guide for instructions on how to do this and to get yourself familiar with the notebook environment."
-            ]
-        }
-    ],
-    "metadata":
-    {
-        "kernelspec":
-        {
-            "display_name": "Python 3",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info":
-        {
-            "codemirror_mode":
-            {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.5.3"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 1
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Samples\n",
+    "\n",
+    "These samples demonstrate various features of the ArcGIS API for Python. The samples are categorized by the user profile they are most relevant to. Most samples are in the form of a [Jupyter Notebooks](http://jupyter-notebook.readthedocs.io/en/latest/notebook.html), that can be viewed online, or downloaded and run interactively. Other samples are provided as stand-alone Python scripts in the GitHub SDK repository.\n",
+    "\n",
+    "## Download and run the sample notebooks\n",
+    "To run the sample notebooks locally, you need the ArcGIS API for Python installed on your computer. See the [Getting Started](https://developers.arcgis.com/python/guide/install-and-set-up/) section in the Guide to learn how to download and run the API.\n",
+    "\n",
+    "Once the API is installed, you can download the samples either as an [archive](https://github.com/Esri/arcgis-python-api/releases) or clone the [arcgis-python-api](https://github.com/Esri/arcgis-python-api) GitHub repository. \n",
+    "\n",
+    "Next, extract the archive if you downloaded as an archive then open your terminal application and enter the directory with the samples. Then start Jupyter notebook application. Refer to [Using the Jupyter Notebook environment](https://developers.arcgis.com/python/guide/using-the-jupyter-notebook-environment/) tutorial in the Guide for instructions on how to do this and to get yourself familiar with the notebook environment."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
In this notebook, the hyperlink for _archive_ points to an outdated reference for downloading an archive of samples. Updated the link to point to the current releases page so user can download what they want.

Hyperlink now points to releases page:

![image](https://github.com/Esri/arcgis-python-api/assets/1399179/6e0d3ee3-a276-487a-917f-3d023630f00e)

