### PR TITLE
Update create_and_load_knowledge_graph_backups.ipynb

### DIFF
--- a/samples/05_content_publishers/create_and_load_knowledge_graph_backups.ipynb
+++ b/samples/05_content_publishers/create_and_load_knowledge_graph_backups.ipynb
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da690f5c",
+   "id": "17968c25",
    "metadata": {},
    "source": [
     "Get the service definition for the knowledge graph service and save it to the service definition file"
@@ -167,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "952e670f",
+   "id": "8c5275cb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f237840",
+   "id": "a2769e71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -464,7 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fa7d1671",
+   "id": "a74ddfe3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -534,7 +534,7 @@
    "outputs": [],
    "source": [
     "# connect to portal via GIS\n",
-    "gis_load = GIS(\"https://myportal.com/portal\", \"username\", \"password\")\n",
+    "gis_load = GIS(\"home\")\n",
     "\n",
     "with open(os.path.join(output_folder, servicedef), \"r\") as file:\n",
     "    service_def = json.load(file)\n",
@@ -559,7 +559,7 @@
     "    },\n",
     "}\n",
     "\n",
-    "result = gis_copyto.content.create_service(\n",
+    "result = gis_load.content.create_service(\n",
     "    name=\"\", service_type=\"KnowledgeGraph\", create_params=updated_service_def\n",
     ")\n",
     "\n",
@@ -861,7 +861,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a6a5ca5",
+   "id": "aa2099c5",
    "metadata": {},
    "source": [
     "### Add additional provenance entity type properties\n",
@@ -871,11 +871,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e663e9fd",
+   "id": "c2fddb86",
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(os.path.join(file_loc, dm_prov), \"r\") as file:\n",
+    "with open(os.path.join(output_folder, dm_prov), \"r\") as file:\n",
     "    prov_dm = json.load(file)\n",
     "\n",
     "prop_list = []\n",

--- a/samples/05_content_publishers/create_and_load_knowledge_graph_backups.ipynb
+++ b/samples/05_content_publishers/create_and_load_knowledge_graph_backups.ipynb
@@ -54,6 +54,7 @@
     "Create a backup of an ArcGIS Knowledge graph you have created to store your data model and data. The backup will be in the format of json files that can read to recreate your graph or be shared for others to be able to create the same graph on a different server.\n",
     "\n",
     "_**Load a new graph easily from your backup files!**_\n",
+    "\n",
     "Use the backup files with the load backup files portion of this notebook to create a graph with the same data model and data."
    ]
   },
@@ -82,7 +83,7 @@
    "outputs": [],
    "source": [
     "# imports\n",
-    "import os, json\n",
+    "import os, json, requests\n",
     "from datetime import datetime\n",
     "from uuid import UUID\n",
     "\n",
@@ -107,14 +108,16 @@
    "outputs": [],
    "source": [
     "# output folder name\n",
-    "output_folder = \"C:\\backups\\myknowledgegraph_backup\"\n",
+    "output_folder = r\"C:\\backups\\myknowledgegraph_backup\"\n",
     "\n",
     "# output backup json file names\n",
     "dm_ent = \"datamodel_entities.json\"\n",
     "dm_rel = \"datamodel_relationships.json\"\n",
+    "dm_prov = \"datamodel_provenance.json\"\n",
     "all_ent = \"all_entities.json\"\n",
     "all_rel = \"all_relationships.json\"\n",
-    "prov_file = \"provenance_entities.json\"  # this will only be used if you want to backup provenance records"
+    "prov_file = \"provenance_entities.json\"  # this will only be used if you want to backup provenance records\n",
+    "servicedef = 'service_definition.json'"
    ]
   },
   {
@@ -151,6 +154,35 @@
     "    knowledgegraph_backup.datamodel\n",
     "except:\n",
     "    raise Exception(\"Knowledge graph to backup does not exist\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "423cbfe2",
+   "metadata": {},
+   "source": [
+    "Get the service definition for the knowledge graph service and save it to the service definition file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b24f732f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create a token for request\n",
+    "token_url = f\"https://myportal.com/portal/sharing/rest/generateToken\"\n",
+    "creds = {\n",
+    "    \"username\": \"myUsername\",\n",
+    "    \"password\": \"myPassword\",\n",
+    "    \"referer\": \"https://myportal.com/portal\",\n",
+    "    \"f\": \"json\"\n",
+    "}\n",
+    "token_response = requests.post(token_url, data=creds, verify=False)\n",
+    "sd_data = requests.get(url=kg_url, params={'f': 'json', 'token': token_response.json()['token']}, verify=False)\n",
+    "with open(os.path.join(output_folder, servicedef), 'w') as f:\n",
+    "    json.dump(sd_data.text, f)"
    ]
   },
   {
@@ -365,6 +397,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d4db5b47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# write provenance information to the provenance data model file\n",
+    "prov_structure = knowledgegraph_backup.datamodel['meta_entity_types']['Provenance']\n",
+    "with open(os.path.join(output_folder, dm_prov), 'w') as f:\n",
+    "    json.dump(prov_structure, f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "3e8576d4",
    "metadata": {},
    "outputs": [],
@@ -421,49 +466,9 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "db4a59d8",
-   "metadata": {},
-   "source": [
-    "### Connect to portal and create knowledge graph\n",
-    "Connect to the portal and create a new knowledge graph service to load data model and data into"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd042d14",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# connect to portal via GIS\n",
-    "gis_load = GIS(\n",
-    "    \"https://myportal.com/portal\", \"username\", \"password\"\n",
-    ")\n",
-    "# create a knowledge graph without provenance enabled\n",
-    "result = gis_load.content.create_service(\n",
-    "    name=\"myknowledgegraph\",\n",
-    "    capabilities=\"Query,Editing,Create,Update,Delete\",\n",
-    "    service_type=\"KnowledgeGraph\",\n",
-    ")\n",
-    "# OPTIONAL: switch line above with line below to create knowledge graph WITH provenance enabled\n",
-    "# result = gis_load.content.create_service(name=\"\", service_type=\"KnowledgeGraph\",create_params={\"name\": \"myknowledgegraph\", \"capabilities\": \"Query\", \"jsonProperties\": {\"supportsProvenance\": True}})\n",
-    "knowledgegraph_load = KnowledgeGraph(result.url, gis=gis_load)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "70b11b8a",
-   "metadata": {},
-   "source": [
-    "### Populate data model from saved json files\n",
-    "Populate entity and relationship types from saved json files. This is using the variables defined in the 'Setup' section above."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ad6f6d63",
+   "id": "0b62742e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,10 +476,7 @@
     "with open(os.path.join(output_folder, dm_ent), \"r\") as file:\n",
     "    dm_ents = json.load(file)\n",
     "with open(os.path.join(output_folder, dm_rel), \"r\") as file:\n",
-    "    dm_rels = json.load(file)\n",
-    "knowledgegraph_load.named_object_type_adds(\n",
-    "    entity_types=dm_ents, relationship_types=dm_rels\n",
-    ")"
+    "    dm_rels = json.load(file)"
    ]
   },
   {
@@ -521,6 +523,77 @@
   },
   {
    "cell_type": "markdown",
+   "id": "db4a59d8",
+   "metadata": {},
+   "source": [
+    "### Connect to portal and create knowledge graph\n",
+    "Connect to the portal and create a new knowledge graph service to load data model and data into"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd042d14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# connect to portal via GIS\n",
+    "gis_load = GIS(\n",
+    "    \"https://myportal.com/portal\", \"username\", \"password\"\n",
+    ")\n",
+    "\n",
+    "with open(os.path.join(output_folder, servicedef), 'r') as file:\n",
+    "    service_def = json.load(file)\n",
+    "service_def = json.loads(service_def)\n",
+    "updated_service_def = {\n",
+    "    'name': \"myNewKnowledgeGraph\", #replace with the name for your new knowledge graph\n",
+    "    'capabilities': service_def['capabilities'],\n",
+    "    'jsonProperties': {\n",
+    "        'allowGeometryUpdates': service_def['allowGeometryUpdates'],\n",
+    "        'searchMaxRecordCount': service_def['searchMaxRecordCount'],\n",
+    "        'spatialReference': service_def['spatialReference'],\n",
+    "        'maxRecordCount': service_def['maxRecordCount'],\n",
+    "        'description': service_def['description'],\n",
+    "        'copyrightText': service_def['copyrightText'],\n",
+    "        'documentEntityTypeInfo': {\n",
+    "            \"documentEntityTypeName\": doc_type_name,\n",
+    "            \"hasDocumentsRelationshipTypeName\": doc_rel_type_name\n",
+    "        },\n",
+    "        'supportsDocuments': service_def['supportsDocuments'],\n",
+    "        'supportsSearch': service_def['supportsSearch'],\n",
+    "        'supportsProvenance': service_def['supportsProvenance']\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "result = gis_copyto.content.create_service(name=\"\",service_type=\"KnowledgeGraph\",create_params=updated_service_def)\n",
+    "\n",
+    "knowledgegraph_load = KnowledgeGraph(result.url, gis=gis_load)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70b11b8a",
+   "metadata": {},
+   "source": [
+    "### Populate data model from saved json files\n",
+    "Populate entity and relationship types from saved json files. This is using the variables defined in the 'Setup' section above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad6f6d63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# populate entity and relationship types based on data model (errors about Document/HasDocument in the output are expected)\n",
+    "knowledgegraph_load.named_object_type_adds(\n",
+    "    entity_types=dm_ents, relationship_types=dm_rels\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "fd1eecc7",
    "metadata": {},
    "source": [
@@ -535,7 +608,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# load any additional document entity type properties\n",
+    "# load any additional document entity type properties (errors about properties that already exist are expected)\n",
     "origin_document_properties = None\n",
     "for entity_type in dm_ents:\n",
     "    if entity_type[\"name\"] == doc_type_name:\n",
@@ -544,7 +617,7 @@
     "for prop in origin_document_properties:\n",
     "    prop_list.append(origin_document_properties[prop])\n",
     "knowledgegraph_load.graph_property_adds(\n",
-    "    type_name=\"Document\", graph_properties=prop_list\n",
+    "    type_name=doc_type_name, graph_properties=prop_list\n",
     ")"
    ]
   },
@@ -555,7 +628,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# load any additional document relationship type properties\n",
+    "# load any additional document relationship type properties (errors about properties that already exist are expected)\n",
     "for relationship_type in dm_rels:\n",
     "    if relationship_type[\"name\"] == doc_rel_type_name:\n",
     "        origin_document_rel_properties = relationship_type[\"properties\"]\n",
@@ -563,7 +636,7 @@
     "for prop in origin_document_rel_properties:\n",
     "    prop_list.append(origin_document_rel_properties[prop])\n",
     "knowledgegraph_load.graph_property_adds(\n",
-    "    type_name=\"HasDocument\", graph_properties=prop_list\n",
+    "    type_name=doc_rel_type_name, graph_properties=prop_list\n",
     ")"
    ]
   },
@@ -766,16 +839,16 @@
    "outputs": [],
    "source": [
     "# add search indexes for all relationship text properties\n",
-    "for entity_type in load_dm[\"relationship_types\"]:\n",
+    "for relationship_type in load_dm[\"relationship_types\"]:\n",
     "    prop_list = []\n",
-    "    for prop in load_dm[\"relationship_types\"][entity_type][\"properties\"]:\n",
+    "    for prop in load_dm[\"relationship_types\"][relationship_type][\"properties\"]:\n",
     "        if (\n",
-    "            load_dm[\"relationship_types\"][entity_type][\"properties\"][prop][\"fieldType\"]\n",
+    "            load_dm[\"relationship_types\"][relationship_type][\"properties\"][prop][\"fieldType\"]\n",
     "            == \"esriFieldTypeString\"\n",
     "        ):\n",
     "            prop_list.append(prop)\n",
     "    knowledgegraph_load.update_search_index(\n",
-    "        adds={entity_type: {\"property_names\": prop_list}}\n",
+    "        adds={relationship_type: {\"property_names\": prop_list}}\n",
     "    )"
    ]
   },
@@ -786,6 +859,35 @@
    "source": [
     "## OPTIONAL: Add provenance records to the knowledge graph\n",
     "This will only apply if you created a backup of provenance records and have enabled provenance on your knowledge graph service."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bce8d5b",
+   "metadata": {},
+   "source": [
+    "### Add additional provenance entity type properties\n",
+    "In the case additional properties exist in the original graph on the provenance type, we need to add those properties to the data model using graph_property_adds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3563b59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(os.path.join(file_loc, dm_prov), 'r') as file:\n",
+    "        prov_dm = json.load(file)\n",
+    "\n",
+    "prop_list = []\n",
+    "for prop in prov_dm['properties']:\n",
+    "    prop_list.append(prov_dm['properties'][prop])\n",
+    "knowledgegraph_load.graph_property_adds(\n",
+    "    type_name=\"Provenance\",\n",
+    "    graph_properties=prop_list\n",
+    ")\n",
+    "# errors about already existing properties are expected"
    ]
   },
   {
@@ -838,7 +940,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/samples/05_content_publishers/create_and_load_knowledge_graph_backups.ipynb
+++ b/samples/05_content_publishers/create_and_load_knowledge_graph_backups.ipynb
@@ -117,7 +117,7 @@
     "all_ent = \"all_entities.json\"\n",
     "all_rel = \"all_relationships.json\"\n",
     "prov_file = \"provenance_entities.json\"  # this will only be used if you want to backup provenance records\n",
-    "servicedef = 'service_definition.json'"
+    "servicedef = \"service_definition.json\""
    ]
   },
   {
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "423cbfe2",
+   "id": "da690f5c",
    "metadata": {},
    "source": [
     "Get the service definition for the knowledge graph service and save it to the service definition file"
@@ -167,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b24f732f",
+   "id": "952e670f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,11 +177,15 @@
     "    \"username\": \"myUsername\",\n",
     "    \"password\": \"myPassword\",\n",
     "    \"referer\": \"https://myportal.com/portal\",\n",
-    "    \"f\": \"json\"\n",
+    "    \"f\": \"json\",\n",
     "}\n",
     "token_response = requests.post(token_url, data=creds, verify=False)\n",
-    "sd_data = requests.get(url=kg_url, params={'f': 'json', 'token': token_response.json()['token']}, verify=False)\n",
-    "with open(os.path.join(output_folder, servicedef), 'w') as f:\n",
+    "sd_data = requests.get(\n",
+    "    url=\"https://myportal.com/server/rest/services/Hosted/myknowledgegraph/KnowledgeGraphServer\",\n",
+    "    params={\"f\": \"json\", \"token\": token_response.json()[\"token\"]},\n",
+    "    verify=False,\n",
+    ")\n",
+    "with open(os.path.join(output_folder, servicedef), \"w\") as f:\n",
     "    json.dump(sd_data.text, f)"
    ]
   },
@@ -282,9 +286,7 @@
    "outputs": [],
    "source": [
     "# query for all entities in graph\n",
-    "original_entities = knowledgegraph_backup.query_streaming(\n",
-    "    \"MATCH (n) RETURN distinct n\"\n",
-    ")"
+    "original_entities = knowledgegraph_backup.query_streaming(\"MATCH (n) RETURN distinct n\")"
    ]
   },
   {
@@ -304,9 +306,7 @@
     "        if type(curr_entity[\"_properties\"][prop]) == UUID:\n",
     "            curr_entity[\"_properties\"][prop] = str(curr_entity[\"_properties\"][prop])\n",
     "    # delete objectid, the server will handle creating new ones when we load the backup\n",
-    "    del curr_entity[\"_properties\"][\n",
-    "        \"objectid\"\n",
-    "    ]\n",
+    "    del curr_entity[\"_properties\"][\"objectid\"]\n",
     "    all_entities_fromquery.append(curr_entity)"
    ]
   },
@@ -367,9 +367,7 @@
     "                curr_relationship[\"_properties\"][prop]\n",
     "            )\n",
     "    # delete objectid, the server will handle creating new ones when we load the backup\n",
-    "    del curr_relationship[\"_properties\"][\n",
-    "        \"objectid\"\n",
-    "    ]\n",
+    "    del curr_relationship[\"_properties\"][\"objectid\"]\n",
     "    all_relationships_fromquery.append(curr_relationship)"
    ]
   },
@@ -397,13 +395,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4db5b47",
+   "id": "9f237840",
    "metadata": {},
    "outputs": [],
    "source": [
     "# write provenance information to the provenance data model file\n",
-    "prov_structure = knowledgegraph_backup.datamodel['meta_entity_types']['Provenance']\n",
-    "with open(os.path.join(output_folder, dm_prov), 'w') as f:\n",
+    "prov_structure = knowledgegraph_backup.datamodel[\"meta_entity_types\"][\"Provenance\"]\n",
+    "with open(os.path.join(output_folder, dm_prov), \"w\") as f:\n",
     "    json.dump(prov_structure, f)"
    ]
   },
@@ -439,9 +437,7 @@
     "                curr_provenance[\"_properties\"][prop]\n",
     "            )\n",
     "    # delete objectid, the server will handle creating new ones when we load the backup\n",
-    "    del curr_provenance[\"_properties\"][\n",
-    "        \"objectid\"\n",
-    "    ]\n",
+    "    del curr_provenance[\"_properties\"][\"objectid\"]\n",
     "    all_provenance_fromquery.append(curr_provenance)"
    ]
   },
@@ -468,7 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b62742e",
+   "id": "fa7d1671",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,34 +534,34 @@
    "outputs": [],
    "source": [
     "# connect to portal via GIS\n",
-    "gis_load = GIS(\n",
-    "    \"https://myportal.com/portal\", \"username\", \"password\"\n",
-    ")\n",
+    "gis_load = GIS(\"https://myportal.com/portal\", \"username\", \"password\")\n",
     "\n",
-    "with open(os.path.join(output_folder, servicedef), 'r') as file:\n",
+    "with open(os.path.join(output_folder, servicedef), \"r\") as file:\n",
     "    service_def = json.load(file)\n",
     "service_def = json.loads(service_def)\n",
     "updated_service_def = {\n",
-    "    'name': \"myNewKnowledgeGraph\", #replace with the name for your new knowledge graph\n",
-    "    'capabilities': service_def['capabilities'],\n",
-    "    'jsonProperties': {\n",
-    "        'allowGeometryUpdates': service_def['allowGeometryUpdates'],\n",
-    "        'searchMaxRecordCount': service_def['searchMaxRecordCount'],\n",
-    "        'spatialReference': service_def['spatialReference'],\n",
-    "        'maxRecordCount': service_def['maxRecordCount'],\n",
-    "        'description': service_def['description'],\n",
-    "        'copyrightText': service_def['copyrightText'],\n",
-    "        'documentEntityTypeInfo': {\n",
+    "    \"name\": \"myNewKnowledgeGraph\",  # replace with the name for your new knowledge graph\n",
+    "    \"capabilities\": service_def[\"capabilities\"],\n",
+    "    \"jsonProperties\": {\n",
+    "        \"allowGeometryUpdates\": service_def[\"allowGeometryUpdates\"],\n",
+    "        \"searchMaxRecordCount\": service_def[\"searchMaxRecordCount\"],\n",
+    "        \"spatialReference\": service_def[\"spatialReference\"],\n",
+    "        \"maxRecordCount\": service_def[\"maxRecordCount\"],\n",
+    "        \"description\": service_def[\"description\"],\n",
+    "        \"copyrightText\": service_def[\"copyrightText\"],\n",
+    "        \"documentEntityTypeInfo\": {\n",
     "            \"documentEntityTypeName\": doc_type_name,\n",
-    "            \"hasDocumentsRelationshipTypeName\": doc_rel_type_name\n",
+    "            \"hasDocumentsRelationshipTypeName\": doc_rel_type_name,\n",
     "        },\n",
-    "        'supportsDocuments': service_def['supportsDocuments'],\n",
-    "        'supportsSearch': service_def['supportsSearch'],\n",
-    "        'supportsProvenance': service_def['supportsProvenance']\n",
-    "    }\n",
+    "        \"supportsDocuments\": service_def[\"supportsDocuments\"],\n",
+    "        \"supportsSearch\": service_def[\"supportsSearch\"],\n",
+    "        \"supportsProvenance\": service_def[\"supportsProvenance\"],\n",
+    "    },\n",
     "}\n",
     "\n",
-    "result = gis_copyto.content.create_service(name=\"\",service_type=\"KnowledgeGraph\",create_params=updated_service_def)\n",
+    "result = gis_copyto.content.create_service(\n",
+    "    name=\"\", service_type=\"KnowledgeGraph\", create_params=updated_service_def\n",
+    ")\n",
     "\n",
     "knowledgegraph_load = KnowledgeGraph(result.url, gis=gis_load)"
    ]
@@ -843,7 +839,9 @@
     "    prop_list = []\n",
     "    for prop in load_dm[\"relationship_types\"][relationship_type][\"properties\"]:\n",
     "        if (\n",
-    "            load_dm[\"relationship_types\"][relationship_type][\"properties\"][prop][\"fieldType\"]\n",
+    "            load_dm[\"relationship_types\"][relationship_type][\"properties\"][prop][\n",
+    "                \"fieldType\"\n",
+    "            ]\n",
     "            == \"esriFieldTypeString\"\n",
     "        ):\n",
     "            prop_list.append(prop)\n",
@@ -863,7 +861,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9bce8d5b",
+   "id": "8a6a5ca5",
    "metadata": {},
    "source": [
     "### Add additional provenance entity type properties\n",
@@ -873,19 +871,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e3563b59",
+   "id": "e663e9fd",
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(os.path.join(file_loc, dm_prov), 'r') as file:\n",
-    "        prov_dm = json.load(file)\n",
+    "with open(os.path.join(file_loc, dm_prov), \"r\") as file:\n",
+    "    prov_dm = json.load(file)\n",
     "\n",
     "prop_list = []\n",
-    "for prop in prov_dm['properties']:\n",
-    "    prop_list.append(prov_dm['properties'][prop])\n",
+    "for prop in prov_dm[\"properties\"]:\n",
+    "    prop_list.append(prov_dm[\"properties\"][prop])\n",
     "knowledgegraph_load.graph_property_adds(\n",
-    "    type_name=\"Provenance\",\n",
-    "    graph_properties=prop_list\n",
+    "    type_name=\"Provenance\", graph_properties=prop_list\n",
     ")\n",
     "# errors about already existing properties are expected"
    ]


### PR DESCRIPTION
Updates to the sample notebook to include using information from the service definition and adding extra properties to the provenance type, these updates were requested by users.

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [x] All `import`s are in the first cell? 
    - [x] First block of imports are standard libraries
    - [x] Second block are 3rd party libraries
    - [x] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [x] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [x] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [x] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [x] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [x] Code simplified & split out across multiple cells, useful comments?
- [x] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [x] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [x] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [x] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [x] **If this notebook showcases deep learning capabilities, please go through the following checklist:**
    - [x] Are the inputs required for `Export Training Data Using Deep Learning` tool published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function?
    - [x] Is training data zipped and published as Image Collection? Note: Whole folder is zipped with name same as the notebook name.
    - [x] Are the inputs required for model inferencing published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function? Note: This includes providing test raster and trained model.
    - [x] Are the inferenced results displayed using a webmap widget?
- [x] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @jyaistMap so he can add it to the list for the next deploy.