### PR TITLE
remove pip caches from image

### DIFF
--- a/docker/LambdaBaseImage.Dockerfile
+++ b/docker/LambdaBaseImage.Dockerfile
@@ -13,7 +13,7 @@ RUN yum -y install gcc gcc-c++ krb5-devel krb5-server krb5-libs && yum clean all
 # install arcgis
 ARG arcgis_version="2.3.0"
 # adding .* ensures the latest patch version is installed
-RUN  pip3 install "arcgis==${arcgis_version}.*" --target "${LAMBDA_TASK_ROOT}"
+RUN  pip3 install "arcgis==${arcgis_version}.*" --target "${LAMBDA_TASK_ROOT}" && rm -rf /root/.cache/pip
 # set entrypoint to app.py handler method
 # (note that app.py is missing from this base image)
 CMD [ "app.handler" ]


### PR DESCRIPTION
- slims down Lambda image by removing the pip install cache