### PR TITLE
Add guide removal notices for 2.4 to goeanalytics and authoring dashboard doc

### DIFF
--- a/guide/07-working-with-bigdata/01-introduction.ipynb
+++ b/guide/07-working-with-bigdata/01-introduction.ipynb
@@ -18,6 +18,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **NOTE:** These guides will be removed from the upcoming ArcGIS API for Python 2.4.0 release documentation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## What is Geospatial big data?"
    ]
   },

--- a/guide/13-managing-arcgis-applications/authoring-arcgis-dashboards.ipynb
+++ b/guide/13-managing-arcgis-applications/authoring-arcgis-dashboards.ipynb
@@ -37,6 +37,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **NOTE:** The `arcgis.apps.dashboard` module was officially deprecated with the ArcGIS API for Python 2.0.1 release. The classes in that module are not updated to reflect the current architecture of ArcGIS Dashboards.  This guide will be removed from the documentation for the upcoming ArcGIS API for Python 2.4.0 release."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Introduction"
    ]
   },
@@ -1026,7 +1033,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1040,7 +1047,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.11"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add deprecation notices that guides will be removed at 2.4 for:
* geoanalytics
<img width="1526" alt="image" src="https://github.com/user-attachments/assets/84193ba8-a985-4101-8e41-b19a3aadf901">

* authoring dashboards
<img width="1522" alt="image" src="https://github.com/user-attachments/assets/56face28-2284-4ff4-92b7-8839ba1c6bc7">
