### PR TITLE
updates for coastline extraction imagery sample

### DIFF
--- a/samples/04_gis_analysts_data_scientists/coastline_extraction-usa-landsat8_multispectral_imagery.ipynb
+++ b/samples/04_gis_analysts_data_scientists/coastline_extraction-usa-landsat8_multispectral_imagery.ipynb
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,13 +107,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from arcgis import GIS\n",
     "gis =  GIS('home')\n",
-    "gis2 = GIS(profile=\"your_enterprise_portal\")"
+    "gis2 = GIS(profile=\"your_enterprise_profile\")"
    ]
   },
   {
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -148,9 +148,9 @@
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
        "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=d9b466d6a9e647ce8d1dd5fe12eb434b' target='_blank'><b>Multispectral Landsat</b>\n",
        "                        </a>\n",
-       "                        <br/>Landsat multispectral and multitemporal imagery with on-the-fly renderings and indices for visualization and analysis.  The Landsat 8 and 9 imagery in this layer is updated daily and is directly sourced from the USGS Landsat collection on AWS.<img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/imagery16.png' style=\"vertical-align:middle;\">Imagery Layer by esri\n",
-       "                        <br/>Last Modified: February 25, 2022\n",
-       "                        <br/>3 comments, 682,761 views\n",
+       "                        <br/>Landsat multispectral and multitemporal imagery with on-the-fly renderings and indices for visualization and analysis.  The Landsat 8 and 9 imagery in this layer is updated daily and is directly sourced from the USGS Landsat collection on AWS.<br/><img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/imagery16.png' style=\"vertical-align:middle;\" width=16 height=16>Imagery Layer by esri\n",
+       "                        <br/>Last Modified: July 01, 2022\n",
+       "                        <br/>3 comments, 1336187 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
@@ -159,7 +159,7 @@
        "<Item title:\"Multispectral Landsat\" type:Imagery Layer owner:esri>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -179,10 +179,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "scrolled": false
-   },
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -197,9 +195,9 @@
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
        "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=6ee0006608704d0389881e0bcf936778' target='_blank'><b>usa_coast_polygon</b>\n",
        "                        </a>\n",
-       "                        <br/>usa_coast_polygon<img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\">Feature Layer Collection by api_data_owner\n",
+       "                        <br/>usa_coast_polygon<br/><img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\" width=16 height=16>Feature Layer Collection by api_data_owner\n",
        "                        <br/>Last Modified: January 24, 2022\n",
-       "                        <br/>0 comments, 207 views\n",
+       "                        <br/>0 comments, 737 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
@@ -208,7 +206,7 @@
        "<Item title:\"usa_coast_polygon\" type:Feature Layer Collection owner:api_data_owner>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -234,12 +232,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = gis.map('USA', 4)\n",
-    "m.add_layer(aoi)\n",
+    "m = gis.map('USA')\n",
+    "m.content.add(aoi)\n",
     "m"
    ]
   },
@@ -252,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {
     "scrolled": true
    },
@@ -629,9 +627,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -691,9 +687,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -722,9 +716,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -753,9 +745,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -794,9 +784,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -829,9 +817,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -874,9 +860,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -899,9 +883,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1312,11 +1294,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "m9= gis2.map('USA', 4)\n",
+    "m9= gis2.map('USA')\n",
     "m9"
    ]
   },
@@ -1329,17 +1311,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
-    "m9.add_layer(landsat)\n",
-    "m9.zoom_to_layer(coastline_final)"
+    "m9.center = [29.058093925550384, -89.19558942966272]\n",
+    "m9.zoom = 14"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m9.content.add(landsat)\n",
+    "m9.content.add(coastline_final)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -1348,7 +1340,7 @@
        "True"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1420,7 +1412,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pr contains changes for map widget related codes for sample `coastline-extraction-usa-landsat8-multispectral-imagery`:

- protected the final result of extracted coastline web map in geosaurus online
- update code for creating map, add layers, center, and zoom level
- map screenshots didn't change as the sample data input didn't change
- note: I was able to run and get the same result for the first and second map (usa coast polygon, landsat) and the following raster analysis layers, but I haven't get the second map (extracted coastline) as `save` function failed with error `the allowed maximum number of rows and columns is 4000 and 4000 respectively`. Will investigate the error and make any change if needed.
- maps shows correctly on locally built developer website