### PR TITLE
update markdown syntax for nav headings and updated sentence to correct number

### DIFF
--- a/guide/14-deep-learning/how-named-entity-recognition-works.ipynb
+++ b/guide/14-deep-learning/how-named-entity-recognition-works.ipynb
@@ -52,9 +52,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Introduction\n",
+    "## Introduction\n",
     "\n",
-    "Geospatial data is not only available in the form of maps and feature/imagery layers, but also in form of unstructured text.\n"
+    "Geospatial data is not only available in the form of maps and feature/imagery layers, but also in form of unstructured text."
    ]
   },
   {
@@ -85,7 +85,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Prerequisites\n",
+    "## Prerequisites\n",
     "\n",
     "- **Data preparation** and **model training workflows** for entity extraction using `arcgis.learn` is based on [spaCy](https://spacy.io/usage/linguistic-features#named-entities) & [Hugging Face Transformers](https://huggingface.co/transformers/v3.0.2/index.html) libraries. A user can choose an appropriate backbone to train the model. \n",
     "- Refer to the section [Install deep learning dependencies of arcgis.learn module](https://developers.arcgis.com/python/guide/install-and-set-up/#Install-deep-learning-dependencies) for detailed explanation about deep learning dependencies.\n",
@@ -98,7 +98,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# EntityRecognizer Model Basics\n",
+    "## EntityRecognizer Model Basics\n",
     "\n",
     "`EntityRecognizer` model in `arcgis.learn` can be created with either [Hugging Face Transformers](https://huggingface.co/transformers/v3.0.2/index.html) or with [spaCy's](https://spacy.io/) [EntityRecognizer](https://spacy.io/api/entityrecognizer) architecture."
    ]
@@ -201,9 +201,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Data preparation\n",
+    "## Data preparation\n",
     "\n",
-    "- **Entity Recognizer** can consume labeled training data in three different formats (csv, [ner_json](https://spacy.io/api/annotation#json-input), [IOB](https://spacy.io/api/annotation#iob) & [BILUO](https://spacy.io/api/annotation#biluo)).\n",
+    "- **Entity Recognizer** can consume labeled training data in four different formats (csv, [ner_json](https://spacy.io/api/annotation#json-input), [IOB](https://spacy.io/api/annotation#iob) & [BILUO](https://spacy.io/api/annotation#biluo)).\n",
     "- Example structure for **csv** format:\n",
     "    - Columns:\n",
     "        - The CSV should include a `text` column.\n",
@@ -474,7 +474,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# EntityRecognizer model\n",
+    "## EntityRecognizer model\n",
     "\n",
     "`EntityRecognizer` model in `arcgis.learn` can be used with [spaCy's](https://spacy.io/) [EntityRecognizer](https://spacy.io/api/entityrecognizer) backbone or with [Hugging Face Transformers](https://huggingface.co/transformers/v3.0.2/index.html) backbones. The model training and inferencing workflow is similar to computer vision models in `arcgis.learn`.\n",
     "\n",
@@ -1323,7 +1323,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#  Visualize entities\n",
+    "##  Visualize entities\n",
     "\n",
     "We can utilize SpaCy's named entity visualizer to check the model's prediction on new text one at a time."
    ]
@@ -1443,7 +1443,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# References"
+    "## References"
    ]
   },
   {
@@ -1482,7 +1482,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* updated markdown headings to `##` so they appear in right-hand nav
![image](https://github.com/user-attachments/assets/9d0eab4a-7ae9-42fc-ad20-3b1384f88f7d)

* corrected sentence
![image](https://github.com/user-attachments/assets/7fff4044-0d91-47d3-bfe5-c80c2db93d25)
