### PR TITLE
update notebook image for v2.4.0

### DIFF
--- a/docker/NotebookImage.Dockerfile
+++ b/docker/NotebookImage.Dockerfile
@@ -37,6 +37,9 @@ RUN mkdir /home/${NB_USER}/$githubfolder && \
            work/ \
            talks/ \
            environment.yml\
+    # remove .DS_Store and __MACOSX from home directory:
+    && find /home/${NB_USER} -name ".DS_Store" -delete \
+    && rm -rf /home/${NB_USER}/__MACOSX \
     && fix-permissions /home/${NB_USER}
 
 # See https://jupyter-docker-stacks.readthedocs.io/en/latest/using/recipes.html#add-a-custom-conda-environment-and-jupyter-kernel

--- a/docker/NotebookImage.Dockerfile
+++ b/docker/NotebookImage.Dockerfile
@@ -1,29 +1,30 @@
 ARG python_version="3.11"
-FROM quay.io/jupyter/base-notebook:python-${python_version}
+FROM quay.io/jupyter/minimal-notebook:python-${python_version}
 
 ARG python_version
-ARG arcgis_version="2.3.1"
+ARG arcgis_version="2.4.0"
 ARG sampleslink="https://github.com/Esri/arcgis-python-api/releases/download/v${arcgis_version}/samples.zip"
 ARG githubfolder="arcgis-python-api"
-ENV DOCKER_STACKS_JUPYTER_CMD="notebook"
+ARG env_name=arcgis
 
 LABEL org.opencontainers.image.authors="jroebuck@esri.com"
-LABEL org.opencontainers.image.description="Jupyter Notebook with the latest version of the ArcGIS API for Python and its Linux dependencies preinstalled"
+LABEL org.opencontainers.image.description="Jupyter environment preconfigured for ArcGIS API for Python"
 LABEL org.opencontainers.image.licenses=Apache
 LABEL org.opencontainers.image.source=https://github.com/Esri/arcgis-python-api
-
-USER root
-
-RUN apt-get update --yes && \
-    apt-get install --yes --no-install-recommends unzip && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 USER ${NB_UID}
 
 # Install Python API from Conda
-RUN conda install -c esri arcgis=${arcgis_version} -y \
+RUN conda create -n ${env_name} -c esri -c defaults arcgis=${arcgis_version} python=${python_version} -y --quiet --override-channels \
     && conda clean --all -f -y \
     && find /opt/conda -name __pycache__ -type d -exec rm -rf {} +
+
+# Install arcgis-mapping if arcgis_version >= 2.4.0
+RUN (dpkg --compare-versions $arcgis_version ge 2.4.0 \
+    && conda install -n ${env_name} -c esri -c defaults arcgis-mapping -y --quiet --override-channels \
+    && conda clean --all -f -y \
+    && find /opt/conda -name __pycache__ -type d -exec rm -rf {} +;) \
+    || echo "[INFO] Skipped installing arcgis-mapping for version $arcgis_version (>= 2.4.0 required for arcgis-mapping)"
 
 # Fetch and extract samples from GitHub
 RUN mkdir /home/${NB_USER}/$githubfolder && \
@@ -38,5 +39,29 @@ RUN mkdir /home/${NB_USER}/$githubfolder && \
            environment.yml\
     && fix-permissions /home/${NB_USER}
 
-RUN rm /opt/conda/lib/python${python_version}/site-packages/notebook/static/base/images/logo.png
-COPY --chown=${NB_USER}:users jupyter_esri_logo.png /opt/conda/lib/python${python_version}/site-packages/notebook/static/base/images/logo.png
+# See https://jupyter-docker-stacks.readthedocs.io/en/latest/using/recipes.html#add-a-custom-conda-environment-and-jupyter-kernel
+# Create Python kernel and link it to jupyter
+RUN "${CONDA_DIR}/envs/${env_name}/bin/python" -m ipykernel install --user --name="${env_name}" && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+
+# More information here: https://github.com/jupyter/docker-stacks/pull/2047
+USER root
+
+# Set DOCKER_STACKS_JUPYTER_CMD to "notebook" for versions less than 2.4.0
+RUN \
+    (dpkg --compare-versions $arcgis_version lt 2.4.0 \
+    && echo 'DOCKER_STACKS_JUPYTER_CMD="notebook"' >> /etc/environment \
+    && echo "[INFO] Set DOCKER_STACKS_JUPYTER_CMD to notebook for arcgis < 2.4.0") \
+    || echo "[INFO] Using default DOCKER_STACKS_JUPYTER_CMD (lab) for arcgis >= 2.4.0"
+
+RUN \
+    # This changes a startup hook, which will activate the custom environment for the process
+    echo conda activate "${env_name}" >> /usr/local/bin/before-notebook.d/10activate-conda-env.sh && \
+    # This makes the custom environment default in Jupyter Terminals for all users which might be created later
+    echo conda activate "${env_name}" >> /etc/skel/.bashrc && \
+    # This makes the custom environment default in Jupyter Terminals for already existing NB_USER
+    echo conda activate "${env_name}" >> "/home/${NB_USER}/.bashrc"
+
+USER ${NB_UID}


### PR DESCRIPTION
Updates notebook image for v2.4.0 (and a fix we'll redeploy to v2.3.x)
- Creates new conda environment to remove dependency on `conda-forge`
- use `minimal` base image for more builtin tooling (removes step to install `unzip`)
- set default version to 2.4.0
- pivot notebooks vs lab on the 2.4.0 release to allow new builds of previous versions
- set default environment to "arcgis"