### PR TITLE
sample notebook `visualize_monthly_changes_in_hirakund_reservoir_using_video.ipynb` updated according to map widget 2.4.0

### DIFF
--- a/samples/04_gis_analysts_data_scientists/visualize_monthly_changes_in_hirakund_reservoir_using_video.ipynb
+++ b/samples/04_gis_analysts_data_scientists/visualize_monthly_changes_in_hirakund_reservoir_using_video.ipynb
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -148,9 +148,9 @@
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
        "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=d9b466d6a9e647ce8d1dd5fe12eb434b' target='_blank'><b>Multispectral Landsat</b>\n",
        "                        </a>\n",
-       "                        <br/>Landsat multispectral and multitemporal imagery with on-the-fly renderings and indices for visualization and analysis.  The Landsat 8 and 9 imagery in this layer is updated daily and is directly sourced from the USGS Landsat collection on AWS.<img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/imagery16.png' style=\"vertical-align:middle;\" width=16 height=16>Imagery Layer by esri\n",
+       "                        <br/>Landsat multispectral and multitemporal imagery with on-the-fly renderings and indices for visualization and analysis.  The Landsat 8 and 9 imagery in this layer is updated daily and is directly sourced from the USGS Landsat collection on AWS.<br/><img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/imagery16.png' style=\"vertical-align:middle;\" width=16 height=16>Imagery Layer by esri\n",
        "                        <br/>Last Modified: June 30, 2022\n",
-       "                        <br/>3 comments, 1,129,252 views\n",
+       "                        <br/>3 comments, 1371075 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
@@ -159,7 +159,7 @@
        "<Item title:\"Multispectral Landsat\" type:Imagery Layer owner:esri>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -179,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +203,7 @@
    "outputs": [],
    "source": [
     "m = gis.map('Hirakund reservoir, Odisha, India')\n",
-    "m.basemap = 'satellite'\n",
+    "m.basemap.basemap = 'satellite'\n",
     "m"
    ]
   },
@@ -230,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -311,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -332,17 +332,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Movie Created\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "create_movie(rgb_collection,'m' ,'2019-01-01','2019-12-31', 1250, 450, extent, 0.4)          # calling create_movie function"
    ]
@@ -396,9 +388,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
the sample notebook  `visualize_monthly_changes_in_hirakund_reservoir_using_video.ipynb` is now updated to incorporate the new map widget and arcgis 2.4.1:

One major change includes replacing   `ImageDraw.content.draw(img)` to `ImageDraw.Draw(img)`