### PR TITLE
Added navigation headings and updated specific values in item_properties dict

### DIFF
--- a/samples/05_content_publishers/publishing_sd_shapefiles_and_csv.ipynb
+++ b/samples/05_content_publishers/publishing_sd_shapefiles_and_csv.ipynb
@@ -260,6 +260,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we'll connect to an ArcGIS Enterprise deployment and publish a service definition file and illustrate the updating of item properties published from them:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -270,28 +277,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Setting `verify_cert` to False is a security risk, use at your own risk.\n"
-     ]
-    }
-   ],
-   "source": [
-    "p_gis = GIS(profile=\"my_own_portal\", verify_cert=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
     "sd_file = \"data/publishing_sd_shapefiles_and_csv/Nursing_home_locations.sd\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's add the service definition file item:"
    ]
   },
   {
@@ -319,59 +316,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['.sd', 'ArcGIS', 'Metadata', 'Service Definition', 'Online']"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "uploaded_file.typeKeywords"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll update some of the item properties for the service definition file."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['ArcGIS',\n",
-       " 'ArcGIS Server',\n",
-       " 'Data',\n",
-       " 'Feature Access',\n",
-       " 'Feature Service',\n",
-       " 'Metadata',\n",
-       " 'providerSDS',\n",
-       " 'Service',\n",
-       " 'Hosted Service']"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "i = p_gis.content.get(\"0affa060f64f49a88d4742f1b6d328cb\")\n",
-    "i.typeKeywords"
+    "We'll update some of the item properties for the service definition file by defining a dictionary and inputting it the [Item.update()](/python/api-reference/arcgis.gis.toc.html#arcgis.gis.Item.update) method."
    ]
   },
   {
@@ -437,6 +385,7 @@
     }
    ],
    "source": [
+    "# Publish the service from the service definition item\n",
     "item = uploaded_file.publish()\n",
     "item.tags"
    ]

--- a/samples/05_content_publishers/publishing_sd_shapefiles_and_csv.ipynb
+++ b/samples/05_content_publishers/publishing_sd_shapefiles_and_csv.ipynb
@@ -24,14 +24,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import Libraries"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
     "from IPython.display import display\n",
     "from arcgis.gis import GIS\n",
-    "import os\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connect to GIS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "gis = GIS('Home')"
    ]
   },
@@ -39,7 +61,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In order to have the codes below run smoothly, use the pre-requisite cells as in cell[2] to delete existing .zip, .sd, or services from the `gis` content, and in cell [3] to delete existing folder."
+    "## Remove existing content\n",
+    "\n",
+    "For this illustration, in order to have the code and data operations below run smoothly, we'll use the cells below to delete existing .zip, .sd, or services from the `gis` content and delete the existing folder that could cause conflict during publishing."
    ]
   },
   {
@@ -114,7 +138,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# Publish all the service definition files in a folder\n",
+    "## Publish all the service definition files in a folder\n",
     "\n",
     "The sample below lists all the service definition (.sd) files in a data directory and publishes them as web layers. To publish a service definition file, we first add the .sd file to the Portal, and then call the publish() method:"
    ]
@@ -208,9 +232,14 @@
     "root_folder = gis.content.folders.get()\n",
     "# Loop through each file and publish it as a service\n",
     "for current_sd_file in sd_file_list:\n",
-    "    item = root_folder.add({\"title\": \"New Layer\", \"type\": \"Service Definition\"}, data_dir + current_sd_file).result()   # .sd file is uploaded and a .sd file item is created\n",
+    "    item = root_folder.add(\n",
+    "        item_properties={\n",
+    "            \"title\": \"New Layer\", \n",
+    "            \"type\": \"Service Definition\"\n",
+    "        }, \n",
+    "        file=data_dir + current_sd_file).result()   # .sd file is uploaded and a .sd file item is created\n",
     "    if \"BuildCache\" not in current_sd_file:\n",
-    "        published_item = item.publish()                      # .sd file item is published and a web layer item is created\n",
+    "        published_item = item.publish()   # .sd file item is published and a web layer item is created\n",
     "    else:\n",
     "        published_item = item.publish(build_initial_cache=True)  # publish as hosted tile layer with \"build cache\" enabled\n",
     "    display(published_item)"
@@ -227,7 +256,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **Note**: When publishing an SD file to Enterprise with customized `publish_parameters`, as specified in [REST API](https://developers.arcgis.com/rest/users-groups-and-items/publish-item.htm), the customization of item properties, such as title, snippets, tags, and description, will not be reflected in the properties of online SD file, or the published service. Instead, the SD file item, and the service item will pertain the local SD file's original settings. A recommended workflow is to use `update()` method after uploading the SD file, and publishing the service."
+    "> **Note**: When publishing an SD file to Enterprise with customized `publish_parameters`, as specified in [REST API](https://developers.arcgis.com/rest/users-groups-and-items/publish-item.htm), the customization of item properties, such as title, snippets, tags, and description, will not be reflected in the properties of online SD file, or the published service. Instead, the SD file item, and the service item will contain the local SD file's original settings. A recommended workflow is to use `update()` method after uploading the SD file, and publishing the service."
    ]
   },
   {
@@ -241,26 +270,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Setting `verify_cert` to False is a security risk, use at your own risk.\n"
+     ]
+    }
+   ],
    "source": [
-    "sd_file = \"data/publishing_sd_shapefiles_and_csv/Nursing_home_locations.sd\"\n",
-    "\n",
-    "item_properties = {\n",
-    "    \"title\": \"Nursing Home Locations from SD file\",\n",
-    "    \"tags\" : \"test 1st, test 2nd, test 2023\",\n",
-    "    \"snippet\": \"test snippet 123456\",\n",
-    "    \"description\": \"test description\",\n",
-    "    \"type\": \"Feature Collection\",\n",
-    "    \"typeKeywords\": \"Data, Feature Collection, Singlelayer\", \n",
-    "    'access': 'org'\n",
-    "}"
+    "p_gis = GIS(profile=\"my_own_portal\", verify_cert=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sd_file = \"data/publishing_sd_shapefiles_and_csv/Nursing_home_locations.sd\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -269,29 +305,112 @@
        "['opendata', 'health', 'automation', 'ArcGIS', 'Service Definition', '.sd']"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "proot_folder = p_gis.content.folders.get()\n",
-    "uploaded_file = proot_folder.add({\"title\": \"Nursing Home Location\", \"type\": \"Service Definition\"}, file=sd_file).result()\n",
+    "uploaded_file = proot_folder.add({\n",
+    "    \"title\": \"Nursing Home Location\", \n",
+    "    \"type\": \"Service Definition\"}, file=sd_file).result()\n",
     "uploaded_file.tags"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['test 1st', 'test 2nd', 'test 2023']"
+       "['.sd', 'ArcGIS', 'Metadata', 'Service Definition', 'Online']"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "uploaded_file.typeKeywords"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll update some of the item properties for the service definition file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['ArcGIS',\n",
+       " 'ArcGIS Server',\n",
+       " 'Data',\n",
+       " 'Feature Access',\n",
+       " 'Feature Service',\n",
+       " 'Metadata',\n",
+       " 'providerSDS',\n",
+       " 'Service',\n",
+       " 'Hosted Service']"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "i = p_gis.content.get(\"0affa060f64f49a88d4742f1b6d328cb\")\n",
+    "i.typeKeywords"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "item_properties = {\n",
+    "    \"title\": \"Nursing Home Locations from SD file\",\n",
+    "    \"tags\" : uploaded_file.tags + [\"test 1st\", \"test 2nd\", \"test 2023\"],\n",
+    "    \"snippet\": \"Nursing homes in Washington state added in API\",\n",
+    "    \"description\": \"Locations of nursing homes in US state of Washington\",\n",
+    "    \"type\": \"Feature Service\",\n",
+    "    \"typeKeywords\": \"Data, Feature Service, Hosted Service, Service, Singlelayer\", \n",
+    "    'access': 'org'\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['opendata',\n",
+       " 'health',\n",
+       " 'automation',\n",
+       " 'ArcGIS',\n",
+       " 'Service Definition',\n",
+       " '.sd',\n",
+       " 'test 1st',\n",
+       " 'test 2nd',\n",
+       " 'test 2023']"
+      ]
+     },
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -303,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -312,7 +431,7 @@
        "['opendata', 'health', 'automation', 'ArcGIS', 'Service Definition', '.sd']"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -324,16 +443,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['test 1st', 'test 2nd', 'test 2023']"
+       "['opendata',\n",
+       " 'health',\n",
+       " 'automation',\n",
+       " 'ArcGIS',\n",
+       " 'Service Definition',\n",
+       " '.sd',\n",
+       " 'test 1st',\n",
+       " 'test 2nd',\n",
+       " 'test 2023']"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -352,16 +479,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Recycle bin not enabled on this organization. Permanent delete parameter ignored.\n",
+      "Recycle bin not enabled on this organization. Permanent delete parameter ignored.\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "True"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -375,7 +510,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Publish a feature service from a shapefile and update the item information\n",
+    "## Publish a feature service from a shapefile and update the item information\n",
     "\n",
     "To publish a shapefile, we first add the zipped shapefile to the Portal as an item, then call publish() method on the item to create a web layer. Often times, your shape files or service definitions may not contain the metadata you want to show on the portal item. This sample demonstrates how you can update those properties after publishing a web layer."
    ]
@@ -544,7 +679,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Publish a CSV file and move it into a folder\n",
+    "## Publish a CSV file and move it into a folder\n",
     "\n",
     "To publish a CSV file, we first add the .csv file to the Portal, and then call the publish() method to publish it as a layer. Once published, we create a destination folder on the server and then move the published items into that folder"
    ]
@@ -759,7 +894,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.10"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
.Hi @nanaeaubry - submitting PR to suggest a couple things:

*  add right-hand nav by changing single # markdown headings to double and adding some new ones
![image](https://github.com/user-attachments/assets/1c2d5e5d-11e1-4edd-a565-c40bdae0e51a)

* change where the  _item_properties_ is defined
* updated some specific _item_properties_ to reflect the sd file (change _Feature Collection_ to _Feature Service_, and kept original tags and added to them
  * the sample seems to be illustrating that you have to update the properties when publishing from and _sd_ file, so I tried to get them to match with what's in the _sd_ file better - does that make sense? 