### PR TITLE
merged the dashboards and storymaps sections at the bottom of the guide

### DIFF
--- a/guide/03-the-gis/cloning-content.ipynb
+++ b/guide/03-the-gis/cloning-content.ipynb
@@ -1388,28 +1388,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### ArcGIS Dashboards"
+    "### ArcGIS Dashboards and ArcGIS StoryMaps"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See the [Cloning and Troubleshooting Complex Items](../cloning-complex-apps#dashboards-and-editing-item-data) guide for details on cloning ArcGIS Dashboards. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Story Maps"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "See the [Cloning and Troubleshooting Complex Items](../cloning-complex-apps/#storymaps-web-scenes-and-item-remapping) guide for details on cloning ArcGIS StoryMaps. "
+    "See the [Cloning and Troubleshooting Complex Items](../cloning-complex-apps#dashboards-and-editing-item-data) guide for details on cloning ArcGIS Dashboards and ArcGIS StoryMaps. "
    ]
   },
   {
@@ -1438,7 +1424,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.11.10"
   },
   "toc": {
    "base_numbering": 1,
@@ -1455,5 +1441,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
The section at the end of the notebook for ArcGIS StoryMaps has a broken link. @nparavicini7 confirmed that the links for Dashboards and Storymaps are supposed to be the same, so I merged the two sections together.


-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **If this notebook showcases deep learning capabilities, please go through the following checklist:**
    - [ ] Are the inputs required for `Export Training Data Using Deep Learning` tool published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function?
    - [ ] Is training data zipped and published as Image Collection? Note: Whole folder is zipped with name same as the notebook name.
    - [ ] Are the inputs required for model inferencing published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function? Note: This includes providing test raster and trained model.
    - [ ] Are the inferenced results displayed using a webmap widget?
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @jyaistMap so he can add it to the list for the next deploy.