### PR TITLE
remove previous output and reformat add code

### DIFF
--- a/samples/05_content_publishers/publishing_packages_as_web_layers.ipynb
+++ b/samples/05_content_publishers/publishing_packages_as_web_layers.ipynb
@@ -64,13 +64,6 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "{'id': 'e5d78c5d26814691bcf539ba334dce72',\n",
-       " 'title': 'packages',\n",
-       " 'username': 'arcgis_python'}"
-      ]
-     },
      "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
@@ -116,7 +109,13 @@
     }
    ],
    "source": [
-    "tpk_item = folder.add({\"title\": \"USA_counties_divorce_rate\", \"type\": \"Tile Package\"}, file='data/USA_counties_divorce_rate.tpk').result()\n",
+    "tpk_item = folder.add(\n",
+    "    item_properties = {\n",
+    "        \"title\": \"USA_counties_divorce_rate\", \n",
+    "        \"type\": \"Tile Package\"\n",
+    "    }, \n",
+    "    file='data/USA_counties_divorce_rate.tpk'\n",
+    ").result()\n",
     "tpk_item"
    ]
   },
@@ -213,7 +212,13 @@
    ],
    "source": [
     "# upload vector tile package to the portal\n",
-    "vtpk_item = folder.add({\"title\": \"World_earthquakes_2010\", \"type\": \"Vector Tile Package\"}, file='data/World_earthquakes_2010.vtpk').result()\n",
+    "vtpk_item = folder.add(\n",
+    "    item_properties={\n",
+    "        \"title\": \"World_earthquakes_2010\", \n",
+    "        \"type\": \"Vector Tile Package\"\n",
+    "    }, \n",
+    "    file='data/World_earthquakes_2010.vtpk'\n",
+    ").result()\n",
     "vtpk_item"
    ]
   },
@@ -321,7 +326,12 @@
     }
    ],
    "source": [
-    "slpk_item = folder.add({\"title\": \"World_earthquakes_2010\", \"type\": \"Scene Package\"}, file='data/World_earthquakes_2000_2010.slpk').result()\n",
+    "slpk_item = folder.add({\n",
+    "    \"title\": \"World_earthquakes_2010\", \n",
+    "    \"type\": \"Scene Package\"\n",
+    "    }, \n",
+    "    file='data/World_earthquakes_2000_2010.slpk'\n",
+    ").result()\n",
     "slpk_item"
    ]
   },
@@ -386,7 +396,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.10"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Hi @nanaeaubry 
* the code to add a folder was showing a dictionary as ouput, which does not occur with 2.4. There is no output when assigning to a variable so I removed that code. I also reformatted the code so you don't have to scroll to see the entire line:

![image](https://github.com/user-attachments/assets/dabf912a-263b-4401-8567-794763597124)

