### PR TITLE
remove map widget output and add layers before zooming to them

### DIFF
--- a/samples/04_gis_analysts_data_scientists/which_areas_are_good_cougar_habitat.ipynb
+++ b/samples/04_gis_analysts_data_scientists/which_areas_are_good_cougar_habitat.ipynb
@@ -265,9 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "m1 = gis.map('oregon')\n",
@@ -382,48 +380,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ab5623576bb841dab4e73c4cc286581d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "MapView(layout=Layout(height='400px', width='100%'))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"map-static-img-preview-c07ea64f-45b8-4af7-b221-92c88131d277\"><img src=\"\"></img></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"map-html-embed-preview-c07ea64f-45b8-4af7-b221-92c88131d277\"></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "m2 = gis.map('oregon')\n",
     "m2.basemap.basemap = 'gray-vector'\n",
@@ -444,8 +403,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m2.zoom_to_layer(buffer_park.layers[0])\n",
-    "m2.content.add(buffer_park.layers[0])"
+    "m2.content.add(buffer_park.layers[0])\n",
+    "m2.zoom_to_layer(buffer_park.layers[0])"
    ]
   },
   {
@@ -544,9 +503,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "m3 = gis.map('oregon')\n",
@@ -568,8 +525,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m3.zoom_to_layer(state_area_boundary.layers[0])\n",
-    "m3.content.add(state_area_boundary.layers[0])"
+    "m3.content.add(state_area_boundary.layers[0])\n",
+    "m3.zoom_to_layer(state_area_boundary.layers[0])"
    ]
   },
   {
@@ -709,48 +666,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7947391c8446406c806e03ebb063dcdf",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "MapView(layout=Layout(height='400px', width='100%'))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"map-static-img-preview-8adb4aaa-5113-437e-8618-642d2b43b10d\"><img src=\"\"></img></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"map-html-embed-preview-8adb4aaa-5113-437e-8618-642d2b43b10d\"></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "m4 = gis.map('oregon')\n",
     "m4.basemap.basemap = 'gray-vector'\n",
@@ -770,9 +688,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m4.zoom_to_layer(clipped_highway_lyr)\n",
     "m4.content.add(state_area_boundary)\n",
-    "m4.content.add(clipped_highway_lyr)"
+    "m4.content.add(clipped_highway_lyr)\n",
+    "m4.zoom_to_layer(clipped_highway_lyr)"
    ]
   },
   {
@@ -876,48 +794,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "04b4c981fb1344ff96a6876c0cf2653f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "MapView(layout=Layout(height='400px', width='100%'))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"map-static-img-preview-58a1e602-af97-418d-96e9-68443b14e4e2\"><img src=\"\"></img></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"map-html-embed-preview-58a1e602-af97-418d-96e9-68443b14e4e2\"></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "m5 = gis.map('oregon')\n",
     "m5.basemap.basemap = 'gray-vector'\n",
@@ -938,8 +817,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m5.zoom_to_layer(potential_cougar_habitat_A.layers[0])\n",
-    "m5.content.add(potential_cougar_habitat_A)"
+    "m5.content.add(potential_cougar_habitat_A)\n",
+    "m5.zoom_to_layer(potential_cougar_habitat_A.layers[0])"
    ]
   },
   {
@@ -1000,48 +879,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8491e423247f49b9ab6e0c5cf9b9d98e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "MapView(layout=Layout(height='400px', width='100%'))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"map-static-img-preview-87b5446a-dec6-4d5f-b0a6-7c8e02458db6\"><img src=\"\"></img></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"map-html-embed-preview-87b5446a-dec6-4d5f-b0a6-7c8e02458db6\"></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "m6 = gis.map('oregon')\n",
     "m6.basemap.basemap = 'gray-vector'\n",
@@ -1062,8 +902,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m6.zoom_to_layer(potential_cougar_habitat_B.layers[0])\n",
-    "m6.content.add(potential_cougar_habitat_B)"
+    "m6.content.add(potential_cougar_habitat_B)\n",
+    "m6.zoom_to_layer(potential_cougar_habitat_B.layers[0])"
    ]
   },
   {
@@ -1081,13 +921,6 @@
     "\n",
     "Thus, scientists from DFW and the national forest decide to work together to field check the results, looking for evidence of cougars inside, as well as outside, the potential habitat areas. "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -1110,9 +943,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.11"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
* in a number of places, the map widget output still appeared, so I removed it from those places:

|**Before**|**After**|
|---|---|
![snow_before](https://github.com/user-attachments/assets/3c6cb735-86c4-4897-ae1a-8625926edadd)|![image](https://github.com/user-attachments/assets/a8feb4fd-897f-4450-8558-b663aae6c806)|

* I also changed the order of _zoom_to_layer()_ and _add()_
  * logically it really confused me to zoom to a layer before it was added to the map. It seems to work - do you think it makes more sense to show adding the layer then zooming to it? 