### PR TITLE
match variable names in the "Editing Features" guide

### DIFF
--- a/guide/04-feature-data-and-analysis/editing-features.ipynb
+++ b/guide/04-feature-data-and-analysis/editing-features.ipynb
@@ -98,8 +98,8 @@
    ],
    "source": [
     "# access the item's feature layers\n",
-    "ports_layer = portal_item.layers[0]\n",
-    "ports_layer"
+    "ports_flayer = portal_item.layers[0]\n",
+    "ports_flayer"
    ]
   },
   {
@@ -118,7 +118,7 @@
    "source": [
     "# query all the features and display it on a map\n",
     "# an empty query string will return all features or the first 1000, whichever is smaller\n",
-    "ports_fset = ports_layer.query()"
+    "ports_fset = ports_flayer.query()"
    ]
   },
   {
@@ -658,7 +658,7 @@
     }
    ],
    "source": [
-    "ports_layer.properties.capabilities"
+    "ports_flayer.properties.capabilities"
    ]
   },
   {


### PR DESCRIPTION
In the first two sections of the guide, a `ports_layer` variable is created and used as the FeatureLayer within the input item.

In the "Editing features" section, the notebook starts referring to and using the same variable as `ports_flayer`. 

This PR updates the variable names to `ports_flayer` so that they are consistent across the notebook.