### PR TITLE
add gdal and pyshp as optional dependencies, update pip

### DIFF
--- a/guide/01-getting-started/system-requirements.ipynb
+++ b/guide/01-getting-started/system-requirements.ipynb
@@ -22,7 +22,7 @@
    "metadata": {},
    "source": [
     "## Operating System \n",
-    "The ArcGIS API for Python 2.4.0 release is compatible with 64-bit versions of Windows, macOS (M-Series and Intel), and Linux.\n",
+    "The ArcGIS API for Python (2.4.0 and greater releases) is compatible with 64-bit versions of Windows, macOS (M-Series and Intel), and Linux.\n",
     "\n",
     "## Python Version\n",
     "Python 3.10.x to 3.12.x is required to use the ArcGIS API for Python 2.3.1 and greater releases.\n",
@@ -30,11 +30,11 @@
     "## Dependencies\n",
     "The full power of the ArcGIS API for Python is best experienced when all its dependencies are installed. However, specific tasks such as GIS administration and content management can be accomplished with a subset of dependencies installed. See [Install with minimum Dependencies](../install-and-set-up#install-with-minimum-dependencies) to install the `arcgis` package in this manner.\n",
     "\n",
-    "It is recommended to install the `arcgis` package the default way of either `conda install -c esri arcgis arcgis-mapping` or `pipenv install arcgis arcgis-mapping`. When version 2.4.0 is installed in this manner, all the below dependencies are automatically installed. \n",
+    "It is recommended to install the `arcgis` package the default way of either `conda install -c esri arcgis arcgis-mapping` or `pip install arcgis arcgis-mapping`. When installed in this manner, all the below dependencies are automatically installed.\n",
     "\n",
     "> __Note__ Most of these packages have dependencies of their own. For a full list of packages installed:\n",
     "  > * conda environment, type `conda list -n <environment_name>`.  \n",
-    "  > * pipenv virtual environment: See [`Pipfile` and `Pipfile.lock`](https://pipenv.pypa.io/en/latest/pipfile/) for details.\n",
+    "  > * pip environment, type `pip list`.\n",
     "    \n",
     "\n",
     "* [anywidget](https://anaconda.org/Esri/anywidget)\n",
@@ -75,12 +75,18 @@
     "\n",
     "> Note: The dependencies above result from installing using `conda`. Versions may vary if `arcgis` is installed using `pip`.\n",
     "\n",
-    "> Note: if `arcpy` is found in the current python environment, it may be used in various locations. Otherwise, `pyshp` will be used. See [Spatially Enabled DataFrame](https://developers.arcgis.com/python/api-reference/arcgis.features.toc.html?highlight=geoaccessor#arcgis.features.GeoAccessor) for more information.\n",
+    "> Note: if `arcpy` is found in the current python environment, it may be used in various locations. Otherwise, `gdal` or `pyshp` will be used. See [Spatially Enabled DataFrame](https://developers.arcgis.com/python/api-reference/arcgis.features.toc.html?highlight=geoaccessor#arcgis.features.GeoAccessor) for more information.\n",
     "\n",
     "\n",
     "### Optional Dependencies\n",
     "\n",
-    "There are some other python packages that may be required to use certain functionality in the API, but are __not__ automatically installed. To use that functionality, you must manually call `conda install {package_name}` or `pipenv install {package_name}` for such optional packages."
+    "There are some other python packages that may be required to use certain functionality in the API, but are __not__ automatically installed. To use that functionality, you must manually call `conda install {package_name}` or `pip install {package_name}` for such optional packages.\n",
+    "\n",
+    "* [gdal](https://anaconda.org/Esri/gdal)\n",
+    "    - if installed, gdal may be used as a geometry engine for certain operations\n",
+    "    > Note: The gdal build on Esri anaconda channel is currently only compatible with environments configured with arcpy.\n",
+    "* [pyshp](https://anaconda.org/anaconda/pyshp)\n",
+    "    - if installed, pyshp may be used as a geometry engine for certain operations"
    ]
   }
  ],


### PR DESCRIPTION
- add gdal and pyshp to optional dependency list
- notate that `esri::gdal` is only for arcpy env
- pipenv -> pip
- 2.4.0 -> 2.4.0 and greater