### PR TITLE
fixed link for web scene specification

### DIFF
--- a/guide/02-api-overview/overview24.ipynb
+++ b/guide/02-api-overview/overview24.ipynb
@@ -249,7 +249,7 @@
    "source": [
     "The previous `arcgis.widgets` module contained the [MapView](/python-2-3/api-reference/arcgis.widgets.html#mapview) class which served as the map widget in Jupyter notebooks. The Python API 2.4 release refactors the _MapView_ functionality into two new classes in the [`arcgis.map`](/python/latest/api-reference/arcgis.map.toc.html) module: [_Map_](/python/latest/api-reference/arcgis.map.toc.html#map) and [_Scene_](/api-reference/arcgis.map.toc.html#scene) classes.\n",
     "\n",
-    "In previous releases, maps and scenes were intialized based on the _mode_ argument entered in the [GIS.map()](/python/latest/api-reference/arcgis.gis.toc.html#arcgis.gis.GIS.map) method, or by setting the [_mode_](/python-2-3/api-reference/arcgis.widgets.html#arcgis.widgets.MapView.mode) property of a _MapView_ object.  Either way, you were always working with an instance of the _MapView_ class. You can still use the _mode_ argument when intializing the _gis.map()_ object, but rather than returning the same type of object, the default value of _2D_ will return a _Map_ object, and _3D_ will return a _Scene_ object. Refactoring the calls allowed Python development to align with the [web map specification](https://developers.arcgis.com/web-map-specification/) and the [web scene specification](https://developers.arcgis.com/web-map-specification/) directly. This will increase widget compatibility within notebooks to more closely reflect the browser experiences of the Map Viewer and Scene Viewer.\n",
+    "In previous releases, maps and scenes were intialized based on the _mode_ argument entered in the [GIS.map()](/python/latest/api-reference/arcgis.gis.toc.html#arcgis.gis.GIS.map) method, or by setting the [_mode_](/python-2-3/api-reference/arcgis.widgets.html#arcgis.widgets.MapView.mode) property of a _MapView_ object.  Either way, you were always working with an instance of the _MapView_ class. You can still use the _mode_ argument when intializing the _gis.map()_ object, but rather than returning the same type of object, the default value of _2D_ will return a _Map_ object, and _3D_ will return a _Scene_ object. Refactoring the calls allowed Python development to align with the [web map specification](https://developers.arcgis.com/web-map-specification/) and the [web scene specification](https://developers.arcgis.com/web-scene-specification/) directly. This will increase widget compatibility within notebooks to more closely reflect the browser experiences of the Map Viewer and Scene Viewer.\n",
     "\n",
     "Some properties and methods on the _MapView_ class have been entirely removed, including interactive functionality that could be programmed into specific events like _on_click_ and _on_draw_, embedding the widget into the notebook, and properties and methods that controlled the Jupyter environment. Other properties and methods have been refactored into new classes, many using the exact same name. See the table below for a mapping between previous _MapView_ method and property names and how to access that functionality within the 2.4 release.\n",
     "\n",
@@ -492,7 +492,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The link for web scene specification was pointing to the same link for web map specification. Fixed it.

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **If this notebook showcases deep learning capabilities, please go through the following checklist:**
    - [ ] Are the inputs required for `Export Training Data Using Deep Learning` tool published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function?
    - [ ] Is training data zipped and published as Image Collection? Note: Whole folder is zipped with name same as the notebook name.
    - [ ] Are the inputs required for model inferencing published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function? Note: This includes providing test raster and trained model.
    - [ ] Are the inferenced results displayed using a webmap widget?
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @jyaistMap so he can add it to the list for the next deploy.