### PR TITLE
Notebook Docker: use conda-forge/pypi

### DIFF
--- a/.github/workflows/DockerBuild.AzureFunctionsBaseImage.yaml
+++ b/.github/workflows/DockerBuild.AzureFunctionsBaseImage.yaml
@@ -11,7 +11,7 @@ on:
       version:
         description: "Version of ArcGIS API for Python to install in the image"
         type: string
-        default: "2.3.1"
+        default: "2.4.1"
       python_version:
         description: "Python version to base image on"
         type: string

--- a/.github/workflows/DockerBuild.LambdaBaseImage.yaml
+++ b/.github/workflows/DockerBuild.LambdaBaseImage.yaml
@@ -11,7 +11,7 @@ on:
       version:
         description: "Version of ArcGIS API for Python to install in the image"
         type: string
-        default: "2.3.1"
+        default: "2.4.1"
       python_version:
         description: "Python version to base image on"
         type: string

--- a/.github/workflows/DockerBuild.NotebookImage.yaml
+++ b/.github/workflows/DockerBuild.NotebookImage.yaml
@@ -11,7 +11,7 @@ on:
       version:
         description: "Version of ArcGIS API for Python to install in the image"
         type: string
-        default: "2.3.1"
+        default: "2.4.1"
       python_version:
         description: "Python version to base image on"
         type: string

--- a/docker/AzureFunctionsBaseImage.Dockerfile
+++ b/docker/AzureFunctionsBaseImage.Dockerfile
@@ -12,6 +12,6 @@ LABEL org.opencontainers.image.source=https://github.com/esri/arcgis-python-api
 RUN apt-get update && apt-get install -y gcc libkrb5-dev krb5-config krb5-user && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN pip3 install azure-functions && rm -rf /home/.cache/pip
 # install arcgis
-ARG arcgis_version="2.3.1"
+ARG arcgis_version="2.4.1"
 # adding .* ensures the latest patch version is installed
 RUN  pip3 install "arcgis==${arcgis_version}.*" && rm -rf /home/.cache/pip

--- a/docker/LambdaBaseImage.Dockerfile
+++ b/docker/LambdaBaseImage.Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.source=https://github.com/esri/arcgis-python-api
 # install dependencies, then clean yum cache
 RUN yum -y install gcc gcc-c++ krb5-devel krb5-server krb5-libs && yum clean all && rm -rf /var/cache/yum
 # install arcgis
-ARG arcgis_version="2.3.1"
+ARG arcgis_version="2.4.1"
 # adding .* ensures the latest patch version is installed
 RUN  pip3 install "arcgis==${arcgis_version}.*" --target "${LAMBDA_TASK_ROOT}" && rm -rf /root/.cache/pip
 # set entrypoint to app.py handler method

--- a/docker/NotebookImage.Dockerfile
+++ b/docker/NotebookImage.Dockerfile
@@ -27,7 +27,8 @@ RUN conda install -n ${env_name} -c conda-forge gdal=${gdal_version} -y --quiet 
 
 # Install ArcGIS API for Python from pypi
 RUN . activate ${env_name} \
-    && python -m pip install arcgis==${arcgis_version} \
+    # adding .* ensures the latest patch version is installed
+    && python -m pip install "arcgis==${arcgis_version}.*" \
     && conda clean --all -f -y \
     && find /opt/conda -name __pycache__ -type d -exec rm -rf {} +
 


### PR DESCRIPTION
- installs GDAL
- avoids using anaconda/defaults due to licensing restrictions
- instead prefers conda-forge for python/gdal and pypi for arcgis/arcgis-mapping

Test build can be executed with:
`docker run -it --rm ghcr.io/esri/arcgis-python-api-notebook:2.4.1-python3.11@sha256:4091a781b5629d9f6849fa5dbd68ec7a926cf3cc8a86fdc74bb667126d43a5aa bash`