### PR TITLE
Add pixi environment config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ guide/gis module/.ipynb_checkpoints/class gis.ContentManager-checkpoint.ipynb
 .ipynb_checkpoints
 .idea/
 .DS_Store
+pixi.lock

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,4 @@ channels:
 - esri
 dependencies:
 - arcgis
-- notebook
-- ipywidgets >=5.2.2,<7
-- widgetsnbextension >=1.2.6,<3
+- arcgis-mapping

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,17 @@
+[workspace]
+authors = ["Esri Python <python@esri.com>"]
+channels = ["esri", "main"]
+channel-priority = "disabled"
+name = "arcgis-python-api"
+platforms = ["win-64", "linux-64", "osx-arm64", "osx-64"]
+version = "2.4.1"
+
+[dependencies]
+python = "3.11.*"
+arcgis = "2.4.1.*"
+
+[feature.mapping.dependencies]
+arcgis-mapping = "4.31.*"
+
+[environments]
+mapping = { features = ["mapping"] }

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,5 +1,8 @@
 [workspace]
 authors = ["Esri Python <python@esri.com>"]
+# NOTE: Usage of `main` channel is governed by Anaconda, Inc. terms of service
+# Please ensure you are in compliance
+# See https://legal.anaconda.com/policies/en/#terms-of-service
 channels = ["esri", "main"]
 channel-priority = "disabled"
 name = "arcgis-python-api"


### PR DESCRIPTION
Adds config for [pixi](https://pixi.sh/latest/), a conda-compatible alternative tool

Enables pixi users to invoke `pixi shell` for a working `arcgis` environment.
`pixi shell -e mapping` will include `arcgis-mapping`.