### PR TITLE
changes to render popups on map

### DIFF
--- a/guide/05-working-with-the-spatially-enabled-dataframe/visualizing-data-with-the-spatially-enabled-dataframe.ipynb
+++ b/guide/05-working-with-the-spatially-enabled-dataframe/visualizing-data-with-the-spatially-enabled-dataframe.ipynb
@@ -69,26 +69,17 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>FID</th>\n",
+       "      <th>OBJECTID</th>\n",
        "      <th>NAME</th>\n",
        "      <th>CLASS</th>\n",
-       "      <th>ST</th>\n",
-       "      <th>STFIPS</th>\n",
-       "      <th>PLACEFIPS</th>\n",
-       "      <th>CAPITAL</th>\n",
-       "      <th>POP_CLASS</th>\n",
+       "      <th>STATE_ABBR</th>\n",
+       "      <th>STATE_FIPS</th>\n",
+       "      <th>PLACE_FIPS</th>\n",
        "      <th>POPULATION</th>\n",
-       "      <th>POP2010</th>\n",
-       "      <th>...</th>\n",
-       "      <th>MARHH_NO_C</th>\n",
-       "      <th>MHH_CHILD</th>\n",
-       "      <th>FHH_CHILD</th>\n",
-       "      <th>FAMILIES</th>\n",
-       "      <th>AVE_FAM_SZ</th>\n",
-       "      <th>HSE_UNITS</th>\n",
-       "      <th>VACANT</th>\n",
-       "      <th>OWNER_OCC</th>\n",
-       "      <th>RENTER_OCC</th>\n",
+       "      <th>POP_CLASS</th>\n",
+       "      <th>POP_SQMI</th>\n",
+       "      <th>SQMI</th>\n",
+       "      <th>CAPITAL</th>\n",
        "      <th>SHAPE</th>\n",
        "    </tr>\n",
        "  </thead>\n",
@@ -96,158 +87,103 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>1</td>\n",
-       "      <td>Ammon</td>\n",
+       "      <td>Alabaster</td>\n",
        "      <td>city</td>\n",
-       "      <td>ID</td>\n",
-       "      <td>16</td>\n",
-       "      <td>1601990</td>\n",
-       "      <td></td>\n",
+       "      <td>AL</td>\n",
+       "      <td>01</td>\n",
+       "      <td>0100820</td>\n",
+       "      <td>33284</td>\n",
        "      <td>6</td>\n",
-       "      <td>15181</td>\n",
-       "      <td>13816</td>\n",
-       "      <td>...</td>\n",
-       "      <td>1131</td>\n",
-       "      <td>106</td>\n",
-       "      <td>335</td>\n",
-       "      <td>3352</td>\n",
-       "      <td>3.61</td>\n",
-       "      <td>4747</td>\n",
-       "      <td>271</td>\n",
-       "      <td>3205</td>\n",
-       "      <td>1271</td>\n",
-       "      <td>{\"x\": -12462673.723706165, \"y\": 5384674.994080...</td>\n",
+       "      <td>1300.7</td>\n",
+       "      <td>25.59</td>\n",
+       "      <td></td>\n",
+       "      <td>{\"x\": -86.81782028299995, \"y\": 33.244497706000...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>2</td>\n",
-       "      <td>Blackfoot</td>\n",
+       "      <td>Albertville</td>\n",
        "      <td>city</td>\n",
-       "      <td>ID</td>\n",
-       "      <td>16</td>\n",
-       "      <td>1607840</td>\n",
-       "      <td></td>\n",
+       "      <td>AL</td>\n",
+       "      <td>01</td>\n",
+       "      <td>0100988</td>\n",
+       "      <td>22386</td>\n",
        "      <td>6</td>\n",
-       "      <td>11946</td>\n",
-       "      <td>11899</td>\n",
-       "      <td>...</td>\n",
-       "      <td>1081</td>\n",
-       "      <td>174</td>\n",
-       "      <td>381</td>\n",
-       "      <td>2958</td>\n",
-       "      <td>3.31</td>\n",
-       "      <td>4547</td>\n",
-       "      <td>318</td>\n",
-       "      <td>2788</td>\n",
-       "      <td>1441</td>\n",
-       "      <td>{\"x\": -12506251.313993266, \"y\": 5341537.793529...</td>\n",
+       "      <td>827.9</td>\n",
+       "      <td>27.04</td>\n",
+       "      <td></td>\n",
+       "      <td>{\"x\": -86.21204767999996, \"y\": 34.264208442000...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>4</td>\n",
-       "      <td>Burley</td>\n",
+       "      <td>3</td>\n",
+       "      <td>Alexander City</td>\n",
        "      <td>city</td>\n",
-       "      <td>ID</td>\n",
-       "      <td>16</td>\n",
-       "      <td>1611260</td>\n",
-       "      <td></td>\n",
+       "      <td>AL</td>\n",
+       "      <td>01</td>\n",
+       "      <td>0101132</td>\n",
+       "      <td>14843</td>\n",
        "      <td>6</td>\n",
-       "      <td>10727</td>\n",
-       "      <td>10345</td>\n",
-       "      <td>...</td>\n",
-       "      <td>861</td>\n",
-       "      <td>139</td>\n",
-       "      <td>358</td>\n",
-       "      <td>2499</td>\n",
-       "      <td>3.37</td>\n",
-       "      <td>3885</td>\n",
-       "      <td>241</td>\n",
-       "      <td>2183</td>\n",
-       "      <td>1461</td>\n",
-       "      <td>{\"x\": -12667411.402393516, \"y\": 5241722.820606...</td>\n",
+       "      <td>337.4</td>\n",
+       "      <td>43.99</td>\n",
+       "      <td></td>\n",
+       "      <td>{\"x\": -85.95631375099998, \"y\": 32.943094153000...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>6</td>\n",
-       "      <td>Chubbuck</td>\n",
+       "      <td>4</td>\n",
+       "      <td>Anniston</td>\n",
        "      <td>city</td>\n",
-       "      <td>ID</td>\n",
-       "      <td>16</td>\n",
-       "      <td>1614680</td>\n",
-       "      <td></td>\n",
+       "      <td>AL</td>\n",
+       "      <td>01</td>\n",
+       "      <td>0101852</td>\n",
+       "      <td>21564</td>\n",
        "      <td>6</td>\n",
-       "      <td>14655</td>\n",
-       "      <td>13922</td>\n",
-       "      <td>...</td>\n",
-       "      <td>1281</td>\n",
-       "      <td>172</td>\n",
-       "      <td>370</td>\n",
-       "      <td>3586</td>\n",
-       "      <td>3.4</td>\n",
-       "      <td>4961</td>\n",
-       "      <td>229</td>\n",
-       "      <td>3324</td>\n",
-       "      <td>1408</td>\n",
-       "      <td>{\"x\": -12520053.904151963, \"y\": 5300220.333409...</td>\n",
+       "      <td>469.9</td>\n",
+       "      <td>45.89</td>\n",
+       "      <td></td>\n",
+       "      <td>{\"x\": -85.81985578299998, \"y\": 33.656500677000...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>12</td>\n",
-       "      <td>Jerome</td>\n",
+       "      <td>5</td>\n",
+       "      <td>Athens</td>\n",
        "      <td>city</td>\n",
-       "      <td>ID</td>\n",
-       "      <td>16</td>\n",
-       "      <td>1641320</td>\n",
-       "      <td></td>\n",
+       "      <td>AL</td>\n",
+       "      <td>01</td>\n",
+       "      <td>0102956</td>\n",
+       "      <td>25406</td>\n",
        "      <td>6</td>\n",
-       "      <td>11403</td>\n",
-       "      <td>10890</td>\n",
-       "      <td>...</td>\n",
-       "      <td>779</td>\n",
-       "      <td>210</td>\n",
-       "      <td>385</td>\n",
-       "      <td>2640</td>\n",
-       "      <td>3.44</td>\n",
-       "      <td>3985</td>\n",
-       "      <td>292</td>\n",
-       "      <td>2219</td>\n",
-       "      <td>1474</td>\n",
-       "      <td>{\"x\": -12747828.64784961, \"y\": 5269214.8197742...</td>\n",
+       "      <td>625.8</td>\n",
+       "      <td>40.6</td>\n",
+       "      <td></td>\n",
+       "      <td>{\"x\": -86.95079502699997, \"y\": 34.784837689000...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>5 rows × 50 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "   FID       NAME CLASS  ST STFIPS PLACEFIPS CAPITAL  POP_CLASS  POPULATION  \\\n",
-       "0    1      Ammon  city  ID     16   1601990                  6       15181   \n",
-       "1    2  Blackfoot  city  ID     16   1607840                  6       11946   \n",
-       "2    4     Burley  city  ID     16   1611260                  6       10727   \n",
-       "3    6   Chubbuck  city  ID     16   1614680                  6       14655   \n",
-       "4   12     Jerome  city  ID     16   1641320                  6       11403   \n",
+       "   OBJECTID            NAME CLASS STATE_ABBR STATE_FIPS PLACE_FIPS  \\\n",
+       "0         1       Alabaster  city         AL         01    0100820   \n",
+       "1         2     Albertville  city         AL         01    0100988   \n",
+       "2         3  Alexander City  city         AL         01    0101132   \n",
+       "3         4        Anniston  city         AL         01    0101852   \n",
+       "4         5          Athens  city         AL         01    0102956   \n",
        "\n",
-       "   POP2010  ...  MARHH_NO_C  MHH_CHILD  FHH_CHILD  FAMILIES  AVE_FAM_SZ  \\\n",
-       "0    13816  ...        1131        106        335      3352        3.61   \n",
-       "1    11899  ...        1081        174        381      2958        3.31   \n",
-       "2    10345  ...         861        139        358      2499        3.37   \n",
-       "3    13922  ...        1281        172        370      3586         3.4   \n",
-       "4    10890  ...         779        210        385      2640        3.44   \n",
-       "\n",
-       "   HSE_UNITS  VACANT  OWNER_OCC  RENTER_OCC  \\\n",
-       "0       4747     271       3205        1271   \n",
-       "1       4547     318       2788        1441   \n",
-       "2       3885     241       2183        1461   \n",
-       "3       4961     229       3324        1408   \n",
-       "4       3985     292       2219        1474   \n",
+       "   POPULATION  POP_CLASS  POP_SQMI   SQMI CAPITAL  \\\n",
+       "0       33284          6    1300.7  25.59           \n",
+       "1       22386          6     827.9  27.04           \n",
+       "2       14843          6     337.4  43.99           \n",
+       "3       21564          6     469.9  45.89           \n",
+       "4       25406          6     625.8   40.6           \n",
        "\n",
        "                                               SHAPE  \n",
-       "0  {\"x\": -12462673.723706165, \"y\": 5384674.994080...  \n",
-       "1  {\"x\": -12506251.313993266, \"y\": 5341537.793529...  \n",
-       "2  {\"x\": -12667411.402393516, \"y\": 5241722.820606...  \n",
-       "3  {\"x\": -12520053.904151963, \"y\": 5300220.333409...  \n",
-       "4  {\"x\": -12747828.64784961, \"y\": 5269214.8197742...  \n",
-       "\n",
-       "[5 rows x 50 columns]"
+       "0  {\"x\": -86.81782028299995, \"y\": 33.244497706000...  \n",
+       "1  {\"x\": -86.21204767999996, \"y\": 34.264208442000...  \n",
+       "2  {\"x\": -85.95631375099998, \"y\": 32.943094153000...  \n",
+       "3  {\"x\": -85.81985578299998, \"y\": 33.656500677000...  \n",
+       "4  {\"x\": -86.95079502699997, \"y\": 34.784837689000...  "
       ]
      },
      "execution_count": 1,
@@ -259,13 +195,12 @@
     "from arcgis import GIS\n",
     "\n",
     "gis = GIS()\n",
-    "# create an anonymous connection to ArcGIS Online and get a public item\n",
-    "item = gis.content.search(\n",
-    "    \"USA Major Cities\", item_type=\"Feature layer\", outside_org=True)[0]\n",
+    "# create an anonymous connection to ArcGIS Online and get a public item for \"USA Major Cities\"\n",
+    "item = gis.content.get(\"9df5e769bfe8412b8de36a2e618c7672\")\n",
     "flayer = item.layers[0]\n",
     "\n",
-    "# Specify a SQL query and get a sub-set of the original data as a DataFrame\n",
-    "df = flayer.query(where=\"AGE_45_54 < 1500\").sdf\n",
+    "# Query the data as a Spatially Enabled DataFrame\n",
+    "df = flayer.query().sdf\n",
     "\n",
     "# Visualize the top 5 records\n",
     "df.head()"
@@ -330,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -339,7 +274,7 @@
        "True"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -383,7 +318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -409,7 +344,7 @@
        "True"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -469,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -495,7 +430,7 @@
        "True"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -506,13 +441,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
     "renderer_manager = m3.content.renderer(0)\n",
     "smm = renderer_manager.smart_mapping()\n",
-    "smm.class_breaks_renderer(break_type=\"size\", field=\"POP2010\")"
+    "smm.class_breaks_renderer(break_type=\"size\", field=\"POPULATION\")"
    ]
   },
   {
@@ -532,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -543,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -552,25 +487,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/svg+xml": [
-       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"100.0\" height=\"100.0\" viewBox=\"-101.58348332176 33.81451220124 0.5577120205200004 0.518474605519998\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,68.147499008)\"><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"0.011154240410400007\" opacity=\"0.6\" d=\"M -101.562827321,33.835168202 L -101.561796784,34.308844809 L -101.4689124,34.309600319 L -101.048392125,34.312330806 L -101.046427302,33.8364457930001 L -101.562827321,33.835168202 z\" /></g></svg>"
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"100.0\" height=\"100.0\" viewBox=\"-100.08372242916 33.70811563283999 0.6381247003201196 0.5544134133200131\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,67.970644679)\"><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"0.012762494006402392\" opacity=\"0.6\" d=\"M -99.4713465139999,33.8277033950001 L -99.4692319769999,33.731749881 L -99.4846210919999,33.7427359120001 L -99.4943949079999,33.7677865840001 L -99.520885111,33.771990223 L -99.524120221,33.784734794 L -99.544575305,33.783456788 L -99.5478179789999,33.79620141 L -99.568288294,33.7912765040001 L -99.5798397139999,33.801320375 L -99.592626712,33.785909088 L -99.603064294,33.7982227000001 L -99.650497989,33.817924813 L -99.6654442829999,33.8120577980001 L -99.6935825799999,33.8248670200001 L -99.703081109,33.7985192790001 L -99.710268298,33.7985382910001 L -99.717386898,33.8158337950001 L -99.72629051,33.7994880140001 L -99.735652226,33.808601122 L -99.752261792,33.798637081 L -99.7538490159999,33.8213723200001 L -99.769344796,33.814585783 L -99.8080195159999,33.820566715 L -99.823507577,33.8146805850001 L -99.8389502059999,33.833341488 L -99.999828894,33.8325460880001 L -100.002033881,33.842547998 L -100.060088181,33.8411667990001 L -100.055391886,34.227977304 L -100.032060383,34.238894798 L -100.013161699,34.227535312 L -99.999825008,34.229354981 L -99.77352072,34.090527718 L -99.720250522,34.0958651920001 L -99.672595986,34.0848339880001 L -99.648700078,34.095671704 L -99.560692423,34.0617380900001 L -99.5468294029999,34.0621387940001 L -99.528991511,34.077069495 L -99.511245001,34.076993499 L -99.49079748,34.0664539150001 L -99.475210111,34.0750216820001 L -99.4713465139999,33.8277033950001 z \" /></g></svg>"
       ],
       "text/plain": [
-       "{'rings': [[[-101.562827321, 33.835168202],\n",
-       "   [-101.561796784, 34.308844809],\n",
-       "   [-101.4689124, 34.309600319],\n",
-       "   [-101.048392125, 34.312330806],\n",
-       "   [-101.046427302, 33.8364457930001],\n",
-       "   [-101.562827321, 33.835168202]]],\n",
+       "{'rings': [[[-99.4713465139999, 33.8277033950001],\n",
+       "   [-99.4692319769999, 33.731749881],\n",
+       "   [-99.4846210919999, 33.7427359120001],\n",
+       "   [-99.4943949079999, 33.7677865840001],\n",
+       "   [-99.520885111, 33.771990223],\n",
+       "   [-99.524120221, 33.784734794],\n",
+       "   [-99.544575305, 33.783456788],\n",
+       "   [-99.5478179789999, 33.79620141],\n",
+       "   [-99.568288294, 33.7912765040001],\n",
+       "   [-99.5798397139999, 33.801320375],\n",
+       "   [-99.592626712, 33.785909088],\n",
+       "   [-99.603064294, 33.7982227000001],\n",
+       "   [-99.650497989, 33.817924813],\n",
+       "   [-99.6654442829999, 33.8120577980001],\n",
+       "   [-99.6935825799999, 33.8248670200001],\n",
+       "   [-99.703081109, 33.7985192790001],\n",
+       "   [-99.710268298, 33.7985382910001],\n",
+       "   [-99.717386898, 33.8158337950001],\n",
+       "   [-99.72629051, 33.7994880140001],\n",
+       "   [-99.735652226, 33.808601122],\n",
+       "   [-99.752261792, 33.798637081],\n",
+       "   [-99.7538490159999, 33.8213723200001],\n",
+       "   [-99.769344796, 33.814585783],\n",
+       "   [-99.8080195159999, 33.820566715],\n",
+       "   [-99.823507577, 33.8146805850001],\n",
+       "   [-99.8389502059999, 33.833341488],\n",
+       "   [-99.999828894, 33.8325460880001],\n",
+       "   [-100.002033881, 33.842547998],\n",
+       "   [-100.060088181, 33.8411667990001],\n",
+       "   [-100.055391886, 34.227977304],\n",
+       "   [-100.032060383, 34.238894798],\n",
+       "   [-100.013161699, 34.227535312],\n",
+       "   [-99.999825008, 34.229354981],\n",
+       "   [-99.77352072, 34.090527718],\n",
+       "   [-99.720250522, 34.0958651920001],\n",
+       "   [-99.672595986, 34.0848339880001],\n",
+       "   [-99.648700078, 34.095671704],\n",
+       "   [-99.560692423, 34.0617380900001],\n",
+       "   [-99.5468294029999, 34.0621387940001],\n",
+       "   [-99.528991511, 34.077069495],\n",
+       "   [-99.511245001, 34.076993499],\n",
+       "   [-99.49079748, 34.0664539150001],\n",
+       "   [-99.475210111, 34.0750216820001],\n",
+       "   [-99.4713465139999, 33.8277033950001]]],\n",
        " 'spatialReference': {'wkid': 4326, 'latestWkid': 4326}}"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -593,7 +566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -625,7 +598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -725,7 +698,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -744,7 +717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -753,7 +726,7 @@
        "True"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -775,7 +748,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -799,7 +772,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>ST</th>\n",
+       "      <th>STATE_ABBR</th>\n",
        "      <th>NAME</th>\n",
        "      <th>POPULATION</th>\n",
        "    </tr>\n",
@@ -807,54 +780,54 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>ID</td>\n",
-       "      <td>Ammon</td>\n",
-       "      <td>15181</td>\n",
+       "      <td>AL</td>\n",
+       "      <td>Alabaster</td>\n",
+       "      <td>33284</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>ID</td>\n",
-       "      <td>Blackfoot</td>\n",
-       "      <td>11946</td>\n",
+       "      <td>AL</td>\n",
+       "      <td>Albertville</td>\n",
+       "      <td>22386</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>ID</td>\n",
-       "      <td>Burley</td>\n",
-       "      <td>10727</td>\n",
+       "      <td>AL</td>\n",
+       "      <td>Alexander City</td>\n",
+       "      <td>14843</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>ID</td>\n",
-       "      <td>Chubbuck</td>\n",
-       "      <td>14655</td>\n",
+       "      <td>AL</td>\n",
+       "      <td>Anniston</td>\n",
+       "      <td>21564</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>ID</td>\n",
-       "      <td>Jerome</td>\n",
-       "      <td>11403</td>\n",
+       "      <td>AL</td>\n",
+       "      <td>Athens</td>\n",
+       "      <td>25406</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   ST       NAME  POPULATION\n",
-       "0  ID      Ammon       15181\n",
-       "1  ID  Blackfoot       11946\n",
-       "2  ID     Burley       10727\n",
-       "3  ID   Chubbuck       14655\n",
-       "4  ID     Jerome       11403"
+       "  STATE_ABBR            NAME  POPULATION\n",
+       "0         AL       Alabaster       33284\n",
+       "1         AL     Albertville       22386\n",
+       "2         AL  Alexander City       14843\n",
+       "3         AL        Anniston       21564\n",
+       "4         AL          Athens       25406"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df[[\"ST\", \"NAME\", \"POPULATION\"]].head()"
+    "df[[\"STATE_ABBR\", \"NAME\", \"POPULATION\"]].head()"
    ]
   },
   {
@@ -876,7 +849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -885,7 +858,7 @@
        "True"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -896,7 +869,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -921,7 +894,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -938,8 +911,8 @@
        "                        <a href='https://www.arcgis.com/home/item.html?id=91c6a5f6410b4991ab0db1d7c26daacb' target='_blank'><b>USA Freeway System</b>\n",
        "                        </a>\n",
        "                        <br/>This layer presents rural and urban interstate highways.<br/><img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\" width=16 height=16>Feature Layer Collection by esri_dm\n",
-       "                        <br/>Last Modified: February 06, 2023\n",
-       "                        <br/>5 comments, 5465042 views\n",
+       "                        <br/>Last Modified: April 07, 2025\n",
+       "                        <br/>6 comments, 6141302 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
@@ -948,7 +921,7 @@
        "<Item title:\"USA Freeway System\" type:Feature Layer Collection owner:esri_dm>"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -963,7 +936,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1073,7 +1046,7 @@
        "4  {\"paths\": [[[-122.137358724846, 37.69015308551...  "
       ]
      },
-     "execution_count": 39,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1109,7 +1082,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1120,7 +1093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -1129,7 +1102,7 @@
        "True"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1149,7 +1122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -1354,18 +1327,18 @@
        "[5 rows x 53 columns]"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from arcgis.features import FeatureLayer\n",
+    "from arcgis.layers import Service\n",
     "\n",
-    "fl = FeatureLayer(\n",
+    "layer = Service(\n",
     "    \"https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/2\"\n",
     ")\n",
-    "county_sdf = fl.query(\"STATE_NAME='Washington'\", out_sr=4326).sdf\n",
+    "county_sdf = layer.query(\"STATE_NAME='Washington'\", out_sr=4326).sdf\n",
     "county_sdf.head()"
    ]
   },
@@ -1389,7 +1362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -1398,7 +1371,7 @@
        "True"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1423,16 +1396,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "from arcgis.map.dataclasses.models import FieldInfo\n",
+    "from arcgis.map.popups import PopupInfo, FieldInfo\n",
     "\n",
-    "pu = m9.content.popup(0)\n",
-    "pu.disable_popup = False\n",
-    "fields = [FieldInfo(field_name=fld) for fld in county_sdf.columns]\n",
-    "pu.edit(\"County Data\", field_infos=fields)"
+    "popup1 = m9.content.popup(0)\n",
+    "popup1.disable_popup = False\n",
+    "fields = [FieldInfo(field_name=column_name) for column_name in county_sdf.columns]\n",
+    "popup1.edit(\"County Data\", field_infos=fields)"
    ]
   },
   {
@@ -1461,7 +1445,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.12.11"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
updated data in the first cell, and used Service class for the last map, update the last cell for current Popup implementation.

closes https://github.com/ArcGIS/geosaurus/issues/13573

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **If this notebook showcases deep learning capabilities, please go through the following checklist:**
    - [ ] Are the inputs required for `Export Training Data Using Deep Learning` tool published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function?
    - [ ] Is training data zipped and published as Image Collection? Note: Whole folder is zipped with name same as the notebook name.
    - [ ] Are the inputs required for model inferencing published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function? Note: This includes providing test raster and trained model.
    - [ ] Are the inferenced results displayed using a webmap widget?
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @jyaistMap so he can add it to the list for the next deploy.