### PR TITLE
fixed feature layer query() parameters

### DIFF
--- a/samples/04_gis_analysts_data_scientists/designate_bike_routes_for_commuting_professionals.ipynb
+++ b/samples/04_gis_analysts_data_scientists/designate_bike_routes_for_commuting_professionals.ipynb
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +168,7 @@
        "                        </a>\n",
        "                        <br/>datascience<br/><img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\" width=16 height=16>Feature Layer Collection by api_data_owner\n",
        "                        <br/>Last Modified: June 13, 2019\n",
-       "                        <br/>0 comments, 127 views\n",
+       "                        <br/>0 comments, 154 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -328,7 +328,7 @@
        "<FeatureSet> 185 features"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -340,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,7 +367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -387,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -396,7 +396,7 @@
        "<FeatureSet> 6605 features"
       ]
      },
-     "execution_count": 96,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -426,13 +426,13 @@
    ],
    "source": [
     "busy_streets_map = gis.map('Seattle')\n",
-    "busy_streets_map.basemap.basemap = \"arcgis-streets\n",
+    "busy_streets_map.basemap.basemap = \"arcgis-streets\"\n",
     "busy_streets_map"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -475,7 +475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -497,7 +497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -505,26 +505,26 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=167d56ea96eb40f3a819a7410ee804e9' target='_blank'>\n",
+       "                       <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=df4963a84fbc4be7a41faf2bd31fd4bb' target='_blank'>\n",
        "                        <img src='http://static.arcgis.com/images/desktopapp.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=167d56ea96eb40f3a819a7410ee804e9' target='_blank'><b>MadisonStreet694249</b>\n",
+       "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=df4963a84fbc4be7a41faf2bd31fd4bb' target='_blank'><b>MadisonStreet486681</b>\n",
        "                        </a>\n",
-       "                        <br/><br/><img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\" width=16 height=16>Feature Layer Collection by arcgis_python\n",
-       "                        <br/>Last Modified: October 22, 2024\n",
+       "                        <br/><br/><img src='https://geosaurus.maps.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/featureshosted16.png' style=\"vertical-align:middle;\" width=16 height=16>Feature Layer Collection by MMajumdar_geosaurus\n",
+       "                        <br/>Last Modified: August 13, 2025\n",
        "                        <br/>0 comments, 0 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
       ],
       "text/plain": [
-       "<Item title:\"MadisonStreet694249\" type:Feature Layer Collection owner:arcgis_python>"
+       "<Item title:\"MadisonStreet486681\" type:Feature Layer Collection owner:MMajumdar_geosaurus>"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -535,7 +535,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,15 +544,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
     "stat_1 = madison_street_lyr.query(where='1=1',\n",
-    "                                  returnGeometry=False,\n",
-    "                                  spatialRel='esriSpatialRelIntersects',\n",
-    "                                  outFields='Length',\n",
-    "                                  outStatistics=[{\"statisticType\":\"count\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"countField\"},\n",
+    "                                  return_geometry=False,\n",
+    "                                  out_fields='Length',\n",
+    "                                  out_statistics=[{\"statisticType\":\"count\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"countField\"},\n",
     "                                              {\"statisticType\":\"sum\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"sumField\"},\n",
     "                                              {\"statisticType\":\"min\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"minField\"},\n",
     "                                              {\"statisticType\":\"max\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"maxField\"},\n",
@@ -562,7 +561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -571,7 +570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,16 +579,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "2.47538356"
+       "np.float64(2.47538356)"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -607,7 +606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -641,7 +640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -665,7 +664,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -687,7 +686,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -721,7 +720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -744,7 +743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -768,7 +767,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -777,20 +776,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
     "stat_2 = broadway_ave_layer.query(where='1=1',\n",
-    "                                  returnGeometry=False,\n",
-    "                                  spatialRel='esriSpatialRelIntersects',\n",
-    "                                  outFields='Length',\n",
-    "                                  outStatistics=[{\"statisticType\":\"count\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"countField\"},{\"statisticType\":\"sum\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"sumField\"},{\"statisticType\":\"min\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"minField\"},{\"statisticType\":\"max\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"maxField\"},{\"statisticType\":\"avg\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"avgField\"},{\"statisticType\":\"stddev\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"stddevField\"}])"
+    "                                  return_geometry=False,\n",
+    "                                  out_fields='Length',\n",
+    "                                  out_statistics=[{\"statisticType\":\"count\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"countField\"},{\"statisticType\":\"sum\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"sumField\"},{\"statisticType\":\"min\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"minField\"},{\"statisticType\":\"max\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"maxField\"},{\"statisticType\":\"avg\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"avgField\"},{\"statisticType\":\"stddev\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"stddevField\"}])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -799,7 +797,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -808,16 +806,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1.98774174"
+       "np.float64(1.98774174)"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -860,7 +858,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -876,9 +874,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"cost\": 0.022}\n"
+     ]
+    }
+   ],
    "source": [
     "buffer_street_broadway = create_buffers(broadway_ave_layer,\n",
     "                                        dissolve_type='Dissolve',\n",
@@ -915,7 +921,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -938,9 +944,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"cost\": 6.61}\n"
+     ]
+    }
+   ],
    "source": [
     "ave = find_existing_locations(input_layers=[{'url': busy_streets_layer.url},\n",
     "                                            {'url': bike_route_neighbourhood.url, 'filter':\"L_HOOD = 'CAPITOL HILL'\"}],\n",
@@ -954,7 +968,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -963,15 +977,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
     "stat_3 = ave_layer.query(where='1=1',\n",
-    "                         returnGeometry=False,\n",
-    "                         spatialRel='esriSpatialRelIntersects',\n",
-    "                         outFields='Length',\n",
-    "                         outStatistics=[{\"statisticType\":\"count\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"countField\"},\n",
+    "                         return_geometry=False,\n",
+    "                         out_fields='Length',\n",
+    "                         out_statistics=[{\"statisticType\":\"count\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"countField\"},\n",
     "                                        {\"statisticType\":\"sum\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"sumField\"},\n",
     "                                        {\"statisticType\":\"min\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"minField\"},\n",
     "                                        {\"statisticType\":\"max\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"maxField\"},\n",
@@ -981,7 +994,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -990,7 +1003,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -999,16 +1012,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1.63694922"
+       "np.float64(1.63694922)"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1051,7 +1064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1067,9 +1080,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"cost\": 0.026}\n"
+     ]
+    }
+   ],
    "source": [
     "buffer_street_ave = create_buffers(ave_layer,\n",
     "                                   dissolve_type='Dissolve',\n",
@@ -1106,7 +1127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1129,9 +1150,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 56,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"cost\": 26.214}\n"
+     ]
+    }
+   ],
    "source": [
     "capitol_hill_streets = find_existing_locations(input_layers=[{'url': bike_route_streets.url},\n",
     "                                                             {'url': bike_route_neighbourhood.url, 'filter':\"L_HOOD = 'CAPITOL HILL'\"}],\n",
@@ -1143,7 +1172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1152,15 +1181,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [],
    "source": [
     "stat_4 = capitol_hill_lyr.query(where='1=1',\n",
-    "                                returnGeometry=False,\n",
-    "                                spatialRel='esriSpatialRelIntersects',\n",
-    "                                outFields='Length',\n",
-    "                                outStatistics=[{\"statisticType\":\"count\",\"onStatisticField\":\"Length\",\n",
+    "                                return_geometry=False,\n",
+    "                                out_fields='Length',\n",
+    "                                out_statistics=[{\"statisticType\":\"count\",\"onStatisticField\":\"Length\",\n",
     "                                               \"outStatisticFieldName\":\"countField\"},\n",
     "                                               {\"statisticType\":\"sum\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"sumField\"},\n",
     "                                               {\"statisticType\":\"min\",\"onStatisticField\":\"Length\",\"outStatisticFieldName\":\"minField\"},\n",
@@ -1171,7 +1199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 59,
    "metadata": {
     "scrolled": true
    },
@@ -1224,7 +1252,7 @@
        "0        1361  93.52469  0.002864  0.944354  0.068718     0.047955"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1235,7 +1263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1244,7 +1272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1253,16 +1281,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "93.52469041"
+       "np.float64(93.52469041)"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1287,16 +1315,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "6.522421505228268"
+       "np.float64(6.522421505228268)"
       ]
      },
-     "execution_count": 75,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1328,9 +1356,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 64,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"cost\": 0.002}\n"
+     ]
+    }
+   ],
    "source": [
     "merge_madison_broadway_buffer = merge_layers(buffer_street,\n",
     "                                             buffer_street_broadway,\n",
@@ -1339,9 +1375,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"cost\": 0.003}\n"
+     ]
+    }
+   ],
    "source": [
     "merge_all_buffers = merge_layers(merge_madison_broadway_buffer,\n",
     "                                 buffer_street_ave,\n",
@@ -1375,7 +1419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1398,9 +1442,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 68,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"cost\": 0.003}\n"
+     ]
+    }
+   ],
    "source": [
     "dissolve = dissolve_boundaries(merge_all_buffers,\n",
     "                               output_name='DissolvedLayers'+ str(dt.now().microsecond))"
@@ -1433,7 +1485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1456,9 +1508,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 71,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"cost\": 0.006}\n"
+     ]
+    }
+   ],
    "source": [
     "cliped_buffer = overlay_layers(dissolve,\n",
     "                               bike_route_neighbourhood,\n",
@@ -1469,7 +1529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1503,7 +1563,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1533,9 +1593,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 75,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"cost\": 0.05}\n"
+     ]
+    }
+   ],
    "source": [
     "clipped_enrich = enrich_layer(cliped_buffer_layer, \n",
     "                              analysis_variables=[\"AtRisk.TOTPOP_CY\"], \n",
@@ -1551,9 +1619,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 76,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "{\"cost\": 0.05}\n"
+     ]
+    }
+   ],
    "source": [
     "capitolhill_enrich = enrich_layer(bike_route_neighbourhood,\n",
     "                                  analysis_variables=[\"AtRisk.TOTPOP_CY\"],\n",
@@ -1562,7 +1638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1571,15 +1647,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [],
    "source": [
     "stat_5 = clip_lyr.query(where='1=1',\n",
-    "                        returnGeometry=False,\n",
-    "                        spatialRel='esriSpatialRelIntersects',\n",
-    "                        outFields='TOTPOP_CY',\n",
-    "                        outStatistics=[{\"statisticType\":\"count\",\"onStatisticField\":\"TOTPOP_CY\",\"outStatisticFieldName\":\"countField\"},\n",
+    "                        return_geometry=False,\n",
+    "                        out_fields='TOTPOP_CY',\n",
+    "                        out_statistics=[{\"statisticType\":\"count\",\"onStatisticField\":\"TOTPOP_CY\",\"outStatisticFieldName\":\"countField\"},\n",
     "                                       {\"statisticType\":\"sum\",\"onStatisticField\":\"TOTPOP_CY\",\"outStatisticFieldName\":\"sumField\"},\n",
     "                                       {\"statisticType\":\"min\",\"onStatisticField\":\"TOTPOP_CY\",\"outStatisticFieldName\":\"minField\"},\n",
     "                                       {\"statisticType\":\"max\",\"onStatisticField\":\"TOTPOP_CY\",\"outStatisticFieldName\":\"maxField\"},\n",
@@ -1589,7 +1664,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [
     {
@@ -1625,22 +1700,22 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>5</td>\n",
-       "      <td>52490.0</td>\n",
-       "      <td>1374.0</td>\n",
-       "      <td>29400.0</td>\n",
-       "      <td>10498.0</td>\n",
-       "      <td>11313.92264</td>\n",
+       "      <td>52369.0</td>\n",
+       "      <td>1317.0</td>\n",
+       "      <td>29432.0</td>\n",
+       "      <td>10473.8</td>\n",
+       "      <td>11342.851524</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   countField  sumField  minField  maxField  avgField  stddevField\n",
-       "0           5   52490.0    1374.0   29400.0   10498.0  11313.92264"
+       "   countField  sumField  minField  maxField  avgField   stddevField\n",
+       "0           5   52369.0    1317.0   29432.0   10473.8  11342.851524"
       ]
      },
-     "execution_count": 91,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1653,7 +1728,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Approximately 49,431 Capitol Hill residents are within ½ mile of the bike routes, which constitutes approximately 99.3% of the neighborhood."
+    "Approximately 52,369 Capitol Hill residents are within ½ mile of the bike routes, which constitutes approximately 99.5% of the neighborhood."
    ]
   },
   {
@@ -1773,7 +1848,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
closes https://github.com/ArcGIS/geosaurus/issues/13088

The query() method had incorrect parameters, replaced those. Tested that the maps render correctly. 

I have left the `cost` for analysis methods in the outputs because we show them in the sample on the [dev site](https://developers.arcgis.com/python/latest/samples/designate-bike-routes-for-commuting-professionals/) too. If the general consensus is to remove it, I'll make that change.

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **If this notebook showcases deep learning capabilities, please go through the following checklist:**
    - [ ] Are the inputs required for `Export Training Data Using Deep Learning` tool published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function?
    - [ ] Is training data zipped and published as Image Collection? Note: Whole folder is zipped with name same as the notebook name.
    - [ ] Are the inputs required for model inferencing published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function? Note: This includes providing test raster and trained model.
    - [ ] Are the inferenced results displayed using a webmap widget?
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @jyaistMap so he can add it to the list for the next deploy.