### PR TITLE
Updated username syntax in `Working with different authentication schemes` guide for for Portal-tier authentication with Active Directory

### DIFF
--- a/guide/03-the-gis/working-with-different-authentication-schemes.ipynb
+++ b/guide/03-the-gis/working-with-different-authentication-schemes.ipynb
@@ -233,7 +233,7 @@
    "metadata": {},
    "source": [
     "### Portal-tier authentication with Active Directory\n",
-    "When connecting using an enterprise user account from an Active Directory, specify your username as `domain\\\\username`"
+    "When connecting using an enterprise user account from an Active Directory, specify your username as `domain\\\\username` or `username@domain`"
    ]
   },
   {
@@ -655,7 +655,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.13.5"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Resolves https://github.com/ArcGIS/geosaurus/issues/13801

Triage issue:
https://github.com/ArcGIS/geosaurus/issues/13802

Added the updated username syntax for Portal-tier authentication with Active Directory
