### PR TITLE
Update sedf to show mgdb access

### DIFF
--- a/guide/05-working-with-the-spatially-enabled-dataframe/part2_data_io_reading_data.ipynb
+++ b/guide/05-working-with-the-spatially-enabled-dataframe/part2_data_io_reading_data.ipynb
@@ -1693,7 +1693,7 @@
    "source": [
     "#### Reading a Featureclass\n",
     "\n",
-    "A [featureclass](http://desktop.arcgis.com/en/arcmap/latest/manage-data/feature-classes/a-quick-tour-of-feature-classes.htm) can be accessed from a File Geodatabase by passing its location in the [`from_featureclass()`](https://developers.arcgis.com/python/api-reference/arcgis.features.toc.html?arcgis.features.GeoAccessor.from_featureclass#arcgis.features.GeoAccessor.from_featureclass) method.\n"
+    "A [featureclass](http://desktop.arcgis.com/en/arcmap/latest/manage-data/feature-classes/a-quick-tour-of-feature-classes.htm) can be accessed from a File Geodatabase or Mobile Geodatabase (.geodatabase) by passing its location in the [`from_featureclass()`](https://developers.arcgis.com/python/api-reference/arcgis.features.toc.html?arcgis.features.GeoAccessor.from_featureclass#arcgis.features.GeoAccessor.from_featureclass) method.\n"
    ]
   },
   {
@@ -4319,7 +4319,7 @@
    "source": [
     "### Read in Non-spatial Table data\n",
     "\n",
-    "Non-spatial table data can be hosted on [**ArcGIS Online**](https://www.arcgis.com) or [**ArcGIS Enterprise**](http://enterprise.arcgis.com/en/), or it can be stored locally in a File Geodatabase. A `SeDF` can be easily created from such non-spatial table data using the following methods:\n",
+    "Non-spatial table data can be hosted on [**ArcGIS Online**](https://www.arcgis.com) or [**ArcGIS Enterprise**](http://enterprise.arcgis.com/en/), or it can be stored locally in a File Geodatabase or Mobile Geodatabase (.geodatabase). A `SeDF` can be easily created from such non-spatial table data using the following methods:\n",
     "\n",
     "- [`from_table()`](https://developers.arcgis.com/python/api-reference/arcgis.features.toc.html?highlight=from_feather#arcgis.features.GeoAccessor.from_table) - for local data\n",
     "- [`from_layer()`](https://developers.arcgis.com/python/api-reference/arcgis.features.toc.html?highlight=from_layer#arcgis.features.GeoAccessor.from_layer) - for data hosted on ArcGIS Online or Enterprise\n"

--- a/guide/05-working-with-the-spatially-enabled-dataframe/part3_data_io_writing_data.ipynb
+++ b/guide/05-working-with-the-spatially-enabled-dataframe/part3_data_io_writing_data.ipynb
@@ -728,7 +728,7 @@
    "source": [
     "#### Write to local databases\n",
     "\n",
-    "The [`to_featureclass()`](https://developers.arcgis.com/python/api-reference/arcgis.features.toc.html?highlight=from_feather#arcgis.features.GeoAccessor.to_featureclass) method can be used to export spatial data from a _SeDF_ into various local databases, such as a [File geodatabase](https://pro.arcgis.com/en/pro-app/latest/help/data/geodatabases/manage-file-gdb/file-geodatabases.htm), a [Mobile geodatabase](https://pro.arcgis.com/en/pro-app/latest/help/data/geodatabases/manage-mobile-gdb/mobile-geodatabases.htm) (.geodatabase), or a [SQLite Database](https://pro.arcgis.com/en/pro-app/latest/tool-reference/data-management/create-sqlite-database.htm).\n"
+    "The [`to_featureclass()`](https://developers.arcgis.com/python/api-reference/arcgis.features.toc.html?highlight=from_feather#arcgis.features.GeoAccessor.to_featureclass) method can be used to export spatial data from a _SeDF_ into various local databases, such as a [File geodatabase](https://pro.arcgis.com/en/pro-app/latest/help/data/geodatabases/manage-file-gdb/file-geodatabases.htm), a [Mobile geodatabase](https://pro.arcgis.com/en/pro-app/latest/help/data/geodatabases/manage-mobile-gdb/mobile-geodatabases.htm) (.geodatabase), or a [SQLite Database](https://pro.arcgis.com/en/pro-app/latest/tool-reference/data-management/create-sqlite-database.htm) (.sqlite).\n"
    ]
   },
   {


### PR DESCRIPTION
- Resolves https://github.com/ArcGIS/geosaurus/issues/14386

We allow data access and editing in mobile geodatabases. This change simply notes that mobile geodatabase access is available. 

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [x ] All `import`s are in the first cell? 
    - [x] First block of imports are standard libraries
    - [x ] Second block are 3rd party libraries
    - [x ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [x] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [x] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [x] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [x] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [x] Code simplified & split out across multiple cells, useful comments?
- [x] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [x] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [x] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [x] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [x] **If this notebook showcases deep learning capabilities, please go through the following checklist:**
    - [x] Are the inputs required for `Export Training Data Using Deep Learning` tool published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function?
    - [x] Is training data zipped and published as Image Collection? Note: Whole folder is zipped with name same as the notebook name.
    - [x] Are the inputs required for model inferencing published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function? Note: This includes providing test raster and trained model.
    - [ ] Are the inferenced results displayed using a webmap widget?
- [x] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @jyaistMap so he can add it to the list for the next deploy.