### PR TITLE
sync up code changes in tebpfn notebook

### DIFF
--- a/samples/04_gis_analysts_data_scientists/classifying_human_activity_using_tabPFN_classifier.ipynb
+++ b/samples/04_gis_analysts_data_scientists/classifying_human_activity_using_tabPFN_classifier.ipynb
@@ -54,18 +54,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: total: 0 ns\n",
-      "Wall time: 1.01 ms\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
@@ -83,12 +74,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The TabPFN package can be installed using the following command in python command prompt:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "conda install -c esri tabpfn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Connect to ArcGIS <a class=\"anchor\" id=\"3\"></a>"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -123,8 +128,8 @@
        "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=1fafacc88bc3491696f981758a72de50' target='_blank'><b>train_har_dataset</b>\n",
        "                        </a>\n",
        "                        <br/>HAR dataset<br/><img src='https://geosaurus.maps.arcgis.com/home/js/arcgisonline/img/item-types/datafiles16.svg' style=\"vertical-align:middle;\" width=16 height=16>CSV by api_data_owner\n",
-       "                        <br/>Last Modified: January 10, 2025\n",
-       "                        <br/>0 comments, 3 views\n",
+       "                        <br/>Last Modified: January 11, 2025\n",
+       "                        <br/>0 comments, 48 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
@@ -133,7 +138,7 @@
        "<Item title:\"train_har_dataset\" type:CSV owner:api_data_owner>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -146,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -382,7 +387,7 @@
        "[5 rows x 563 columns]"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -395,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -404,7 +409,7 @@
        "(1020, 563)"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -422,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -439,8 +444,8 @@
        "                        <a href='https://geosaurus.maps.arcgis.com/home/item.html?id=e65312babe5b4efbaa2842235b79f653' target='_blank'><b>test_har_dataset</b>\n",
        "                        </a>\n",
        "                        <br/>HAR dataset<br/><img src='https://geosaurus.maps.arcgis.com/home/js/arcgisonline/img/item-types/datafiles16.svg' style=\"vertical-align:middle;\" width=16 height=16>CSV by api_data_owner\n",
-       "                        <br/>Last Modified: January 10, 2025\n",
-       "                        <br/>0 comments, 0 views\n",
+       "                        <br/>Last Modified: January 11, 2025\n",
+       "                        <br/>0 comments, 55 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
@@ -449,7 +454,7 @@
        "<Item title:\"test_har_dataset\" type:CSV owner:api_data_owner>"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -462,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +477,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -698,7 +703,7 @@
        "[5 rows x 563 columns]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -711,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -720,7 +725,7 @@
        "(6332, 563)"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -738,7 +743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -749,7 +754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 13,
    "metadata": {
     "scrolled": true
    },
@@ -1320,7 +1325,7 @@
        " 'angle(Z,gravityMean)']"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1331,7 +1336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -1340,7 +1345,7 @@
        "561"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1365,7 +1370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -1374,18 +1379,18 @@
        "(1020, 6)"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Data processing to reduce the features to 100 or less as required for TabPFN models\n",
-    "X = train_har_data.drop(columns=['Activity'])\n",
+    "X = train_har_data.drop(columns=['subject','Activity'])\n",
     "y = train_har_data['Activity']\n",
     "scaler = StandardScaler()\n",
     "X_scaled = scaler.fit_transform(X)\n",
-    "lda = LinearDiscriminantAnalysis(n_components=min(100, len(set(y)) - 1))\n",
+    "lda = LinearDiscriminantAnalysis() \n",
     "X_reduced_lda = lda.fit_transform(X_scaled, y)\n",
     "X_train_lda_df = pd.DataFrame(X_reduced_lda, columns=[f'LDA{i+1}' for i in range(X_reduced_lda.shape[1])])\n",
     "X_train_lda_df['Activity'] = y.reset_index(drop=True)\n",
@@ -1394,7 +1399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1403,7 +1408,7 @@
        "Index(['LDA1', 'LDA2', 'LDA3', 'LDA4', 'LDA5', 'Activity'], dtype='object')"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1422,7 +1427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1431,7 +1436,7 @@
        "5"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1454,7 +1459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1477,7 +1482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -1513,47 +1518,47 @@
        "    <tr>\n",
        "      <th>28</th>\n",
        "      <td>STANDING</td>\n",
-       "      <td>-19.431367</td>\n",
-       "      <td>-11.174415</td>\n",
-       "      <td>0.816325</td>\n",
-       "      <td>-0.687153</td>\n",
-       "      <td>2.809134</td>\n",
+       "      <td>-19.417553</td>\n",
+       "      <td>-11.243740</td>\n",
+       "      <td>0.918685</td>\n",
+       "      <td>-0.649895</td>\n",
+       "      <td>2.771662</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>130</th>\n",
        "      <td>SITTING</td>\n",
-       "      <td>-18.377005</td>\n",
-       "      <td>-9.429310</td>\n",
-       "      <td>0.342490</td>\n",
-       "      <td>-0.757008</td>\n",
-       "      <td>-4.074501</td>\n",
+       "      <td>-18.471293</td>\n",
+       "      <td>-9.240233</td>\n",
+       "      <td>0.375931</td>\n",
+       "      <td>-0.752110</td>\n",
+       "      <td>-4.075432</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>311</th>\n",
        "      <td>WALKING</td>\n",
-       "      <td>17.852727</td>\n",
-       "      <td>-1.390446</td>\n",
-       "      <td>-8.164604</td>\n",
-       "      <td>4.176480</td>\n",
-       "      <td>-0.160302</td>\n",
+       "      <td>17.773490</td>\n",
+       "      <td>-1.438111</td>\n",
+       "      <td>-8.164614</td>\n",
+       "      <td>4.168316</td>\n",
+       "      <td>-0.154530</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>734</th>\n",
        "      <td>WALKING_UPSTAIRS</td>\n",
-       "      <td>23.633640</td>\n",
-       "      <td>2.301121</td>\n",
-       "      <td>2.475455</td>\n",
-       "      <td>-10.447339</td>\n",
-       "      <td>-0.302447</td>\n",
+       "      <td>23.623186</td>\n",
+       "      <td>2.154564</td>\n",
+       "      <td>2.490316</td>\n",
+       "      <td>-10.440684</td>\n",
+       "      <td>-0.306971</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>847</th>\n",
        "      <td>LAYING</td>\n",
-       "      <td>-26.620913</td>\n",
-       "      <td>14.783496</td>\n",
-       "      <td>-0.705847</td>\n",
-       "      <td>0.511383</td>\n",
-       "      <td>-0.568820</td>\n",
+       "      <td>-26.261936</td>\n",
+       "      <td>14.538433</td>\n",
+       "      <td>-0.750472</td>\n",
+       "      <td>0.509736</td>\n",
+       "      <td>-0.579957</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1561,14 +1566,14 @@
       ],
       "text/plain": [
        "             Activity       LDA1       LDA2      LDA3       LDA4      LDA5\n",
-       "28           STANDING -19.431367 -11.174415  0.816325  -0.687153  2.809134\n",
-       "130           SITTING -18.377005  -9.429310  0.342490  -0.757008 -4.074501\n",
-       "311           WALKING  17.852727  -1.390446 -8.164604   4.176480 -0.160302\n",
-       "734  WALKING_UPSTAIRS  23.633640   2.301121  2.475455 -10.447339 -0.302447\n",
-       "847            LAYING -26.620913  14.783496 -0.705847   0.511383 -0.568820"
+       "28           STANDING -19.417553 -11.243740  0.918685  -0.649895  2.771662\n",
+       "130           SITTING -18.471293  -9.240233  0.375931  -0.752110 -4.075432\n",
+       "311           WALKING  17.773490  -1.438111 -8.164614   4.168316 -0.154530\n",
+       "734  WALKING_UPSTAIRS  23.623186   2.154564  2.490316 -10.440684 -0.306971\n",
+       "847            LAYING -26.261936  14.538433 -0.750472   0.509736 -0.579957"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1596,7 +1601,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1614,7 +1619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1623,7 +1628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -1632,7 +1637,7 @@
        "0.9901960784313726"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1659,9 +1664,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "'force_all_finite' was renamed to 'ensure_all_finite' in 1.6 and will be removed in 1.8.\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -1696,51 +1708,51 @@
        "    <tr>\n",
        "      <th>101</th>\n",
        "      <td>LAYING</td>\n",
-       "      <td>-27.925746</td>\n",
-       "      <td>17.698939</td>\n",
-       "      <td>-0.211993</td>\n",
-       "      <td>0.137931</td>\n",
-       "      <td>-0.872844</td>\n",
+       "      <td>-27.572224</td>\n",
+       "      <td>17.536857</td>\n",
+       "      <td>-0.293677</td>\n",
+       "      <td>0.122248</td>\n",
+       "      <td>-0.868357</td>\n",
        "      <td>LAYING</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>299</th>\n",
        "      <td>WALKING</td>\n",
-       "      <td>22.230659</td>\n",
-       "      <td>0.572533</td>\n",
-       "      <td>-8.318169</td>\n",
-       "      <td>1.275016</td>\n",
-       "      <td>0.139479</td>\n",
+       "      <td>22.234214</td>\n",
+       "      <td>0.341170</td>\n",
+       "      <td>-8.293393</td>\n",
+       "      <td>1.279935</td>\n",
+       "      <td>0.128431</td>\n",
        "      <td>WALKING</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>693</th>\n",
        "      <td>SITTING</td>\n",
-       "      <td>-18.977440</td>\n",
-       "      <td>-10.123049</td>\n",
-       "      <td>0.551960</td>\n",
-       "      <td>-0.028800</td>\n",
-       "      <td>-3.010251</td>\n",
+       "      <td>-19.069578</td>\n",
+       "      <td>-9.945686</td>\n",
+       "      <td>0.593088</td>\n",
+       "      <td>-0.020452</td>\n",
+       "      <td>-3.014706</td>\n",
        "      <td>SITTING</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>884</th>\n",
        "      <td>WALKING</td>\n",
-       "      <td>23.685543</td>\n",
-       "      <td>-0.261172</td>\n",
-       "      <td>-11.338481</td>\n",
-       "      <td>3.464041</td>\n",
-       "      <td>-0.628183</td>\n",
+       "      <td>23.716562</td>\n",
+       "      <td>-0.591834</td>\n",
+       "      <td>-11.292542</td>\n",
+       "      <td>3.476408</td>\n",
+       "      <td>-0.650639</td>\n",
        "      <td>WALKING</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>967</th>\n",
        "      <td>SITTING</td>\n",
-       "      <td>-18.285170</td>\n",
-       "      <td>-11.017798</td>\n",
-       "      <td>1.873937</td>\n",
-       "      <td>-0.702550</td>\n",
-       "      <td>-1.983438</td>\n",
+       "      <td>-18.414386</td>\n",
+       "      <td>-10.779558</td>\n",
+       "      <td>1.910474</td>\n",
+       "      <td>-0.696723</td>\n",
+       "      <td>-1.982649</td>\n",
        "      <td>SITTING</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -1749,11 +1761,11 @@
       ],
       "text/plain": [
        "    Activity       LDA1       LDA2       LDA3      LDA4      LDA5  \\\n",
-       "101   LAYING -27.925746  17.698939  -0.211993  0.137931 -0.872844   \n",
-       "299  WALKING  22.230659   0.572533  -8.318169  1.275016  0.139479   \n",
-       "693  SITTING -18.977440 -10.123049   0.551960 -0.028800 -3.010251   \n",
-       "884  WALKING  23.685543  -0.261172 -11.338481  3.464041 -0.628183   \n",
-       "967  SITTING -18.285170 -11.017798   1.873937 -0.702550 -1.983438   \n",
+       "101   LAYING -27.572224  17.536857  -0.293677  0.122248 -0.868357   \n",
+       "299  WALKING  22.234214   0.341170  -8.293393  1.279935  0.128431   \n",
+       "693  SITTING -19.069578  -9.945686   0.593088 -0.020452 -3.014706   \n",
+       "884  WALKING  23.716562  -0.591834 -11.292542  3.476408 -0.650639   \n",
+       "967  SITTING -18.414386 -10.779558   1.910474 -0.696723 -1.982649   \n",
        "\n",
        "    Activity_results  \n",
        "101           LAYING  \n",
@@ -1763,7 +1775,7 @@
        "967          SITTING  "
       ]
      },
-     "execution_count": 42,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1785,7 +1797,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -1798,11 +1810,11 @@
    ],
    "source": [
     "# Align tset data with the train data format \n",
-    "X = test_har_data.drop(columns=['Activity'])\n",
+    "X = test_har_data.drop(columns=['subject','Activity'])\n",
     "y = test_har_data['Activity']\n",
     "scaler = StandardScaler()\n",
-    "X_scaled = scaler.fit_transform(X)\n",
-    "lda = LinearDiscriminantAnalysis(n_components=min(100, len(set(y)) - 1)) \n",
+    "X_scaled = scaler.fit_transform(X) \n",
+    "lda = LinearDiscriminantAnalysis() \n",
     "X_reduced_lda = lda.fit_transform(X_scaled, y)\n",
     "X_test_lda_df = pd.DataFrame(X_reduced_lda, columns=[f'LDA{i+1}' for i in range(X_reduced_lda.shape[1])])\n",
     "X_test_lda_df['Activity'] = y.reset_index(drop=True)\n",
@@ -1811,7 +1823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -1902,7 +1914,7 @@
        "4  -9.596161 -6.980061  0.480017 -0.284537  1.103180  STANDING"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1920,16 +1932,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "'force_all_finite' was renamed to 'ensure_all_finite' in 1.6 and will be removed in 1.8.\n"
+     ]
+    }
+   ],
    "source": [
     "activity_predicted_tabpfn = tabpfn_classifier.predict(X_test_lda_df, prediction_type='dataframe')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -2033,7 +2053,7 @@
        "6331    WALKING_UPSTAIRS  "
       ]
      },
-     "execution_count": 46,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2053,14 +2073,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy: 96.83%\n",
+      "Accuracy: 96.72%\n",
       "Precision: 0.97\n",
       "Recall: 0.97\n",
       "F1 Score: 0.97\n",
@@ -2069,8 +2089,8 @@
       "                    precision    recall  f1-score   support\n",
       "\n",
       "            LAYING       1.00      1.00      1.00      1219\n",
-      "           SITTING       1.00      0.83      0.91      1119\n",
-      "          STANDING       0.86      0.99      0.93      1197\n",
+      "           SITTING       1.00      0.83      0.90      1119\n",
+      "          STANDING       0.86      0.99      0.92      1197\n",
       "           WALKING       1.00      1.00      1.00      1031\n",
       "WALKING_DOWNSTAIRS       1.00      0.99      1.00       835\n",
       "  WALKING_UPSTAIRS       0.99      1.00      1.00       931\n",
@@ -2114,7 +2134,7 @@
    "source": [
     "The performance metrics obtained from the trained TabPFN model on the test dataset of 6,332 samples indicate excellent classification quality.\n",
     "\n",
-    "`Accuracy (96.81%)` : The model correctly classified approximately 97% of the samples, which is a strong indication of its ability to generalize well to unseen data, despite being trained on a smaller dataset of just 1,020 samples.\n",
+    "`Accuracy (96.72%)` : The model correctly classified approximately 97% of the samples, which is a strong indication of its ability to generalize well to unseen data, despite being trained on a smaller dataset of just 1,020 samples.\n",
     "\n",
     "`Precision (0.97)`      : Precision measures the proportion of true positive predictions among all positive predictions made by the model. A precision of 0.97 means that 97% of the predicted positive activity classes are correct, indicating that the model rarely makes false positive errors.\n",
     "\n",
@@ -2158,9 +2178,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pro3.5_LearnLesson2025",
+   "display_name": "pro3.6_certify2.4.2_24Sep2025 [conda env:conda-pro3.6_certify2.4.2_24Sep2025] *",
    "language": "python",
-   "name": "pro3.5_learnlesson2025"
+   "name": "conda-env-conda-pro3.6_certify2.4.2_24Sep2025-pro3.6_certify2.4.2_24sep2025"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2172,7 +2192,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
\<insert pull request description here\>

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **If this notebook showcases deep learning capabilities, please go through the following checklist:**
    - [ ] Are the inputs required for `Export Training Data Using Deep Learning` tool published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function?
    - [ ] Is training data zipped and published as Image Collection? Note: Whole folder is zipped with name same as the notebook name.
    - [ ] Are the inputs required for model inferencing published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function? Note: This includes providing test raster and trained model.
    - [ ] Are the inferenced results displayed using a webmap widget?
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @jyaistMap so he can add it to the list for the next deploy.