### PR TITLE
Adding a new guide for dashboards module

### DIFF
--- a/guide/13-managing-arcgis-applications/introduction_to_dashboards_module.ipynb
+++ b/guide/13-managing-arcgis-applications/introduction_to_dashboards_module.ipynb
@@ -13,7 +13,7 @@
    "id": "3c886262",
    "metadata": {},
    "source": [
-    "The `arcgis.apps.dashboards` module, introduced in ArcGIS Python API v2.4.3, provides programmatic tools for managing dashboard items. It enables automation of common tasks such as:\n",
+    "The [`arcgis.apps.dashboards`](/python/latest/api-reference/arcgis.apps.dashboards.html) module, introduced in ArcGIS Python API v2.4.3, provides programmatic tools for managing dashboard items. It enables automation of common tasks such as:\n",
     "\n",
     "<ul><li><b>Updating Data Sources:</b> Replace outdated or deprecated data sources without manual edits.\n",
     "<li><b>Preserving Layout and Interactivity:</b> Reuse existing dashboard configurations while connecting to new datasets.</li>\n",
@@ -27,7 +27,7 @@
    "source": [
     "This module supports only modern ArcGIS Dashboards items and does not work with items created in the retired ArcGIS Dashboards Classic app. \n",
     "\n",
-    "Tip: To check whether a dashboard is supported, you can look at its data using the item’s `get_data()` function. Dashboards with a version shown as a string (such as \"4.30.0\",\"4.31.0\" and so on) or a number of 27 or higher are supported (see helper function below). If you find an older Classic dashboard (those with a version number below 27), you can update it by opening it in ArcGIS Dashboards, switching to Edit mode, and saving it."
+    "> Tip: To check whether a dashboard is supported, you can look at its data using the item’s [`get_data()`](/python/latest/api-reference/arcgis.gis.toc.html#arcgis.gis.Item.get_data) function. Dashboards with a version shown as a string (such as \"4.30.0\",\"4.31.0\" and so on) or a number of 27 or higher are supported (see helper function below). If you find an older Classic dashboard (those with a version number below 27), you can update it by opening it in ArcGIS Dashboards, switching to Edit mode, and saving it."
    ]
   },
   {
@@ -59,7 +59,7 @@
    "id": "7dde42a9",
    "metadata": {},
    "source": [
-    "<blockquote><b>[TBD] Note:</b> Support is currently limited to ArcGIS Online dashboards. ArcGIS Enterprise support will be introduced in a future release.</blockquote>"
+    "<blockquote><b>Note:</b> Support is currently limited to ArcGIS Online dashboards. ArcGIS Enterprise support will be introduced in a future release.</blockquote>"
    ]
   },
   {
@@ -76,7 +76,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "`DashboardManager` is the main class for managing dashboard items. It supports operations such as dependency discovery and replacement, copying and upgrading dashboards.\n"
+    "[`DashboardManager`](\"/python/latest/api-reference/arcgis.apps.dashboards.html#dashboardmanager\")  is the main class for managing dashboard items. It supports operations such as dependency discovery and replacement, copying and upgrading dashboards.\n"
    ]
   },
   {
@@ -186,7 +186,7 @@
    "id": "130d11d9",
    "metadata": {},
    "source": [
-    "The `get_dependencies()` function in the `DashboardManager` class retrieves the dependencies that a dashboard uses, including web maps and scenes, feature layers, embedded apps, and Arcade data expressions. You can optionally retrieve layer IDs and fields by specifying the DependencyOptions object."
+    "The [`get_dependencies()`](/python/latest/api-reference/arcgis.apps.dashboards.html#arcgis.apps.dashboards.DashboardManager.get_dependencies) function in the `DashboardManager` class retrieves the dependencies that a dashboard uses, including web maps and scenes, feature layers, embedded apps, and Arcade data expressions. You can optionally retrieve layer IDs and fields by specifying the [DependencyOptions](/python/latest/api-reference/arcgis.apps.dashboards.html#dependencyoptions) object."
    ]
   },
   {
@@ -226,7 +226,7 @@
    "id": "0875080c",
    "metadata": {},
    "source": [
-    " The `replace_dependencies()` function allows you to update existing dependencies and data sources by replacing them with new ones. The `item_mapping` parameter is a list of `ItemMapping` objects, where each entry maps a source item ID to a target item ID. Within each `ItemMapping`, optional `LayerMapping` and `FieldMapping` objects specify layer-level and field-level details for the replacement.\n",
+    " The [`replace_dependencies()`](/python/latest/api-reference/arcgis.apps.dashboards.html#arcgis.apps.dashboards.DashboardManager.replace_dependencies) function allows you to update existing dependencies and data sources by replacing them with new ones. The `item_mapping` parameter is a list of [`ItemMapping`](/python/latest/api-reference/arcgis.apps.dashboards.html#arcgis.apps.dashboards.ItemMapping) objects, where each entry maps a source item ID to a target item ID. Within each `ItemMapping`, optional [`LayerMapping`](/python/latest/api-reference/arcgis.apps.dashboards.html#arcgis.apps.dashboards.LayerMapping) and [`FieldMapping`](/python/latest/api-reference/arcgis.apps.dashboards.html#fieldmapping) objects specify layer-level and field-level details for the replacement.\n",
     "\n",
     "Here is an example of item_mapping structure -"
    ]
@@ -300,7 +300,7 @@
    "source": [
     "The `replace_dependencies()` function updates an existing dashboard, making it ideal for scenarios where you need to fix broken data sources or update data with most current information. \n",
     "\n",
-    "However, if the goal is to simply reuse the design layout and configurations of an existing dashboard and create a copy with different data sources, use the `copy()` function instead. Let's look at how this works below."
+    "However, if the goal is to simply reuse the design layout and configurations of an existing dashboard and create a copy with different data sources, use the [`copy()`](/python/latest/api-reference/arcgis.apps.dashboards.html#arcgis.apps.dashboards.DashboardManager.copy) function instead. Let's look at how this works below."
    ]
   },
   {
@@ -316,7 +316,7 @@
    "id": "4f489047",
    "metadata": {},
    "source": [
-    "The `copy()` function duplicates an existing dashboard within the same organization. \n",
+    "The [`copy()`](/python/latest/api-reference/arcgis.apps.dashboards.html#arcgis.apps.dashboards.DashboardManager.copy) function duplicates an existing dashboard within the same organization. \n",
     "\n",
     "> Note: Providing an `ItemMapping` list through the `item_mapping` parameter lets you remap dependencies in the new dashboard; otherwise, the copy will continue to reference the original dependencies.\n",
     "\n",
@@ -385,7 +385,7 @@
    "id": "646057ec",
    "metadata": {},
    "source": [
-    "> Tip - If the goal is to clone dashboards from one organization to another, it is recommended to use `clone_items()` as it has also been enhanced to support dashboard items and the remapping of their dependencies.\n"
+    "> Tip - If the goal is to clone dashboards from one organization to another, it is recommended to use [`clone_items()`](/python/latest/api-reference/arcgis.gis.toc.html#arcgis.gis.ContentManager.clone_items) as it has also been enhanced to support dashboard items and the remapping of their dependencies.\n"
    ]
   },
   {
@@ -401,7 +401,7 @@
    "id": "5de7b145",
    "metadata": {},
    "source": [
-    "Use the `upgrade()` function to update a dashboard item to the latest version supported by the portal."
+    "Use the [`upgrade()`](/python/latest/api-reference/arcgis.apps.dashboards.html#arcgis.apps.dashboards.DashboardManager.upgrade) function to update a dashboard item to the latest version supported by the portal."
    ]
   },
   {


### PR DESCRIPTION
A guide documentation for the new `arcgis.apps.dashboards` module that walks through the `DashboardManager` class and its available functions— `get_dependencies()`, `replace_dependencies()`, `copy()`, and `upgrade()`

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **If this notebook showcases deep learning capabilities, please go through the following checklist:**
    - [ ] Are the inputs required for `Export Training Data Using Deep Learning` tool published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function?
    - [ ] Is training data zipped and published as Image Collection? Note: Whole folder is zipped with name same as the notebook name.
    - [ ] Are the inputs required for model inferencing published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function? Note: This includes providing test raster and trained model.
    - [ ] Are the inferenced results displayed using a webmap widget?
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @jyaistMap so he can add it to the list for the next deploy.