### PR TITLE
intro to briefings guide 3/4

### DIFF
--- a/guide/13-managing-arcgis-applications/storymap-briefings.ipynb
+++ b/guide/13-managing-arcgis-applications/storymap-briefings.ipynb
@@ -7,12 +7,12 @@
    "source": [
     "## Introduction to Briefings (ArcGIS StoryMaps)\n",
     "\n",
-    "Using the ArcGIS API for Python you can build Briefings in ArcGIS StoryMaps. Briefings offer a slide-based output ideal for delivering presentations that integrate maps and data from your organization. You can now create elegant and interactive slide-based presentations called briefings for succinct storytelling and offline sharing with ArcGIS StoryMaps. "
+    "Using the ArcGIS API for Python you can build [Briefings in ArcGIS StoryMaps](https://learn.arcgis.com/en/paths/getting-started-with-briefings-in-arcgis-storymaps/). Briefings offer a slide-based output ideal for delivering presentations that integrate maps and data from your organization. You can now create elegant and interactive slide-based presentations called briefings for succinct storytelling and offline sharing with ArcGIS StoryMaps. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 1,
    "id": "80ee349f-f60d-479e-a6ec-f2d6d72055e1",
    "metadata": {},
    "outputs": [],
@@ -24,12 +24,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "id": "1fd881a8-484b-4d72-a7d8-6e8cb5a427a7",
    "metadata": {},
    "outputs": [],
    "source": [
     "gis = GIS(profile='your_online_profile')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f458e254-3653-4f78-9041-34d2a736357d",
+   "metadata": {},
+   "source": [
+    "ArcGIS StoryMaps enable users to add content through various content type elements. The following content element types are supported within the ArcGIS API for Python. \n",
+    "\n",
+    "* [Image](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#image)\n",
+    "* [Image360](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#image360)\n",
+    "* [Video](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#video)\n",
+    "* [Audio](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#audio)\n",
+    "* [Embed](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#embed)\n",
+    "* [App](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#app)\n",
+    "* [Map](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#map)\n",
+    "* [Text](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#text)\n",
+    "* [Button](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#button)\n",
+    "* [Gallery](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#gallery)\n",
+    "* [Swipe](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#swipe)\n",
+    "* [Sidecar](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#sidecar)\n",
+    "* [Timeline](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#timeline)\n",
+    "* [MapTour](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#maptour)\n",
+    "* [Places](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#places)\n",
+    "* [Code](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#code)\n",
+    "* [Table](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#table)\n",
+    "* [ExpressMap](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#expressmap)\n",
+    "* [Infographic](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#infographic)\n",
+    "* [Navigation](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#navigation)\n",
+    "* [Cover](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#cover)\n",
+    "* [Separator](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#separator)\n",
+    "\n",
+    "Specific to Briefings, the following content elements are additionally supported:\n",
+    "* [Briefing](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#briefing)\n",
+    "* [BriefingSlide](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#briefingslide)\n",
+    "* [Block](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#block)"
    ]
   },
   {
@@ -42,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "id": "91b76e7c-9dff-4efe-8568-9a19259c74ac",
    "metadata": {},
    "outputs": [],
@@ -51,8 +87,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "691577f1-7c6f-498c-99ea-f8c56152d098",
+   "metadata": {},
+   "source": [
+    "The `Cover` is the first slide in the briefing. We will update necessary properties such as a `title`, `summary` etc. of the cover slide and we define the `Image` below that we would like to include on the cover slide."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "id": "2b0c9b04-3519-492f-a793-0f4d6da7a6fd",
    "metadata": {},
    "outputs": [],
@@ -61,13 +105,30 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "77e1cc7d-4fca-4ec5-a5aa-f338b6124e15",
+   "metadata": {},
+   "source": [
+    "A key thing to note in the cell below is that each slide of the `Briefing` can be accessed via the `slides` property of the `Briefing` using the index of the slide. The first slide (index = 0) will always be the cover slide, and we access it as follows:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
+   "id": "fb1fd38e-501a-4d4f-b2d7-e669adf89e31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cover = my_briefing.slides[0].cover"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "ccdd188c-e99a-48b8-9fb5-5a21639f66d1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "cover = my_briefing.slides[0].cover\n",
     "cover.title = \"Nature Presentation\"\n",
     "cover.summary = \"Briefing about nature created programmatically\"\n",
     "cover.by_line = \"Nature Briefing\"\n",
@@ -75,8 +136,30 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "f20d742d-07fa-43fa-90f8-4c5a7e45f471",
+   "metadata": {},
+   "source": [
+    "#### Themes \n",
+    "\n",
+    "Theme sets the visual style and appearance of the briefing. ArcGIS StoryMaps supports the following themes:\n",
+    "\n",
+    "![themes](https://github.com/user-attachments/assets/8f1cc448-cc6a-4e87-8734-7351d04a9e47)\n",
+    "\n",
+    "The ArcGIS API for Python supports these themes through type enumerations which include:\n",
+    "* `SUMMIT` = \"summit\"\n",
+    "* `OBSIDIAN` = \"obsidian\"\n",
+    "* `RIDGELINE` = \"ridgeline\"\n",
+    "* `MESA` = \"mesa\"\n",
+    "* `TIDAL` = \"tidal\"\n",
+    "* `SLATE` = \"slate\"\n",
+    "\n",
+    "You can fetch and update the theme of your briefing as shown below."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "id": "6217344d-c57b-4647-9b56-0b9f0f445ed4",
    "metadata": {},
    "outputs": [
@@ -86,7 +169,7 @@
        "True"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -97,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "id": "e2f4ba54-445b-42a8-8552-41562301d13b",
    "metadata": {},
    "outputs": [
@@ -107,7 +190,7 @@
        "True"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -121,12 +204,14 @@
    "id": "e536ae50-bbe2-4eef-a27d-f301932dc681",
    "metadata": {},
    "source": [
-    "We will now save this Briefing and verify these updates."
+    "We will now save this Briefing and verify these updates. Since we are saving this for the first time, we provide a suitable `title` in the `save()` method. \n",
+    "\n",
+    "It is important to `save()` the Briefing (without `title` parameter) everytime you make changes or add new slides. This method helps update the item with your desired changes."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "id": "98099b78-7d3f-4f87-ac03-07e76edbf5f4",
    "metadata": {},
    "outputs": [
@@ -135,16 +220,16 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://www.arcgis.com/home/item.html?id=af0ff7bd06d046b3b7b3344c78eecb4f' target='_blank'>\n",
+       "                       <a href='https://www.arcgis.com/home/item.html?id=9e08960bd71e4c53aa76933f656b1a0f' target='_blank'>\n",
        "                        <img src='http://static.arcgis.com/images/desktopapp.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://www.arcgis.com/home/item.html?id=af0ff7bd06d046b3b7b3344c78eecb4f' target='_blank'><b>Nature themed Briefing slides</b>\n",
+       "                        <a href='https://www.arcgis.com/home/item.html?id=9e08960bd71e4c53aa76933f656b1a0f' target='_blank'><b>Nature themed Briefing slides</b>\n",
        "                        </a>\n",
        "                        <br/><br/><img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\" width=16 height=16>StoryMap by MMajumdar_geosaurus\n",
-       "                        <br/>Last Modified: January 23, 2026\n",
+       "                        <br/>Last Modified: February 05, 2026\n",
        "                        <br/>0 comments, 0 views\n",
        "                    </div>\n",
        "                </div>\n",
@@ -154,7 +239,7 @@
        "<Item title:\"Nature themed Briefing slides\" type:StoryMap owner:MMajumdar_geosaurus>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -184,14 +269,12 @@
     "\n",
     "Each slide within has one or more blocks, and the number of blocks need to be specified during slide creation using the `num_blocks` parameter. A block represents a section that holds individual content elements. \n",
     "\n",
-    "To learn more about ArcGIS StoryMaps content elements supported within the ArcGIS API for Python, please refer to the [Introduction to StoryMaps](../introduction-to-storymaps) guide.\n",
-    "\n",
     "We start by creating three slides below."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "id": "a92538dd-7c88-4c77-a034-952ae5c49e2c",
    "metadata": {},
    "outputs": [],
@@ -202,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 11,
    "id": "62cfcb07-9566-42fc-a59f-c779d96460fb",
    "metadata": {},
    "outputs": [],
@@ -213,7 +296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 12,
    "id": "1f451cc0-5c03-4ccb-a2f0-50527963b9ac",
    "metadata": {},
    "outputs": [],
@@ -229,12 +312,27 @@
    "source": [
     "### Adding text to a block in a slide\n",
     "\n",
-    "Our first slide has one block. We will update it with a text summary of the contents of this `Briefing`."
+    "You can add `Text` to your Briefing by providing the text string of choice to the`text` parameter of this [Text class](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#text).\n",
+    "\n",
+    "You can also specify the `style` you would like to render your text in, using the following [`TextStyles` enumeration](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#arcgis.apps.storymap.story_content.TextStyles) values supported in the ArcGIS API for Python.\n",
+    "\n",
+    "* BULLETLIST = 'bullet-list'\n",
+    "* NUMBERLIST = 'numbered-list'\n",
+    "* HEADING = 'h2'\n",
+    "* SUBHEADING = 'h3'\n",
+    "* HEADING1 = 'h2'\n",
+    "* HEADING2 = 'h3'\n",
+    "* HEADING3 = 'h4'\n",
+    "* PARAGRAPH = 'paragraph'\n",
+    "* QUOTE = 'quote'\n",
+    "\n",
+    "\n",
+    "Our first slide has one block. We will update it with a heading and a text summary of the contents of this `Briefing`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 13,
    "id": "3ae8aff5-b88c-4ab9-b426-b38a87371614",
    "metadata": {},
    "outputs": [],
@@ -244,7 +342,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 14,
+   "id": "c7faf1ea-641e-497c-9de6-b1b68152893b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "heading = Text(\n",
+    "    text=\"Contents\",\n",
+    "    style=TextStyles.HEADING,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b42c950a-d259-4e7a-b8a3-2f691f7fc0ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(text=Contents)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "block_1.add_content(heading)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
    "id": "bc660ae4-0463-434f-95e3-0b59397706db",
    "metadata": {},
    "outputs": [],
@@ -257,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 17,
    "id": "104bb391-e384-4f7f-bf5e-46db064db402",
    "metadata": {},
    "outputs": [
@@ -267,7 +399,7 @@
        "Text(text=This Briefing will have images related to nature, and a map about the coverage of Forests in the US.)"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -278,7 +410,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 22,
    "id": "638807de-fda4-4067-8cdb-9dc0f86c4570",
    "metadata": {},
    "outputs": [
@@ -287,17 +419,17 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://www.arcgis.com/home/item.html?id=af0ff7bd06d046b3b7b3344c78eecb4f' target='_blank'>\n",
+       "                       <a href='https://www.arcgis.com/home/item.html?id=9e08960bd71e4c53aa76933f656b1a0f' target='_blank'>\n",
        "                        <img src='http://static.arcgis.com/images/desktopapp.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://www.arcgis.com/home/item.html?id=af0ff7bd06d046b3b7b3344c78eecb4f' target='_blank'><b>Nature themed Briefing slides</b>\n",
+       "                        <a href='https://www.arcgis.com/home/item.html?id=9e08960bd71e4c53aa76933f656b1a0f' target='_blank'><b>Nature themed Briefing slides</b>\n",
        "                        </a>\n",
        "                        <br/><br/><img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\" width=16 height=16>StoryMap by MMajumdar_geosaurus\n",
-       "                        <br/>Last Modified: January 23, 2026\n",
-       "                        <br/>0 comments, 3 views\n",
+       "                        <br/>Last Modified: February 05, 2026\n",
+       "                        <br/>0 comments, 0 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
@@ -306,7 +438,7 @@
        "<Item title:\"Nature themed Briefing slides\" type:StoryMap owner:MMajumdar_geosaurus>"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -322,7 +454,7 @@
    "source": [
     "The first slide is successfully updated with text. \n",
     "\n",
-    "![text](https://github.com/user-attachments/assets/9042ce80-e481-465f-b3b7-a5c8f0450555)"
+    "![text](https://github.com/user-attachments/assets/43a8bb11-2e3f-4f2f-a108-3091a48de404)"
    ]
   },
   {
@@ -384,8 +516,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "1f38f0fd-7340-4773-906e-fd8da39ded76",
+   "metadata": {},
+   "source": [
+    "We can also set a `title` to the slide using the property."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 21,
+   "id": "d7eea429-4f0a-485b-a178-021aeaf2f5f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "slide2.title = \"Visual Glimpses\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
    "id": "49d8264b-0d49-4185-829f-1eef5123ec44",
    "metadata": {},
    "outputs": [
@@ -394,17 +544,17 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://www.arcgis.com/home/item.html?id=af0ff7bd06d046b3b7b3344c78eecb4f' target='_blank'>\n",
+       "                       <a href='https://www.arcgis.com/home/item.html?id=9e08960bd71e4c53aa76933f656b1a0f' target='_blank'>\n",
        "                        <img src='http://static.arcgis.com/images/desktopapp.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://www.arcgis.com/home/item.html?id=af0ff7bd06d046b3b7b3344c78eecb4f' target='_blank'><b>Nature themed Briefing slides</b>\n",
+       "                        <a href='https://www.arcgis.com/home/item.html?id=9e08960bd71e4c53aa76933f656b1a0f' target='_blank'><b>Nature themed Briefing slides</b>\n",
        "                        </a>\n",
        "                        <br/><br/><img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\" width=16 height=16>StoryMap by MMajumdar_geosaurus\n",
-       "                        <br/>Last Modified: January 23, 2026\n",
-       "                        <br/>0 comments, 1 views\n",
+       "                        <br/>Last Modified: February 05, 2026\n",
+       "                        <br/>0 comments, 0 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
@@ -413,7 +563,7 @@
        "<Item title:\"Nature themed Briefing slides\" type:StoryMap owner:MMajumdar_geosaurus>"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -429,7 +579,7 @@
    "source": [
     "Our briefing has now updated the two blocks with images.\n",
     "\n",
-    "![image](https://github.com/user-attachments/assets/beda5a54-ffe5-4c78-8e07-12a7f510d807)"
+    "![image1](https://github.com/user-attachments/assets/1d59d8e1-2087-41f9-8f2f-17f31590b638)"
    ]
   },
   {
@@ -439,12 +589,14 @@
    "source": [
     "### Adding a Map to a block in a slide\n",
     "\n",
-    "We will now fetch a map item and add it to the third slide."
+    "We will now fetch a map item and add it to the third slide.\n",
+    "\n",
+    "> Note: We are fetching an item of type `Web Map`, and then invoking the Storymap `Map` content class to add the item as a `Map` to our briefing. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 24,
    "id": "e2277d72-810d-4123-a3b9-69e03ad4fedd",
    "metadata": {},
    "outputs": [],
@@ -454,8 +606,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b45014a1-e601-432b-b95b-81a5ee5bcd37",
+   "metadata": {},
+   "source": [
+    "We will add the map to a block in the third slide. Following that we will se another pattern for setting the title of this slide."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 25,
    "id": "5e79e925-bca9-4089-94a0-f3f99e3f2aac",
    "metadata": {},
    "outputs": [],
@@ -465,7 +625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 26,
    "id": "6a09110a-b5dc-41fc-b168-f7d4e457af0a",
    "metadata": {},
    "outputs": [
@@ -475,7 +635,7 @@
        "Map(item='dd3e4259b7434f1ebd488c09a8611ddf', type='Web Map')"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -486,7 +646,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 28,
+   "id": "4efc1db7-2a8a-4e5a-abee-f611c0385951",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "slide3.title = Text(\n",
+    "    text=\"Forest Service USA\",\n",
+    "    style=TextStyles.HEADING,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
    "id": "6182f734-905b-4821-8ca8-33d4435eba6f",
    "metadata": {},
    "outputs": [
@@ -495,17 +668,17 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://www.arcgis.com/home/item.html?id=af0ff7bd06d046b3b7b3344c78eecb4f' target='_blank'>\n",
+       "                       <a href='https://www.arcgis.com/home/item.html?id=9e08960bd71e4c53aa76933f656b1a0f' target='_blank'>\n",
        "                        <img src='http://static.arcgis.com/images/desktopapp.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://www.arcgis.com/home/item.html?id=af0ff7bd06d046b3b7b3344c78eecb4f' target='_blank'><b>Nature themed Briefing slides</b>\n",
+       "                        <a href='https://www.arcgis.com/home/item.html?id=9e08960bd71e4c53aa76933f656b1a0f' target='_blank'><b>Nature themed Briefing slides</b>\n",
        "                        </a>\n",
        "                        <br/><br/><img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\" width=16 height=16>StoryMap by MMajumdar_geosaurus\n",
-       "                        <br/>Last Modified: January 23, 2026\n",
-       "                        <br/>0 comments, 4 views\n",
+       "                        <br/>Last Modified: February 05, 2026\n",
+       "                        <br/>0 comments, 1 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
@@ -514,7 +687,7 @@
        "<Item title:\"Nature themed Briefing slides\" type:StoryMap owner:MMajumdar_geosaurus>"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -530,7 +703,7 @@
    "source": [
     "The slide now displays this map.\n",
     "\n",
-    "![map_block](https://github.com/user-attachments/assets/91cdd96f-ca8a-4d43-ae9c-497ff579ad2b)"
+    "![map_slide](https://github.com/user-attachments/assets/dac367bd-0045-4cb5-8ec3-9a0d9b56f578)"
    ]
   },
   {
@@ -547,7 +720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 30,
    "id": "3e343595-89bd-45a3-bf2e-a4a9f96d85f9",
    "metadata": {},
    "outputs": [
@@ -556,16 +729,16 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://www.arcgis.com/home/item.html?id=2436260d455e499baa8cd7661f760a68' target='_blank'>\n",
+       "                       <a href='https://www.arcgis.com/home/item.html?id=3a808c1cdec842a4bb0b71dc951d4ced' target='_blank'>\n",
        "                        <img src='http://static.arcgis.com/images/desktopapp.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://www.arcgis.com/home/item.html?id=2436260d455e499baa8cd7661f760a68' target='_blank'><b>Copy of my Nature themed Briefing</b>\n",
+       "                        <a href='https://www.arcgis.com/home/item.html?id=3a808c1cdec842a4bb0b71dc951d4ced' target='_blank'><b>Copy of my Nature themed Briefing</b>\n",
        "                        </a>\n",
        "                        <br/><br/><img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\" width=16 height=16>StoryMap by MMajumdar_geosaurus\n",
-       "                        <br/>Last Modified: January 23, 2026\n",
+       "                        <br/>Last Modified: February 06, 2026\n",
        "                        <br/>0 comments, 0 views\n",
        "                    </div>\n",
        "                </div>\n",
@@ -575,7 +748,7 @@
        "<Item title:\"Copy of my Nature themed Briefing\" type:StoryMap owner:MMajumdar_geosaurus>"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -601,7 +774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 31,
    "id": "d45ea02c-0588-4cc4-9831-219b98ceb8e2",
    "metadata": {},
    "outputs": [
@@ -611,7 +784,7 @@
        "True"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -630,7 +803,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 32,
    "id": "1a2029ea-db78-4fa7-8e6a-6fe274dd9f24",
    "metadata": {},
    "outputs": [
@@ -640,7 +813,7 @@
        "True"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -651,7 +824,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 33,
    "id": "1df39d2a-eda2-4966-843d-501ce9c601a9",
    "metadata": {},
    "outputs": [
@@ -660,17 +833,17 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://www.arcgis.com/home/item.html?id=af0ff7bd06d046b3b7b3344c78eecb4f' target='_blank'>\n",
+       "                       <a href='https://www.arcgis.com/home/item.html?id=9e08960bd71e4c53aa76933f656b1a0f' target='_blank'>\n",
        "                        <img src='http://static.arcgis.com/images/desktopapp.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://www.arcgis.com/home/item.html?id=af0ff7bd06d046b3b7b3344c78eecb4f' target='_blank'><b>Nature themed Briefing slides</b>\n",
+       "                        <a href='https://www.arcgis.com/home/item.html?id=9e08960bd71e4c53aa76933f656b1a0f' target='_blank'><b>Nature themed Briefing slides</b>\n",
        "                        </a>\n",
        "                        <br/><br/><img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\" width=16 height=16>StoryMap by MMajumdar_geosaurus\n",
-       "                        <br/>Last Modified: January 23, 2026\n",
-       "                        <br/>0 comments, 5 views\n",
+       "                        <br/>Last Modified: February 06, 2026\n",
+       "                        <br/>0 comments, 3 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
@@ -679,7 +852,7 @@
        "<Item title:\"Nature themed Briefing slides\" type:StoryMap owner:MMajumdar_geosaurus>"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -701,7 +874,7 @@
    "id": "45a09b27-9b12-4f33-98ff-2948c05e3329",
    "metadata": {},
    "source": [
-    "The ArcGIS API for Python also allows for copying selective sections of a Briefing over to another using the [`copy_content()`](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#arcgis.apps.storymap.briefing.Briefing.copy_content) method if you do not wish to clone all the content of a Briefing. \n",
+    "The ArcGIS API for Python also allows for copying selective sections of a Briefing over to another using the [`copy_content()`](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#arcgis.apps.storymap.briefing.Briefing.copy_content) method. Use this method if you do not wish to clone all the content of a Briefing. \n",
     "\n",
     "This capability can be beneficial in a few cases. \n",
     "1. You may already have another Briefing item in your organization with relevant slides and information that you need to add to your current Briefing, without cloning the entire Briefing.\n",
@@ -714,7 +887,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 34,
    "id": "11aa97b5-cfa0-4838-bcdc-c7f1fcff6030",
    "metadata": {},
    "outputs": [
@@ -733,7 +906,7 @@
        "                        </a>\n",
        "                        <br/><br/><img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\" width=16 height=16>StoryMap by ssong_geosaurus\n",
        "                        <br/>Last Modified: July 16, 2024\n",
-       "                        <br/>0 comments, 1 views\n",
+       "                        <br/>0 comments, 2 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
@@ -742,7 +915,7 @@
        "https://storymaps.arcgis.com/briefings/203ca5e1ffc141528cbdf7bced801274"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -755,7 +928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 35,
    "id": "95349085-9584-4a94-a993-cacc9183e7c4",
    "metadata": {},
    "outputs": [],
@@ -765,7 +938,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 36,
    "id": "387dd074-6979-4688-bd00-3a7acf2da729",
    "metadata": {},
    "outputs": [
@@ -775,7 +948,7 @@
        "True"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -791,12 +964,14 @@
    "source": [
     "### Publish the Briefing\n",
     "\n",
-    "We will now publish this Briefing by setting `publish=True` in the `save()` function."
+    "We will now publish this Briefing by setting `publish=True` in the `save()` function.\n",
+    "\n",
+    "> Note: While we have demonstrated the process to programmatically [`save()`](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.storymap.html#arcgis.apps.storymap.briefing.Briefing.save) the Briefing throughout this guide, it is strongly encouraged to view and verify the Briefing in the UI and publish it there, especially for the first time you publish a Briefing. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 37,
    "id": "4bc9b954-ee30-4b50-9f96-82257fbff4bc",
    "metadata": {},
    "outputs": [
@@ -805,17 +980,17 @@
       "text/html": [
        "<div class=\"item_container\" style=\"height: auto; overflow: hidden; border: 1px solid #cfcfcf; border-radius: 2px; background: #f6fafa; line-height: 1.21429em; padding: 10px;\">\n",
        "                    <div class=\"item_left\" style=\"width: 210px; float: left;\">\n",
-       "                       <a href='https://www.arcgis.com/home/item.html?id=af0ff7bd06d046b3b7b3344c78eecb4f' target='_blank'>\n",
+       "                       <a href='https://www.arcgis.com/home/item.html?id=9e08960bd71e4c53aa76933f656b1a0f' target='_blank'>\n",
        "                        <img src='http://static.arcgis.com/images/desktopapp.png' class=\"itemThumbnail\">\n",
        "                       </a>\n",
        "                    </div>\n",
        "\n",
        "                    <div class=\"item_right\"     style=\"float: none; width: auto; overflow: hidden;\">\n",
-       "                        <a href='https://www.arcgis.com/home/item.html?id=af0ff7bd06d046b3b7b3344c78eecb4f' target='_blank'><b>Nature themed Briefing slides</b>\n",
+       "                        <a href='https://www.arcgis.com/home/item.html?id=9e08960bd71e4c53aa76933f656b1a0f' target='_blank'><b>Nature themed Briefing slides</b>\n",
        "                        </a>\n",
        "                        <br/><br/><img src='https://www.arcgis.com/home/js/jsapi/esri/css/images/item_type_icons/layers16.png' style=\"vertical-align:middle;\" width=16 height=16>StoryMap by MMajumdar_geosaurus\n",
-       "                        <br/>Last Modified: January 23, 2026\n",
-       "                        <br/>0 comments, 5 views\n",
+       "                        <br/>Last Modified: February 06, 2026\n",
+       "                        <br/>0 comments, 3 views\n",
        "                    </div>\n",
        "                </div>\n",
        "                "
@@ -824,7 +999,7 @@
        "<Item title:\"Nature themed Briefing slides\" type:StoryMap owner:MMajumdar_geosaurus>"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -832,6 +1007,14 @@
    "source": [
     "my_briefing.save(publish=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87f085ad-fb83-410b-98c7-021115797247",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Guide 3 of 4, introduction to briefings.

Closes https://github.com/ArcGIS/geosaurus/issues/12370

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **If this notebook showcases deep learning capabilities, please go through the following checklist:**
    - [ ] Are the inputs required for `Export Training Data Using Deep Learning` tool published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function?
    - [ ] Is training data zipped and published as Image Collection? Note: Whole folder is zipped with name same as the notebook name.
    - [ ] Are the inputs required for model inferencing published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function? Note: This includes providing test raster and trained model.
    - [ ] Are the inferenced results displayed using a webmap widget?
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @jyaistMap so he can add it to the list for the next deploy.