### PR TITLE
fixed broken links in 3 guides

### DIFF
--- a/guide/14-deep-learning/add_model_using_model_extension.ipynb
+++ b/guide/14-deep-learning/add_model_using_model_extension.ipynb
@@ -608,22 +608,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From here, we can continue with the usual workflow of using an `arcgis.learn` deep learning model. Refer to the [Detecting Swimming Pools using Deep Learning sample](https://developers.arcgis.com/python/sample-notebooks/detecting-swimming-pools-using-satellite-image-and-deep-learning/) sample notebook to see the workflow for an **object detection** model and the [Land Cover Classification using Satellite Imagery and Deep Learning](https://developers.arcgis.com/python/sample-notebooks/land-cover-classification-using-unet/) sample notebook for the workflow for a **pixel classification** model."
+    "From here, we can continue with the usual workflow of using an `arcgis.learn` deep learning model. Refer to the [Detecting Swimming Pools using Deep Learning sample](https://developers.arcgis.com/python/samples/detecting-swimming-pools-using-satellite-image-and-deep-learning/) sample notebook to see the workflow for an **object detection** model and the [Land Cover Classification using Satellite Imagery and Deep Learning](https://developers.arcgis.com/python/samples/land-cover-classification-using-unet/) sample notebook for the workflow for a **pixel classification** model."
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:conda-new] *",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-conda-new-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -635,7 +633,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.11"
   },
   "toc": {
    "base_numbering": 1,

--- a/guide/14-deep-learning/how-named-entity-recognition-works.ipynb
+++ b/guide/14-deep-learning/how-named-entity-recognition-works.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Named Entity Extraction Workflow with `arcgis.learn`"
+    "# Named Entity Extraction Workflow with arcgis.learn"
    ]
   },
   {
@@ -91,7 +91,7 @@
     "- Refer to the section [Install deep learning dependencies of arcgis.learn module](https://developers.arcgis.com/python/guide/install-and-set-up/#Install-deep-learning-dependencies) for detailed explanation about deep learning dependencies.\n",
     "- **Labeled data**: For `EntityRecognizer` to learn, it needs to see examples that have been labeled for all the custom categories that the model is expected to extract. Head to the **Data preparation** section to see the supported formats for training data.\n",
     "\n",
-    "- If you wish to try this workflow, you can find a sample notebook along with the necessary labeled training and test datasets over [here](https://developers.arcgis.com/python/sample-notebooks/information-extraction-from-madison-city-crime-incident-reports-using-deep-learning#Publishing-the-results-as-feature-layer)."
+    "- If you wish to try this workflow, you can find a sample notebook along with the necessary labeled training and test datasets over [here](https://developers.arcgis.com/python/samples/information-extraction-from-madison-city-crime-incident-reports-using-deep-learning#Publishing-the-results-as-feature-layer)."
    ]
   },
   {
@@ -1482,7 +1482,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/guide/14-deep-learning/use_mmdetection_with_arcgis_learn.ipynb
+++ b/guide/14-deep-learning/use_mmdetection_with_arcgis_learn.ipynb
@@ -109,9 +109,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "30813304",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -212,7 +210,7 @@
    "id": "22976ebb",
    "metadata": {},
    "source": [
-    "For more information about the API, visit the [API reference for MMDetection](https://developers.arcgis.com/python/api-reference/arcgis.learn.toc.html#mmdetection). For a detailed object detection workflow, refer to a sample [notebook](https://developers.arcgis.com/python/sample-notebooks/detecting-and-categorizing-brick-kilns-from-satellite-imagery/)."
+    "For more information about the API, visit the [API reference for MMDetection](https://developers.arcgis.com/python/api-reference/arcgis.learn.toc.html#mmdetection). For a detailed object detection workflow, refer to a [sample notebook](https://developers.arcgis.com/python/samples/detecting-and-categorizing-brick-kilns-from-satellite-imagery/)."
    ]
   },
   {
@@ -248,7 +246,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.12.11"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
closes https://github.com/ArcGIS/geosaurus/issues/14573

All the links to samples have been updated in these guides.

For the[ named entity extraction guide ](https://developers.arcgis.com/python/latest/guide/how-named-entity-recognition-works/) I also updated the title because it appears broken on the developer website.

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **If this notebook showcases deep learning capabilities, please go through the following checklist:**
    - [ ] Are the inputs required for `Export Training Data Using Deep Learning` tool published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function?
    - [ ] Is training data zipped and published as Image Collection? Note: Whole folder is zipped with name same as the notebook name.
    - [ ] Are the inputs required for model inferencing published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function? Note: This includes providing test raster and trained model.
    - [ ] Are the inferenced results displayed using a webmap widget?
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @jyaistMap so he can add it to the list for the next deploy.