### PR TITLE
sample that shows SEDF and Geometry tools

### DIFF
--- a/samples/04_gis_analysts_data_scientists/which_counties_and_states_have_access_to_airports.ipynb
+++ b/samples/04_gis_analysts_data_scientists/which_counties_and_states_have_access_to_airports.ipynb
@@ -903,7 +903,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We also print out the names of states that lack have counties lacking airports. "
+    "We also print out the names of states with counties that lack airports within. "
    ]
   },
   {
@@ -989,7 +989,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now write this method below to loop through each county and find its nearest airport using the spatial index for a quick search. We then use the __[`distance()`](https://developers.arcgis.com/python/latest/api-reference/arcgis.geometry.functions.html#distance)__ geometry method to find the distance between the centroid of the county and the closest airport in miles. We extract this data in the form of a distance matrix that gives us the distance between a county and its nearest airport, along with the population density. "
+    "We now write this method below to loop through each county and find its nearest airport using the spatial index for a quick search. We then use the __[`distance()`](https://developers.arcgis.com/python/latest/api-reference/arcgis.geometry.functions.html#distance)__ Geometry method to find the distance between the centroid of the county and the closest airport in miles. We extract this data in the form of a distance matrix that gives us the distance between a county and its nearest airport, along with the population density. "
    ]
   },
   {
@@ -1146,7 +1146,7 @@
    "source": [
     "def get_distance(x):\n",
     "    '''\n",
-    "    Fetch distance value from the distance disctionary\n",
+    "    Fetch distance value from the distance dictionary\n",
     "    '''\n",
     "    return x['distance']\n",
     "\n",
@@ -1208,7 +1208,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The map below shows us that a few airports we saw initially in the Midwest and the central part of the country are no longer on this map, indicating that they are within 30 miles of the closest airport."
+    "The map below shows us that a few counties we saw initially in the Midwest and the central part of the country are no longer on this map, indicating that they are within 30 miles of the closest airport."
    ]
   },
   {


### PR DESCRIPTION
A sample that demos Pandas, GeoAccessor and Geometry tools. 

-----

# Checklist

Please go through each entry in the below checklist and mark an 'X' if that condition has been met. Every entry should be marked with an 'X' to be get the Pull Request approved.


- [ ] All `import`s are in the first cell? 
    - [ ] First block of imports are standard libraries
    - [ ] Second block are 3rd party libraries
    - [ ] Third block are all `arcgis` imports? Note that in some cases, for samples, it is a good idea to keep the imports next to where they are used, particularly for uncommonly used features that we want to highlight.
- [ ] All `GIS` object instantiations are one of the following?
    - `gis = GIS()`
    - `gis = GIS('home')` or `gis = GIS('pro')`
    - `gis = GIS(profile="your_online_portal")`
    - `gis = GIS(profile="your_enterprise_portal")`
- [ ] If this notebook requires setup or teardown, did you add the appropriate code to `./misc/setup.py` and/or `./misc/teardown.py`?
- [ ] If this notebook references any portal items that need to be staged on AGOL/Python API playground, did you coordinate with a Python API team member to stage the item the correct way with the `api_data_owner` user?
- [ ] If the notebook requires working with local data (such as CSV, FGDB, SHP, Raster files), upload the files as items to the [Geosaurus Online Org](geosaurus.maps.arcgis.com/) using `api_data_owner` account and change the notebook to first download and unpack the files.
- [ ] Code simplified & split out across multiple cells, useful comments?
- [ ] Consistent voice/tense/narrative style? Thoroughly checked for typos?
- [ ] All images used like `<img src="base64str_here">` instead of `<img src="https://some.url">`? All map widgets contain a static image preview? (Call `mapview_inst.take_screenshot()` to do so)
- [ ] All file paths are constructed in an OS-agnostic fashion with `os.path.join()`? (Instead of `r"\foo\bar"`, `os.path.join(os.path.sep, "foo", "bar")`, etc.)
- [ ] Is your code formatted using [Jupyter Black](https://www.freecodecamp.org/news/auto-format-your-python-code-with-black/)? You can use Jupyter Black to format your code in the  notebook.
- [ ] **If this notebook showcases deep learning capabilities, please go through the following checklist:**
    - [ ] Are the inputs required for `Export Training Data Using Deep Learning` tool published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function?
    - [ ] Is training data zipped and published as Image Collection? Note: Whole folder is zipped with name same as the notebook name.
    - [ ] Are the inputs required for model inferencing published on geosaurus org (api data owner account) and added in the notebook using `gis.content.get` function? Note: This includes providing test raster and trained model.
    - [ ] Are the inferenced results displayed using a webmap widget?
- [ ] **IF YOU WANT THIS SAMPLE TO BE DISPLAYED ON THE DEVELOPERS.ARCGIS.COM WEBSITE**, ping @jyaistMap so he can add it to the list for the next deploy.