### PR TITLE
[Developers-Site-Feedback] smart-mapping guide `sample` word corrected to `example`

### DIFF
--- a/guide/10-mapping-and-visualization/smart-mapping.ipynb
+++ b/guide/10-mapping-and-visualization/smart-mapping.ipynb
@@ -234,9 +234,9 @@
     "## Visualizing area features\n",
     "Area or polygon features are typically symbolized in varying colors to represent the differences in values. The example below shows how a **Classed Color Renderer** can be used to visualize the population differences between the counties of the state of Washington.\n",
     "\n",
-    "As you have seen in the previous sample, by using the **SmartMappingManager** class, you can author the map, add your layer, and create the smart mapping class by specifying the layer to use. From this you can utilize any of the smart mapping methods and the necessary parameters, and your GIS does the rest, such as identifying a suitable color scheme based on your basemap and the min and max values for the color ramp.\n",
+    "As you have seen in the freeways example above, by using the **SmartMappingManager** class, you can author the map, add your layer, and create the smart mapping class by specifying the layer to use. From this you can utilize any of the smart mapping methods and the necessary parameters, and your GIS does the rest, such as identifying a suitable color scheme based on your basemap and the min and max values for the color ramp.\n",
     "\n",
-    "The sample also shows how querying can be used to limit the features displayed from the layer, and how the layer can be represented with transparency allowing the basemap to be seen."
+    "The example also shows how querying can be used to limit the features displayed from the layer, and how the layer can be represented with transparency allowing the basemap to be seen."
    ]
   },
   {
@@ -267,9 +267,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "The steps to search for a Feature Layer item and obtaining its url is demonstrated in the previous sample. For brevity, this sample skips that part."
-   ]
+   "source": "The steps to search for a Feature Layer item and obtaining its url is demonstrated in the previous example. For brevity, this example skips that part."
   },
   {
    "cell_type": "code",
@@ -352,7 +350,7 @@
     "## Visualizing location data\n",
     "Point features are the most common type of location data. Smart mapping provides a special visualization technique called **heatmap**. The heatmap renderer is useful when representing the spatial distribution or clustering of points as it represents the relative density of points on a map as smoothly varying sets of colors ranging from cool (low density) to hot (many points).\n",
     "\n",
-    "The sample below visualizes earthquake occurrences in Southern California using the heatmap renderer."
+    "The example below visualizes earthquake occurrences in Southern California using the heatmap renderer."
    ]
   },
   {


### PR DESCRIPTION
Resolves the feedback - https://tools.afd.geocloud.com/feedback-service?feedbackId=4125

In the guide, the word `sample` is corrected to `example`