### PR TITLE
Update syntax so math formulas render correctly

### DIFF
--- a/samples/04_gis_analysts_data_scientists/calculate_post_fire_landslide_risk.ipynb
+++ b/samples/04_gis_analysts_data_scientists/calculate_post_fire_landslide_risk.ipynb
@@ -261,13 +261,16 @@
     "\n",
     "The meaning of the ∆NBR values can vary by scene, and interpretation in specific instances should always be based on some field assessment. However, the following table from the USGS FireMon program can be useful as a first approximation for interpreting the NBR difference:\n",
     "\n",
-    "| \\begin{align}{\\Delta \\mathbf{NBR}} \\end{align} |     Burn Severity      |\n",
-    "| ---------------------------------------------- | :--------------------: |\n",
-    "| -2.0 to 0.1                                    | Regrowth and Unburned  |\n",
-    "| 0.1 to 0.27                                    |   Low severity burn    |\n",
-    "| 0.27 to 0.44                                   |  Medium severity burn  |\n",
-    "| 0.44 to 0.66                                   | Moderate severity burn |\n",
-    "| > 0.66                                         |   High severity burn   |\n",
+    "\n",
+    "                                                                     \n",
+    "| $$ \\begin{align}{\\Delta \\mathbf{NBR}} \\end{align}$$ |     Burn Severity      |\n",
+    "| --------------------------------------------------- | :--------------------: |\n",
+    "| -2.0 to 0.1                                         | Regrowth and Unburned  |\n",
+    "| 0.1 to 0.27                                         |   Low severity burn    |\n",
+    "| 0.27 to 0.44                                        |  Medium severity burn  |\n",
+    "| 0.44 to 0.66                                        | Moderate severity burn |\n",
+    "| > 0.66                                              |   High severity burn   |\n",
+    "\n",
     "\n",
     "Source: http://wiki.landscapetoolbox.org/doku.php/remote_sensing_methods:normalized_burn_ratio\n"
    ]
@@ -917,7 +920,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.13.13"
   },
   "toc": {
    "base_numbering": 1,

--- a/samples/04_gis_analysts_data_scientists/predict-floods-with-unit-hydrographs.ipynb
+++ b/samples/04_gis_analysts_data_scientists/predict-floods-with-unit-hydrographs.ipynb
@@ -201,9 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pour_point = item.layers[0]\n",
@@ -635,9 +633,7 @@
   {
    "cell_type": "code",
    "execution_count": 201,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -910,9 +906,7 @@
   {
    "cell_type": "code",
    "execution_count": 208,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1176,14 +1170,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "V = $V_m$ * ($S^b$$A^c$) / ($S^b$$A^c$$_m$) ------------- (1)"
+    "$$\n",
+    "V = V_m * \\frac{(S^bA^c)}{(S^bA^c_m}\n",
+    "$$"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Where V is the velocity of a single cell with a local slope of s and an upstream contributing area of A. Coefficients b and c can be determined by calibration, a statistical method of tweaking model parameters so that predicted data is as close as possible to observed data. In this scenario, you'll use the method's recommended value of b = c = 0.5. $V_m$ is the average velocity of all cells in the watershed. You'll assume an average velocity of $V_m$ = 0.1 m/s. Lastly, $S^b$$A^c$$_m$ is the average slope-area term throughout the watershed. To avoid results that are unrealistically fast or slow, you'll set limits for minimum and maximum velocities. The lower limit will be 0.02 meters per second, while the upper limit will be 2 meters per second.\n",
+    "Where:\n",
+    "* _V_ is the velocity of a single cell with a local slope of _S_ and an upstream contributing area of _A)\n",
+    "* Coefficients b and c can be determined by calibration, a statistical method of tweaking model parameters so that predicted data is as close as possible to observed data. In this scenario, you'll use the method's recommended value of b = c = 0.5.\n",
+    "* $$V_m$$ is the average velocity of all cells in the watershed. You'll assume an average velocity of:\n",
+    "  * $$V_m = 0.1 m/s.$$\n",
+    "\n",
+    "* $S^bA^c_m$ is the average slope-area term throughout the watershed.\n",
+    "\n",
+    "To avoid results that are unrealistically fast or slow, you'll set limits for minimum and maximum velocities. The lower limit will be 0.02 meters per second, while the upper limit will be 2 meters per second.\n",
     "\n",
     "This equation is only one of many ways that a velocity field can be calculated, and it comes with several [assumptions and limitations](https://learn.arcgis.com/en/projects/predict-floods-with-unit-hydrographs/assumptions-and-limitations-of-the-unit-hydrograph-model.htm) of its own. "
    ]
@@ -1693,9 +1697,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2744,9 +2746,7 @@
   {
    "cell_type": "code",
    "execution_count": 205,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2813,7 +2813,7 @@
    "notebookRuntimeVersion": "9.0"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -2827,7 +2827,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.13.13"
   },
   "toc": {
    "base_numbering": 1,
@@ -2844,5 +2844,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
* Fixes rendering for math formulas in:

  * [Calculate land fire risk](https://developers.arcgis.com/python/latest/samples/calculate-post-fire-landslide-risk/) sample

  |**Before**|**After**|
  |---|---|
  |<img width="551" height="269" alt="image" src="https://github.com/user-attachments/assets/d9f7cfb2-7197-4e63-8277-9e177519d945" />|<img width="378" height="227" alt="image" src="https://github.com/user-attachments/assets/9fe569bb-0d3e-404e-b5c9-c87899b3d1f9" />

  * [Predict floods]() sample

  |**Before**|**After**|
  |---|---|
  |<img width="921" height="437" alt="image" src="https://github.com/user-attachments/assets/660c85f1-061d-437a-ab6f-a6e4562a2c6b" />|<img width="778" height="349" alt="image" src="https://github.com/user-attachments/assets/c869ab34-29b3-43c2-8121-c196822b6f55" />
