### PR TITLE
Add hyperlinks and update hashmark headings to supplement right-hand nav

### DIFF
--- a/guide/13-managing-arcgis-applications/itemgraph-to-knowledge-graph.ipynb
+++ b/guide/13-managing-arcgis-applications/itemgraph-to-knowledge-graph.ipynb
@@ -13,9 +13,9 @@
    "id": "bcbe6f8a-7557-461d-b284-323445c1cbf5",
    "metadata": {},
    "source": [
-    "Constructing an `ItemGraph` can give us a lot of valuable information- the question then becomes, how can we best use it? Though analyzing our graphs purely in Python is possible, combining our graphs with the added capabilities of ArcGIS Knowledge allows us to take our analysis to the next level and easily visualize complex dependency structures.\n",
+    "Constructing an [`ItemGraph`](/python/latest/api-reference/arcgis.apps.itemgraph.html#itemgraph) can give us a lot of valuable information- the question then becomes, how can we best use it? Though analyzing our graphs purely in Python is possible, combining our graphs with the added capabilities of [ArcGIS Knowledge](https://doc.esri.com/en/arcgis-enterprise/latest/plan/additional-server-deployment.html?pivots=os-windows#AEE) allows us to take our analysis to the next level and easily visualize complex dependency structures.\n",
     "\n",
-    "For customers with access to an ArcGIS Enterprise with ArcGIS Knowledge Server enabled, version 2.4.3 of the ArcGIS API for Python introduces a handy tool- the [`ItemGraph.to_knowledge_graph()`](https://developers.arcgis.com/python/latest/api-reference/arcgis.apps.itemgraph.html#arcgis.apps.itemgraph.ItemGraph.to_knowledge_graph) function. This function allows for the creation of an ArcGIS Knowledge Service based on the contents of an ItemGraph, or the addition of an ItemGraph's contents to an existent Knowledge Graph.\n",
+    "For customers with access to an ArcGIS Enterprise with ArcGIS Knowledge Server enabled, version 2.4.3 of the ArcGIS API for Python introduces a handy tool- the [`ItemGraph.to_knowledge_graph()`](/python/latest/api-reference/arcgis.apps.itemgraph.html#arcgis.apps.itemgraph.ItemGraph.to_knowledge_graph) function. This function allows for the creation of an ArcGIS Knowledge Service based on the contents of an `ItemGraph`, or the addition of an `ItemGraph's` contents to an existent Knowledge Graph.\n",
     "\n",
     "An `ItemGraph` generated from any organization can be visualized in your Knowledge-enabled ArcGIS Enterprise. This means that if you generate a dependency graph based on items in an ArcGIS Online organization, you can still add them to a Knowledge Graph in your ArcGIS Enterprise org- something we'll show here."
    ]
@@ -51,7 +51,7 @@
    "source": [
     "## Usage Examples\n",
     "\n",
-    "#### Creating a new Knowledge Graph\n",
+    "### Creating a new Knowledge Graph\n",
     "We'll start with the most simple use case- creating an ItemGraph on a Knowledge-enabled Enterprise and quickly publishing it to a Knowledge Graph."
    ]
   },
@@ -200,7 +200,7 @@
    "id": "ffd06e13-7cf4-42b4-a09f-66cccc5f048c",
    "metadata": {},
    "source": [
-    "#### Adding to an existing Knowledge Graph\n",
+    "### Adding to an existing Knowledge Graph\n",
     "\n",
     "Say we want to add more items to the graph we just made- all we have to do is create a new `ItemGraph`, and then reference our KG object in the method call."
    ]
@@ -283,7 +283,7 @@
    "id": "e983ccf4-96f0-435c-a265-a7c6c061e935",
    "metadata": {},
    "source": [
-    "#### Adding from a different organization and detailed item types\n",
+    "### Adding from a different organization and detailed item types\n",
     "\n",
     "We're going to do 2 for 1 now- we'll show how you can display an `ItemGraph` created in a different organization, and show how we can make it more informative with detailed entity types in our new Knowledge Graph. We'll be working with an ArcGIS Online organization for this example."
    ]
@@ -424,7 +424,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.11"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
@nparavicini7 
* updated the first paragraph with relative hyperlinks where appropriate, and added link to Knowledge Server doc
* updated the hashmark headings so each section in the Usage Examples appeared in the right-hand nav

<img width="1088" height="397" alt="image" src="https://github.com/user-attachments/assets/24391409-7572-4409-b684-fc69284246af" />
